### PR TITLE
ci: drop peter-evans/dockerhub-description from publish workflows

### DIFF
--- a/.github/workflows/publish-agent.yml
+++ b/.github/workflows/publish-agent.yml
@@ -46,12 +46,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             INSIGHTD_VERSION=${{ steps.version.outputs.version }}
-
-      - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: andreas404/insightd-agent
-          short-description: "Lightweight monitoring agent for insightd — collects Docker and host metrics"
-          readme-filepath: agent/DOCKERHUB.md

--- a/.github/workflows/publish-hub.yml
+++ b/.github/workflows/publish-hub.yml
@@ -46,12 +46,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             INSIGHTD_VERSION=${{ steps.version.outputs.version }}
-
-      - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: andreas404/insightd-hub
-          short-description: "Self-hosted server monitoring hub — dashboard, alerts, insights, digests"
-          readme-filepath: hub/DOCKERHUB.md


### PR DESCRIPTION
## Problem

PR #89 ("hardening") narrowed the repo's Actions allow-list to github-owned + verified creators only. That immediately broke both `Publish Hub` and `Publish Agent`, which reference `peter-evans/dockerhub-description@v4` — a cosmetic step that pushes the Docker Hub README. It's not on the verified list, so the workflow fails at startup (zero jobs run, logs unavailable).

Evidence: `hub-v0.11.0` tag pushed earlier today against `da1c073` triggered Publish Hub run `24304903885` which completed with `startup_failure`, while `hub-v0.10.0` from 3 hours earlier (before #89 merged) published cleanly with the identical workflow file.

## Fix

Remove the `dockerhub-description` step from both publish workflows. The Docker Hub READMEs can still be updated manually if needed — it's not worth maintaining an allow-list exception for a cosmetic sync.

## Follow-up

After this merges, I'll recreate the `hub-v0.11.0` tag on the new main HEAD so the AI Diagnose feature actually ships to Docker Hub. (Agent is unchanged since `agent-v0.10.0` and doesn't need a bump.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)