### PR TITLE
Docs: refresh README, CLAUDE.md, and .env.example for v0.9.x features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,16 @@ INSIGHTD_COLLECT_INTERVAL=5
 # Disk warning threshold (percent, default: 85)
 INSIGHTD_DISK_WARN_THRESHOLD=85
 
+# === Data Retention ===
+
+# Days to keep full-resolution snapshots (default: 30, min: 7)
+# Older raw data is rolled up into hourly aggregates before deletion.
+# INSIGHTD_RETENTION_RAW_DAYS=30
+
+# Days to keep hourly rollups (default: 365, min: 30)
+# Rollups give you long-term trends without unbounded growth.
+# INSIGHTD_RETENTION_ROLLUP_DAYS=365
+
 # Data directory (default: /data inside container)
 # INSIGHTD_DATA_DIR=/data
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Self-hosted server awareness tool for homelabbers. Monitors containers, hosts, a
 - Backend: Node.js 20, TypeScript (strict), SQLite (better-sqlite3), dockerode, @kubernetes/client-node, MQTT, Nodemailer, node-cron, tsx
 - Frontend: React 19, TypeScript (strict), Tailwind CSS v4, Vite 6, React Router v6, TanStack Query v5
 - Docker multi-arch (amd64 + arm64)
-- Tests: ~480 tests using `node:test` + tsx (zero external test dependencies)
+- Tests: ~500 tests using `node:test` + tsx (zero external test dependencies)
 
 ## Project Structure
 
@@ -40,6 +40,7 @@ insightd/
   agent/k8s/                 # Kubernetes manifests (DaemonSet, RBAC) for k8s/k3s deployment
   hub/src/                   # DB, digest, alerts, MQTT subscriber, insights engine
   hub/src/insights/          # Baselines (time-of-day), health scores, capacity-based detector, predictions, correlations
+  hub/src/insights/diagnosis/ # Correlation-based diagnosis framework (context, diagnosers, log cache, runtime)
   hub/src/web/               # HTTP server, API handlers, auth (SQLite sessions + API keys), rate limiting
   hub/src/web/frontend/      # React + TypeScript SPA (Vite build → public/)
   hub/src/web/frontend/src/components/  # Shared UI components (Card, Button, Skeleton, InsightsFeed, etc.)
@@ -53,7 +54,7 @@ insightd/
     StacksPage.tsx, StackDetailPage.tsx, StackFormPage.tsx  # Container groups (renamed from "Services" in #72)
     InsightsPage.tsx         # Dedicated insights page with feedback (thumbs up/down)
   hub/src/web/public/        # Built frontend assets (served by Node HTTP server)
-  hub/src/db/                # Connection, schema (currently v18), settings, rollups
+  hub/src/db/                # Connection, schema (currently v20), settings, rollups
   src/                       # Standalone mode code (Docker only, mirrors hub for single-host)
   tests/                     # Tests using node:test
   docs/                      # Setup guides (kubernetes-setup.md)
@@ -92,12 +93,16 @@ docker compose up -d        # Run full stack (mosquitto + hub + agent)
 - `INSIGHTD_ALLOW_UPDATES` — enable remote agent updates (default false, Docker only)
 - `INSIGHTD_ALLOW_ACTIONS` — enable container start/stop/restart (default false, Docker only)
 - `INSIGHTD_STATUS_PAGE` — enable public status page (default false)
+- `INSIGHTD_RETENTION_RAW_DAYS` — days to keep full-resolution snapshots (default 30, min 7)
+- `INSIGHTD_RETENTION_ROLLUP_DAYS` — days to keep hourly rollups (default 365, min 30)
 - `NODE_NAME` / `NODE_IP` — required in Kubernetes DaemonSet mode (set via downward API)
 - See hub/src/config.ts and agent/src/config.ts for full list (40+ vars)
 
 ## Database
 
-SQLite with WAL mode. **Schema v18.** Key tables: container_snapshots, host_snapshots, disk_snapshots, http_endpoints, http_checks, baselines, health_scores, insights, insight_feedback, alert_state, sessions, api_keys, webhooks, service_groups (still named in DB; surfaces as "Stacks" in the UI), hosts (with `runtime_type`, `host_group`, and `host_group_override` columns — the UI override beats the agent-reported value via COALESCE in queries), host_rollups, container_rollups, disk_rollups, http_rollups (hourly aggregates for long-term retention).
+SQLite with WAL mode. **Schema v20.** Key tables: container_snapshots (with `health_check_output` column added v19), host_snapshots, disk_snapshots, http_endpoints, http_checks, baselines, health_scores, insights (with `evidence`, `suggested_action`, `confidence` columns added v20 for diagnosis findings), insight_feedback, alert_state, sessions, api_keys, webhooks, service_groups (still named in DB; surfaces as "Stacks" in the UI), hosts (with `runtime_type`, `host_group`, and `host_group_override` columns — the UI override beats the agent-reported value via COALESCE in queries), host_rollups, container_rollups, disk_rollups, http_rollups (hourly aggregates for long-term retention).
+
+Data retention is configurable via `retention.rawDays` (default 30, min 7) and `retention.rollupDays` (default 365, min 30) settings. Daily prune cron at 03:30 rolls up raw data into hourly aggregates before deleting it, and runs a conditional VACUUM after large prunes. Schema v18 added the four rollup tables and pruning was rewritten in PR #81.
 
 Both schema files (`hub/src/db/schema.ts` and `src/db/schema.ts`) create `sessions`, `api_keys`, and `insight_feedback` in the bootstrap CREATE TABLE batch — fresh installs need them on first boot, not just via the v12/v14 migration paths (fixed in #74).
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,18 @@ No critical issues. Good week.
 - **Disk monitoring** — usage warnings with "X days until full" forecasts
 - **HTTP endpoint monitoring** — uptime, response time, configurable intervals
 - **Smart insights engine** — capacity-based health scoring (only flags actual saturation, not baseline deviation), time-of-day baselines, predictive alerts, correlation detection
+- **Health check diagnosis** — when a container is unhealthy, insightd correlates metrics, baselines, restart history, host state, and recent logs to explain *why* and suggest *what to do* — not just "wget connection refused"
 - **Insights page** — dedicated `/insights` view with expandable cards, thumbs up/down feedback, and per-session dismiss
-- **Real-time alerts** — 10 alert types with cooldowns, auto-resolution, and webhook delivery
+- **Real-time alerts** — 10 alert types with cooldowns, auto-resolution, and webhook delivery — alerts include the health check output so notifications tell you *why* a container is unhealthy
 - **Webhook notifications** — Slack, Discord, Telegram, ntfy, or any generic webhook
 - **Weekly digest emails** — HTML + plaintext summary of the week
 - **Container actions** — start/stop/restart/remove containers from the UI (opt-in, Docker mode only)
 - **Remove containers** — delete exited containers + clean all insightd data (alerts, history, baselines)
 - **Remote agent updates** — update agents from the hub UI via MQTT (opt-in, Docker mode only)
-- **Image update detection** — compares local images against Docker Hub
+- **Image update detection** — compares local images against Docker Hub, with a "Check now" button on the Updates page
 - **Explainable alerts** — every alert stores why it fired (value, threshold, message) so you can understand what happened
+- **Configurable data retention** — keep raw snapshots for 30 days (configurable), then automatic hourly rollups for long-term trends (default 365 days)
+- **Storage management** — see your database size and last cleanup time on the Settings page, with an on-demand vacuum button
 - **Metric personalities** — baseline-aware human-friendly moods on every metric (e.g. "😌 Normal", "🔥 Way above normal")
 - **Health score breakdown** — click the system health score to see per-host factor analysis
 - **Stacks** — organize containers by purpose across hosts, auto-detected from Docker Compose project labels (UI label, formerly "Services")
@@ -110,14 +113,14 @@ The hub serves a dashboard at `http://localhost:3000`:
 - **Dashboard** — health score with clickable breakdown, availability, compact status bar, unified "Needs Attention" feed, metric personalities
 - **Hosts** — collapsible sections per host group, with status, metrics, and inline group editing
 - **Host detail** — tabbed view: overview, resources, alerts; click the group badge to retag the host
-- **Container detail** — CPU/memory gauges, logs, status history
+- **Container detail** — CPU/memory gauges, logs, status history, structured health diagnosis when unhealthy
 - **Endpoints** — HTTP endpoint monitoring with uptime timelines
 - **Stacks** — container groups with aggregate status (auto-detected from Docker Compose, or create your own)
 - **Alerts** — full alert history with reason, trigger value, and threshold
 - **Insights** — analytical signals (predictions, trends, performance) with thumbs up/down feedback
 - **Updates** — available image updates, remote agent updates
 - **Status page** — public uptime view (enable with `INSIGHTD_STATUS_PAGE=true`)
-- **Settings** — email, alerts, thresholds, API keys
+- **Settings** — email, alerts, thresholds, retention, storage management, API keys
 
 ## Architecture
 
@@ -154,6 +157,8 @@ All configuration can be done via the **Setup Wizard** and **Settings page** in 
 | `INSIGHTD_DIGEST_CRON` | `0 8 * * 1` | Digest schedule (default: Monday 08:00) |
 | `INSIGHTD_COLLECT_INTERVAL` | `5` | Collection interval in minutes |
 | `INSIGHTD_DISK_WARN_THRESHOLD` | `85` | Disk usage warning threshold (%) |
+| `INSIGHTD_RETENTION_RAW_DAYS` | `30` | Days to keep full-resolution snapshots (min 7) |
+| `INSIGHTD_RETENTION_ROLLUP_DAYS` | `365` | Days to keep hourly rollups (min 30) |
 | `TZ` | `UTC` | Timezone for cron schedules |
 
 ## Docker Images
@@ -169,7 +174,7 @@ Insightd is designed to be lightweight:
 
 - **~28MB RAM** in typical use
 - **SQLite** for storage — no external database needed
-- Data older than 30 days is automatically pruned
+- Raw snapshots auto-pruned after 30 days (configurable), with hourly rollups kept for 365 days for long-term trends
 
 ## Development
 


### PR DESCRIPTION
## Summary
Refreshes the project documentation to cover everything shipped in this release cycle:
- Data retention with hourly rollups (#81)
- Health check output captured by agent (#82)
- Manual version check button (#83)
- Correlation-based diagnosis engine (#85)

## Changes
- **README.md** — adds diagnosis engine and storage management to feature list, mentions health check reasons in alert notifications, fixes the "30 days pruned" claim to reflect configurable retention + rollups, adds \`INSIGHTD_RETENTION_RAW_DAYS\` / \`INSIGHTD_RETENTION_ROLLUP_DAYS\` to the env var table
- **CLAUDE.md** — schema v18 → v20, mentions \`health_check_output\` column (v19), \`evidence\`/\`suggested_action\`/\`confidence\` columns (v20), updated tests count, added \`hub/src/insights/diagnosis/\` to project structure, retention env vars in key list
- **.env.example** — new Data Retention section with the two retention vars

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)