### PR TITLE
perf: fix dashboard cold-start latency (16s → 16ms)

### DIFF
--- a/hub/src/db/connection.ts
+++ b/hub/src/db/connection.ts
@@ -18,7 +18,14 @@ function getDb(dbPath: string): Database.Database {
 
   // Performance pragmas
   db.pragma('journal_mode = WAL');
-  db.pragma('cache_size = -2000'); // 2MB cache
+  // 64 MB page cache (negative = KB). DBs grow to ~100 MB in real installs, so
+  // fitting most of the working set in SQLite's own cache makes cold queries
+  // fast without depending on the OS page cache surviving a restart.
+  db.pragma('cache_size = -65536');
+  // Memory-map up to 256 MB of the database. Reads become direct memory
+  // accesses once pages are resident, which is dramatically faster than
+  // the regular I/O path for large scans on cold cache.
+  db.pragma('mmap_size = 268435456');
   db.pragma('busy_timeout = 5000');
   db.pragma('synchronous = NORMAL');
   db.pragma('foreign_keys = ON');

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -61,6 +61,20 @@ async function main(): Promise<void> {
 
     logger.info('main', 'insightd hub is running (MQTT mode)');
 
+    // Warm the dashboard cache in the background so the first user request
+    // hits pre-populated data instead of paying a ~10s cold-cache penalty.
+    setImmediate(() => {
+      try {
+        const { getDashboard } = require('./web/queries') as { getDashboard: (db: Database.Database, threshold: number, showInternal: boolean) => unknown };
+        const threshold = (config.collectIntervalMinutes || 5) * 2;
+        const t0 = Date.now();
+        getDashboard(db, threshold, false);
+        logger.info('warmup', `Dashboard cache primed in ${Date.now() - t0}ms`);
+      } catch (err) {
+        logger.warn('warmup', `Dashboard warmup failed: ${(err as Error).message}`);
+      }
+    });
+
     const shutdown = (): void => {
       logger.info('main', 'Shutting down gracefully...');
       stopScheduler();

--- a/hub/src/web/group-queries.ts
+++ b/hub/src/web/group-queries.ts
@@ -73,38 +73,74 @@ interface GroupUpdateData {
 }
 
 function getGroups(db: Database.Database, showInternal: boolean = false): GroupRow[] {
+  // The old version used `ROW_NUMBER() OVER (PARTITION BY ...)` with no WHERE
+  // clause on container_snapshots, which forces a full scan + window sort of
+  // every row in that table (82k+ in prod). On a 100 MB DB that translated
+  // to ~4 seconds per call — and the internal-filter loop below called it
+  // again per group. The rewrite uses an index-friendly MAX() join restricted
+  // to the last day of snapshots (more than enough for "latest per container"
+  // while still hitting idx_snapshots_host_name_time).
   const groups = db.prepare(`
+    WITH latest AS (
+      SELECT cs.host_id, cs.container_name, cs.status, cs.cpu_percent,
+             cs.memory_mb, cs.labels
+      FROM container_snapshots cs
+      INNER JOIN (
+        SELECT host_id, container_name, MAX(collected_at) AS max_at
+        FROM container_snapshots
+        WHERE collected_at >= datetime('now', '-1 day')
+        GROUP BY host_id, container_name
+      ) m ON m.host_id = cs.host_id
+         AND m.container_name = cs.container_name
+         AND m.max_at = cs.collected_at
+    )
     SELECT sg.*,
       COUNT(sgm.id) as member_count,
-      SUM(CASE WHEN cs.status = 'running' THEN 1 ELSE 0 END) as running_count,
-      ROUND(SUM(cs.cpu_percent), 1) as total_cpu,
-      ROUND(SUM(cs.memory_mb)) as total_memory
+      SUM(CASE WHEN latest.status = 'running' THEN 1 ELSE 0 END) as running_count,
+      ROUND(SUM(latest.cpu_percent), 1) as total_cpu,
+      ROUND(SUM(latest.memory_mb)) as total_memory
     FROM service_groups sg
     LEFT JOIN service_group_members sgm ON sg.id = sgm.group_id
-    LEFT JOIN (
-      SELECT host_id, container_name, status, cpu_percent, memory_mb, labels,
-        ROW_NUMBER() OVER (PARTITION BY host_id, container_name ORDER BY collected_at DESC) as rn
-      FROM container_snapshots
-    ) cs ON cs.host_id = sgm.host_id AND cs.container_name = sgm.container_name AND cs.rn = 1
+    LEFT JOIN latest ON latest.host_id = sgm.host_id AND latest.container_name = sgm.container_name
     GROUP BY sg.id
     ORDER BY sg.name
   `).all() as GroupRow[];
   if (showInternal) return groups;
-  // Hide groups where ALL members are internal (e.g. the "insightd" compose group)
-  return groups.filter(g => {
-    const members = db.prepare(`
-      SELECT cs.labels FROM service_group_members sgm
-      LEFT JOIN (
-        SELECT host_id, container_name, labels,
-          ROW_NUMBER() OVER (PARTITION BY host_id, container_name ORDER BY collected_at DESC) as rn
+
+  // Hide groups where ALL members are internal (the "insightd" compose group).
+  // One query returns every (group_id, labels) pair so we avoid an N-per-group
+  // subquery. Map group_id → labels[] in memory and decide per group.
+  const memberLabels = db.prepare(`
+    WITH latest AS (
+      SELECT cs.host_id, cs.container_name, cs.labels
+      FROM container_snapshots cs
+      INNER JOIN (
+        SELECT host_id, container_name, MAX(collected_at) AS max_at
         FROM container_snapshots
-      ) cs ON cs.host_id = sgm.host_id AND cs.container_name = sgm.container_name AND cs.rn = 1
-      WHERE sgm.group_id = ?
-    `).all(g.id) as LabelsRow[];
+        WHERE collected_at >= datetime('now', '-1 day')
+        GROUP BY host_id, container_name
+      ) m ON m.host_id = cs.host_id
+         AND m.container_name = cs.container_name
+         AND m.max_at = cs.collected_at
+    )
+    SELECT sgm.group_id, latest.labels
+    FROM service_group_members sgm
+    LEFT JOIN latest ON latest.host_id = sgm.host_id AND latest.container_name = sgm.container_name
+  `).all() as Array<{ group_id: number; labels: string | null }>;
+
+  const labelsByGroup = new Map<number, Array<string | null>>();
+  for (const row of memberLabels) {
+    const arr = labelsByGroup.get(row.group_id) ?? [];
+    arr.push(row.labels);
+    labelsByGroup.set(row.group_id, arr);
+  }
+
+  return groups.filter(g => {
+    const members = labelsByGroup.get(g.id as unknown as number) ?? [];
     if (members.length === 0) return true;
-    const allInternal = members.every(m => {
-      if (!m.labels) return false;
-      try { return JSON.parse(m.labels)['insightd.internal'] === 'true'; } catch { return false; }
+    const allInternal = members.every(labels => {
+      if (!labels) return false;
+      try { return JSON.parse(labels)['insightd.internal'] === 'true'; } catch { return false; }
     });
     return !allInternal;
   });

--- a/hub/src/web/queries.ts
+++ b/hub/src/web/queries.ts
@@ -444,22 +444,39 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
   } catch { /* group queries not available */ }
 
   // 24h availability per container — only for containers still being reported.
-  // Containers that have stopped reporting (deleted, filtered, etc.) are
-  // excluded so they don't show as "0% uptime" in the dashboard.
-  const availRows = db.prepare(`
-    SELECT host_id, container_name, labels,
-      COUNT(*) as total,
-      SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) as running
+  // Two-pass to avoid a correlated EXISTS over the snapshot table: first get
+  // the set of (host,name) pairs active in the last 15 min, then aggregate
+  // 24h stats filtered to that set. Joining via a temp table is much cheaper
+  // than re-evaluating EXISTS for every matching row.
+  const activePairs = db.prepare(`
+    SELECT DISTINCT host_id, container_name
     FROM container_snapshots
-    WHERE collected_at >= datetime('now', '-1 day')
-      AND EXISTS (
-        SELECT 1 FROM container_snapshots cs2
-        WHERE cs2.host_id = container_snapshots.host_id
-          AND cs2.container_name = container_snapshots.container_name
-          AND cs2.collected_at > datetime('now', '-15 minutes')
-      )
-    GROUP BY host_id, container_name
-  `).all() as AvailabilityRow[];
+    WHERE collected_at > datetime('now', '-15 minutes')
+  `).all() as Array<{ host_id: string; container_name: string }>;
+  const availRows: AvailabilityRow[] = [];
+  if (activePairs.length > 0) {
+    const availStmt = db.prepare(`
+      SELECT labels,
+        COUNT(*) as total,
+        SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) as running
+      FROM container_snapshots
+      WHERE host_id = ? AND container_name = ?
+        AND collected_at >= datetime('now', '-1 day')
+    `);
+    for (const pair of activePairs) {
+      const row = availStmt.get(pair.host_id, pair.container_name) as
+        { labels: string | null; total: number; running: number } | undefined;
+      if (row && row.total > 0) {
+        availRows.push({
+          host_id: pair.host_id,
+          container_name: pair.container_name,
+          labels: row.labels,
+          total: row.total,
+          running: row.running,
+        });
+      }
+    }
+  }
   const availFiltered = showInternal ? availRows : availRows.filter(c => {
     if (!c.labels) return true;
     try { return JSON.parse(c.labels)['insightd.internal'] !== 'true'; } catch { return true; }


### PR DESCRIPTION
## Problem

Noticed by user: "the hub is running a bit slow". Measured: `/api/dashboard` took **13-20 seconds on the first request after a hub restart** (every other endpoint was <50ms).

## Root cause

Profiling each sub-query in `getDashboard` pointed at **`getGroups`**, which ran this on every call:

```sql
SELECT ..., ROW_NUMBER() OVER (PARTITION BY host_id, container_name
                               ORDER BY collected_at DESC) as rn
FROM container_snapshots
```

No `WHERE` clause, so SQLite materialized a window function over every row in `container_snapshots` (~82k in prod) for each call. Warm: ~4s. Cold: ~16s.

Worse, the internal-filter loop below it called the same query **once per group**, so for N groups it was N × 82k row scans to render one dashboard.

A secondary issue in the dashboard's own availability query was the correlated `EXISTS` subquery flagged by the `feedback_sqlite_perf` memory.

## Fix

1. **Rewrite `getGroups`** to use a MAX(collected_at) join scoped to the last 24h. Hits `idx_snapshots_host_name_time` and runs in ~20ms end-to-end.
2. **Collapse the per-group filter subquery** into a single query that returns all `(group_id, labels)` pairs, consumed via a `Map` lookup. Removes the O(groups) quadratic scan.
3. **Drop the correlated `EXISTS`** in the dashboard availability query — two passes (active pairs, then per-pair aggregate) are much cheaper than re-evaluating `EXISTS` for every matching row.
4. **Bump SQLite PRAGMAs**: `cache_size` 2MB → 64MB, enable 256MB `mmap_size`. Keeps the working set resident across OS page-cache cold-starts.
5. **Warm the dashboard cache at boot** via a fire-and-forget `setImmediate(getDashboard)` so the first user request always hits pre-populated data.

## Measurements

All from the dev VM (~100 MB DB, 9 hosts, 82k snapshots).

| Scenario | Before | After |
|---|---|---|
| Dashboard cache warmup (at boot) | 16,470 ms | **71 ms** |
| First dashboard HTTP request after restart | 13–20 s | **~16 ms** |
| Subsequent requests | ~3 ms | ~3 ms |

> **~1000× improvement on cold-start**, and subsequent loads unchanged.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 535/535 passing
- [x] Rebuilt + deployed to dev; warmup log reports `Dashboard cache primed in 71ms`
- [x] First HTTP request after `docker restart insightd-hub` measured at 16ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)