### PR TITLE
docs: refresh for host grouping, Stacks rename, k8s host metrics, schema v17

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,9 @@ Self-hosted server awareness tool for homelabbers. Monitors containers, hosts, a
 ```
 
 - **Agent**: collects container/host metrics, publishes to MQTT, handles log requests + actions
-  - Supports multiple container runtimes via `agent/src/runtime/` abstraction (Docker today; Kubernetes via DaemonSet)
+  - Supports multiple container runtimes via `agent/src/runtime/` abstraction (Docker; Kubernetes via DaemonSet)
   - Auto-detects runtime by socket probing, or set `INSIGHTD_RUNTIME=docker|kubernetes`
+  - In k8s mode, host CPU/memory/uptime come from kubelet (`/stats/summary` + Node API capacity), not `/proc`. Load average, CPU temperature, gpu, disk-io, and network-io are explicitly NULL because `/proc` and `/sys` inside a containerized agent reflect the underlying machine, not the node.
 - **Hub**: subscribes to MQTT, stores in SQLite, serves React UI on port 3000, runs insights engine, sends digests + alerts + webhooks
 - **Standalone mode**: hub with no MQTT runs collectors locally (Docker only)
 - **Mosquitto**: message broker, separate container (stays up during hub updates)
@@ -20,7 +21,7 @@ Self-hosted server awareness tool for homelabbers. Monitors containers, hosts, a
 - Backend: Node.js 20, TypeScript (strict), SQLite (better-sqlite3), dockerode, @kubernetes/client-node, MQTT, Nodemailer, node-cron, tsx
 - Frontend: React 19, TypeScript (strict), Tailwind CSS v4, Vite 6, React Router v6, TanStack Query v5
 - Docker multi-arch (amd64 + arm64)
-- Tests: ~300 tests using `node:test` + tsx (zero external test dependencies)
+- Tests: ~480 tests using `node:test` + tsx (zero external test dependencies)
 
 ## Project Structure
 
@@ -32,7 +33,7 @@ insightd/
   agent/src/runtime/         # Container runtime abstraction (Docker, Kubernetes)
     types.ts                 #   ContainerRuntime interface and shared types
     docker.ts                #   DockerRuntime — listContainers, collectResources, fetchLogs, performAction, checkImageUpdates
-    kubernetes.ts            #   KubernetesRuntime — pod listing, kubelet cAdvisor metrics, K8s API logs (read-only)
+    kubernetes.ts            #   KubernetesRuntime — pod listing, kubelet cAdvisor + /stats/summary metrics, K8s API logs, getHostMetrics override (read-only)
     detect.ts                #   Socket-based runtime auto-detection
     index.ts                 #   getRuntime() factory
   agent/src/collectors/      # Host-level collectors (disk, host, gpu, temperature, disk-io, network-io)
@@ -47,11 +48,12 @@ insightd/
   hub/src/web/frontend/src/pages/       # Page components, decomposed into subdirectories:
     dashboard/               # DashboardPage, AttentionList, StatusRow
     containers/              # ContainerDetailPage, ContainerHistoryTab, HistorySummary, MetricGauge
-    hosts/                   # HostDetailPage, HostOverviewTab, HostResourcesTab, HostAlertsTab, HostsPage
+    hosts/                   # HostDetailPage (with HostGroupEditor), HostOverviewTab, HostResourcesTab, HostAlertsTab, HostsPage (collapsible group sections)
     updates/                 # UpdatesPage, HubUpdateCard, AgentUpdatesCard, ImageUpdatesCard
+    StacksPage.tsx, StackDetailPage.tsx, StackFormPage.tsx  # Container groups (renamed from "Services" in #72)
     InsightsPage.tsx         # Dedicated insights page with feedback (thumbs up/down)
   hub/src/web/public/        # Built frontend assets (served by Node HTTP server)
-  hub/src/db/                # Connection, schema (currently v15), settings
+  hub/src/db/                # Connection, schema (currently v17), settings
   src/                       # Standalone mode code (Docker only, mirrors hub for single-host)
   tests/                     # Tests using node:test
   docs/                      # Setup guides (kubernetes-setup.md)
@@ -79,12 +81,14 @@ docker compose up -d        # Run full stack (mosquitto + hub + agent)
 ## Docker Hub
 
 - Images: `andreas404/insightd-hub`, `andreas404/insightd-agent`
-- Latest: hub-v0.6.0 (multi-runtime support coming in v0.7.0)
 - Multi-arch: linux/amd64 + linux/arm64
+- Tags: `hub-v*` and `agent-v*` trigger independent CI publishes
+- Latest tagged release isn't tracked here — check `git tag --list 'hub-v*'` or Docker Hub for the current version
 
 ## Key Environment Variables
 
 - `INSIGHTD_RUNTIME` — container runtime: `auto` (default), `docker`, or `kubernetes`
+- `INSIGHTD_HOST_GROUP` — optional logical group label (e.g. "production-cluster", "basement"). Surfaces as collapsible sections on the Hosts page. Manual UI override via PUT `/api/hosts/:id/group` always wins over the env var.
 - `INSIGHTD_ALLOW_UPDATES` — enable remote agent updates (default false, Docker only)
 - `INSIGHTD_ALLOW_ACTIONS` — enable container start/stop/restart (default false, Docker only)
 - `INSIGHTD_STATUS_PAGE` — enable public status page (default false)
@@ -93,7 +97,9 @@ docker compose up -d        # Run full stack (mosquitto + hub + agent)
 
 ## Database
 
-SQLite with WAL mode. **Schema v15.** Key tables: container_snapshots, host_snapshots, disk_snapshots, http_endpoints, http_checks, baselines, health_scores, insights, insight_feedback, alert_state, sessions, api_keys, webhooks, service_groups, hosts (with `runtime_type` column).
+SQLite with WAL mode. **Schema v17.** Key tables: container_snapshots, host_snapshots, disk_snapshots, http_endpoints, http_checks, baselines, health_scores, insights, insight_feedback, alert_state, sessions, api_keys, webhooks, service_groups (still named in DB; surfaces as "Stacks" in the UI), hosts (with `runtime_type`, `host_group`, and `host_group_override` columns — the UI override beats the agent-reported value via COALESCE in queries).
+
+Both schema files (`hub/src/db/schema.ts` and `src/db/schema.ts`) create `sessions`, `api_keys`, and `insight_feedback` in the bootstrap CREATE TABLE batch — fresh installs need them on first boot, not just via the v12/v14 migration paths (fixed in #74).
 
 ## UI Design Principles
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ No critical issues. Good week.
 ## Features
 
 - **Multi-host monitoring** — deploy agents on each server, all reporting to a central hub via MQTT
-- **Multi-runtime support** — Docker (default) and Kubernetes/k3s (DaemonSet mode), one agent per node
+- **Multi-runtime support** — Docker (default) and Kubernetes/k3s (DaemonSet mode), one agent per node. K8s mode uses kubelet stats for accurate per-node CPU/memory.
+- **Host grouping** — organize hosts by cluster, environment, or location with `INSIGHTD_HOST_GROUP`. The Hosts page renders collapsible sections per group, with a UI override per host for users without env-var access.
 - **Container monitoring** — status, CPU, RAM, restarts, network/block I/O, health checks
-- **Host system metrics** — CPU, memory, load, uptime, GPU, temperature, disk I/O, network I/O
+- **Host system metrics** — CPU, memory, load, uptime, GPU, temperature, disk I/O, network I/O (Docker mode); CPU, memory, uptime (k8s mode)
 - **Disk monitoring** — usage warnings with "X days until full" forecasts
 - **HTTP endpoint monitoring** — uptime, response time, configurable intervals
 - **Smart insights engine** — capacity-based health scoring (only flags actual saturation, not baseline deviation), time-of-day baselines, predictive alerts, correlation detection
@@ -34,7 +35,7 @@ No critical issues. Good week.
 - **Explainable alerts** — every alert stores why it fired (value, threshold, message) so you can understand what happened
 - **Metric personalities** — baseline-aware human-friendly moods on every metric (e.g. "😌 Normal", "🔥 Way above normal")
 - **Health score breakdown** — click the system health score to see per-host factor analysis
-- **Service groups** — organize containers by purpose, auto-detect from Docker Compose/labels
+- **Stacks** — organize containers by purpose across hosts, auto-detected from Docker Compose project labels (UI label, formerly "Services")
 - **Public status page** — shareable uptime page, no auth required (opt-in)
 - **API keys** — programmatic access with hashed key storage
 - **Full UI onboarding** — setup wizard configures everything including SMTP, no .env file required
@@ -100,18 +101,18 @@ kubectl apply -f agent/k8s/rbac.yaml
 kubectl apply -f agent/k8s/daemonset.yaml
 ```
 
-Edit `agent/k8s/daemonset.yaml` first to set your `INSIGHTD_MQTT_URL`. Each pod's containers appear in insightd as `{namespace}/{pod-name}/{container-name}`. K8s mode is read-only — actions and image update checks aren't supported (those are managed by the cluster).
+Edit `agent/k8s/daemonset.yaml` first to set your `INSIGHTD_MQTT_URL`. Each pod's containers appear in insightd as `{namespace}/{pod-name}/{container-name}`. K8s mode is read-only — actions and image update checks aren't supported (those are managed by the cluster). Host CPU, memory, and uptime come from the kubelet (`/stats/summary` + Node API), not `/proc` — see [`docs/kubernetes-setup.md`](docs/kubernetes-setup.md) for details.
 
 ## Web UI
 
 The hub serves a dashboard at `http://localhost:3000`:
 
 - **Dashboard** — health score with clickable breakdown, availability, compact status bar, unified "Needs Attention" feed, metric personalities
-- **Hosts** — grid of all connected agents with status and metrics
-- **Host detail** — tabbed view: overview, resources, alerts
+- **Hosts** — collapsible sections per host group, with status, metrics, and inline group editing
+- **Host detail** — tabbed view: overview, resources, alerts; click the group badge to retag the host
 - **Container detail** — CPU/memory gauges, logs, status history
 - **Endpoints** — HTTP endpoint monitoring with uptime timelines
-- **Services** — container groups with aggregate status
+- **Stacks** — container groups with aggregate status (auto-detected from Docker Compose, or create your own)
 - **Alerts** — full alert history with reason, trigger value, and threshold
 - **Insights** — analytical signals (predictions, trends, performance) with thumbs up/down feedback
 - **Updates** — available image updates, remote agent updates
@@ -142,6 +143,7 @@ All configuration can be done via the **Setup Wizard** and **Settings page** in 
 |----------|---------|-------------|
 | `INSIGHTD_MQTT_URL` | — | MQTT broker URL (enables hub mode) |
 | `INSIGHTD_HOST_ID` | `local` | Identifies this host in multi-host setups |
+| `INSIGHTD_HOST_GROUP` | — | Optional logical group label for the Hosts page (e.g. `production`, `k3d-test`) |
 | `INSIGHTD_RUNTIME` | `auto` | Container runtime: `auto`, `docker`, or `kubernetes` |
 | `INSIGHTD_ADMIN_PASSWORD` | — | Admin password for the web UI |
 | `INSIGHTD_ALLOW_ACTIONS` | `false` | Enable container start/stop/restart from UI |

--- a/agent/DOCKERHUB.md
+++ b/agent/DOCKERHUB.md
@@ -1,8 +1,12 @@
 # Insightd Agent
 
-**Lightweight monitoring agent** for [insightd](https://github.com/goldenproductions/insightd). Deploy on each host to collect Docker container and system metrics, reporting back to the central hub via MQTT.
+**Lightweight monitoring agent** for [insightd](https://github.com/goldenproductions/insightd). Deploy on each host or k8s node to collect container and system metrics, reporting back to the central hub via MQTT.
 
-## Quick Start
+Supports two runtimes:
+- **Docker** — auto-detected via the docker socket (default)
+- **Kubernetes** — runs as a DaemonSet, one pod per node, uses kubelet stats
+
+## Quick Start (Docker)
 
 ```bash
 docker run -d \
@@ -21,20 +25,33 @@ The agent will immediately start collecting metrics and publishing to the hub.
 
 > Tip: The hub's **Add Agent** page generates a ready-to-paste `docker run` command with your MQTT details pre-filled.
 
+## Quick Start (Kubernetes / k3s)
+
+Run as a DaemonSet — see [`agent/k8s/`](https://github.com/goldenproductions/insightd/tree/main/agent/k8s) for the manifests and [`docs/kubernetes-setup.md`](https://github.com/goldenproductions/insightd/blob/main/docs/kubernetes-setup.md) for the full guide.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/goldenproductions/insightd/main/agent/k8s/rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/goldenproductions/insightd/main/agent/k8s/daemonset.yaml
+```
+
+Edit the DaemonSet first to set `INSIGHTD_MQTT_URL` (and optionally `INSIGHTD_HOST_GROUP`). K8s mode is read-only — container actions and image update checks aren't supported (those are managed by the cluster).
+
 ## What It Collects
 
-| Metric | Details |
-|--------|---------|
-| **Containers** | Status, CPU, RAM, restarts, network I/O, block I/O, health checks |
-| **Host CPU** | Usage, load average |
-| **Host memory** | Total, used, available |
-| **Disks** | Usage per mount, days-until-full forecast |
-| **GPU** | Utilization, memory, temperature (NVIDIA) |
-| **Temperature** | CPU/system sensor readings |
-| **Disk I/O** | Read/write throughput |
-| **Network I/O** | Per-interface bandwidth |
+| Metric | Docker mode | Kubernetes mode |
+|--------|-------------|-----------------|
+| **Containers** | Status, CPU, RAM, restarts, network I/O, block I/O, health checks | Same — sourced from kubelet cAdvisor |
+| **Host CPU** | `/proc/stat` | kubelet `/stats/summary` |
+| **Host memory** | `/proc/meminfo` | kubelet `/stats/summary` + Node API capacity |
+| **Host uptime** | `/proc/uptime` | Node `metadata.creationTimestamp` |
+| **Disks** | Usage per mount, days-until-full forecast | Same |
+| **GPU** | Utilization, memory, temperature (NVIDIA) | Not collected |
+| **Temperature** | CPU/system sensor readings | Not collected |
+| **Disk I/O** | Read/write throughput | Not collected |
+| **Network I/O** | Per-interface bandwidth | Not collected |
+| **Load average** | `/proc/loadavg` | Not collected (kernel concept that doesn't map to a single node) |
 
-Metrics are collected every 5 minutes (configurable) and published to MQTT.
+Metrics are collected every 5 minutes (configurable) and published to MQTT. In k8s mode, the values that aren't collected appear as `null` rather than misleading numbers — `/proc` and `/sys` inside the agent pod reflect the underlying machine's kernel, not the node.
 
 ## Additional Capabilities
 
@@ -48,12 +65,14 @@ Metrics are collected every 5 minutes (configurable) and published to MQTT.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `INSIGHTD_HOST_ID` | `local` | Unique name for this host |
+| `INSIGHTD_HOST_GROUP` | — | Optional logical group label (e.g. `production`, `basement`) for the Hosts page |
+| `INSIGHTD_RUNTIME` | `auto` | Container runtime: `auto`, `docker`, or `kubernetes` |
 | `INSIGHTD_MQTT_URL` | — | MQTT broker URL (required) |
 | `INSIGHTD_MQTT_USER` | — | MQTT username |
 | `INSIGHTD_MQTT_PASS` | — | MQTT password |
 | `INSIGHTD_COLLECT_INTERVAL` | `5` | Collection interval (minutes) |
-| `INSIGHTD_ALLOW_ACTIONS` | `false` | Enable container start/stop/restart |
-| `INSIGHTD_ALLOW_UPDATES` | `false` | Enable remote agent updates |
+| `INSIGHTD_ALLOW_ACTIONS` | `false` | Enable container start/stop/restart (Docker mode) |
+| `INSIGHTD_ALLOW_UPDATES` | `false` | Enable remote agent updates (Docker mode) |
 | `INSIGHTD_DISK_WARN_THRESHOLD` | `85` | Disk warning threshold (%) |
 | `TZ` | `UTC` | Timezone |
 

--- a/docs/kubernetes-setup.md
+++ b/docs/kubernetes-setup.md
@@ -46,10 +46,43 @@ the hub, and the pods running on that node appear as "containers".
 
 - **One host per node** in the insightd UI, named after the node
 - **Each pod's containers** appear as containers under that host
-- **Container names** use the format `{namespace}/{pod-name}/{container-name}`
-- **CPU/memory metrics** from the kubelet's cAdvisor endpoint
+- **Container names** use the format `{namespace}/{pod-name}/{container-name}` (stable across pod rollouts — derived from owner references, so consecutive Deployment/ReplicaSet pods share one entry)
+- **Per-container metrics** (CPU, memory, network, fs I/O) from the kubelet's cAdvisor endpoint (`/metrics/cadvisor`)
+- **Per-node host metrics** (CPU%, memory used/available/total, uptime) from the kubelet's `/stats/summary` endpoint plus the Node API for total capacity
 - **Restart count** directly from the pod status
 - **Logs** via the Kubernetes API
+
+## What gets reported as NULL in k8s mode (and why)
+
+`/proc/*` and `/sys/*` inside the agent pod reflect the underlying machine's kernel — not the node the agent reports on. Reading them would give the wrong values, so insightd explicitly suppresses them in k8s mode:
+
+- **Load average** — kernel concept that doesn't map cleanly to a single k8s node
+- **CPU temperature** — physical sensors aren't exposed per-node
+- **GPU metrics** — not collected (would need device-plugin integration)
+- **Disk I/O** and **network I/O** rates — would report the underlying VM's view
+
+These appear as `null` in the API and as missing values in the UI, rather than misleading numbers.
+
+## Host group / cluster organization
+
+Set `INSIGHTD_HOST_GROUP` on the DaemonSet to label all nodes in this cluster as belonging to a single group on the Hosts page:
+
+```yaml
+- name: INSIGHTD_HOST_GROUP
+  value: production-cluster
+```
+
+The Hosts page renders one collapsible section per group, with an "Ungrouped" section for hosts that haven't set one. Individual hosts can also be retagged from the host detail page in the UI — the manual override beats the env var.
+
+## Memory total caveat for k3d / unconstrained nodes
+
+The kubelet reports the node's *allocatable* memory, which is whatever the OS thinks is available. **k3d nodes don't set Docker memory limits by default**, so each k3d node reports the entire host machine's RAM as its total — even though k3s only uses a small fraction.
+
+Real production k8s clusters with proper node sizing get correct totals. To fix it for k3d, pass `--servers-memory` / `--agents-memory` at cluster creation:
+
+```bash
+k3d cluster create my-cluster --servers-memory 4G --agents-memory 4G
+```
 
 ## What's not supported in k8s mode
 
@@ -67,8 +100,9 @@ runtime mode instead.
 The DaemonSet uses a ServiceAccount with these cluster permissions:
 
 - `pods` and `pods/log` — get, list, watch (to discover pods on the node and read logs)
-- `nodes` — get, list (to verify the node exists at startup)
-- `nodes/metrics`, `nodes/stats`, `nodes/proxy` — get (to query the kubelet's cAdvisor endpoint)
+- `nodes` — get, list (to verify the node exists, read capacity for total memory, read `creationTimestamp` for uptime)
+- `nodes/metrics`, `nodes/stats`, `nodes/proxy` — get (to query the kubelet's `/metrics/cadvisor` and `/stats/summary` endpoints)
+- `replicasets` (apps API group) — get, list (to walk pod owner references up to the parent Deployment for stable container names across rollouts)
 
 These are read-only permissions. The agent never modifies anything in the cluster.
 

--- a/hub/DOCKERHUB.md
+++ b/hub/DOCKERHUB.md
@@ -56,15 +56,17 @@ Then deploy [`andreas404/insightd-agent`](https://hub.docker.com/r/andreas404/in
 ## Features
 
 - **Dashboard** — health scores, availability, unified "Needs Attention" feed
+- **Multi-runtime** — Docker and Kubernetes/k3s (via the agent's DaemonSet mode)
+- **Host grouping** — collapsible Hosts page sections by cluster, environment, or location
 - **Container monitoring** — status, CPU, RAM, restarts, network/block I/O, health checks
-- **Host metrics** — CPU, memory, load, disk, GPU, temperature
+- **Host metrics** — CPU, memory, load, disk, GPU, temperature (Docker mode); CPU, memory, uptime from kubelet (k8s mode)
 - **HTTP endpoint monitoring** — uptime tracking, response times
 - **Insights engine** — time-of-day baselines, anomaly detection, predictive alerts, correlations
 - **Real-time alerts** — 10 alert types with cooldowns and auto-resolution
 - **Webhooks** — Slack, Discord, Telegram, ntfy, or generic
 - **Weekly digest emails** — HTML + plaintext summaries
-- **Container actions** — start/stop/restart from the UI (opt-in)
-- **Service groups** — organize containers across hosts
+- **Container actions** — start/stop/restart from the UI (opt-in, Docker mode)
+- **Stacks** — container groups across hosts (auto-detected from Docker Compose, or create your own)
 - **Public status page** — shareable uptime page at `/status` (opt-in)
 - **API keys** — programmatic access with hashed storage
 


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md, README, Docker Hub descriptions, and Kubernetes setup docs
- Reflects host grouping, Services→Stacks rename, k8s host metrics, and schema v17

## Test plan
- Docs-only change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)