### PR TITLE
feat: exponential backoff for alert reminders

### DIFF
--- a/hub/src/alerts/evaluator.ts
+++ b/hub/src/alerts/evaluator.ts
@@ -30,7 +30,23 @@ interface AlertsConfig {
   endpointDown: boolean | undefined;
   endpointFailureThreshold: number;
   cooldownMinutes: number;
+  reminderBackoff?: boolean;
+  reminderMaxMinutes?: number;
   to: string;
+}
+
+/**
+ * Required minutes between reminders. With backoff enabled, the gap doubles
+ * each reminder (base, 2×, 4×, 8×, …) and caps at reminderMaxMinutes — so a
+ * persistent alert settles into at most one notification per cap window.
+ * notifyCount is the cumulative count *before* the next reminder (so after
+ * the initial send it's 1, meaning "wait base minutes for reminder #1").
+ */
+function requiredReminderGap(notifyCount: number, baseMinutes: number, capMinutes: number, backoff: boolean): number {
+  if (!backoff) return baseMinutes;
+  const exponent = Math.max(0, notifyCount - 1);
+  const scaled = baseMinutes * Math.pow(2, Math.min(exponent, 30));
+  return Math.min(scaled, capMinutes);
 }
 
 interface EvaluatorConfig {
@@ -403,6 +419,8 @@ function getResolutionMessage(type: string, target: string, hostId: string): str
 function processAlerts(db: Database.Database, config: EvaluatorConfig, { triggered, resolved }: EvaluationResult): AlertItem[] {
   const toSend: AlertItem[] = [];
   const cooldownMinutes = config.alerts.cooldownMinutes;
+  const backoff = config.alerts.reminderBackoff !== false;
+  const capMinutes = config.alerts.reminderMaxMinutes ?? 1440;
 
   for (const alert of triggered) {
     const active = db.prepare(`
@@ -421,7 +439,8 @@ function processAlerts(db: Database.Database, config: EvaluatorConfig, { trigger
         "SELECT (julianday('now') - julianday(?)) * 1440 as minutes"
       ).get(active.last_notified) as { minutes: number }).minutes;
 
-      if (minutesSinceLast >= cooldownMinutes) {
+      const requiredGap = requiredReminderGap(active.notify_count, cooldownMinutes, capMinutes, backoff);
+      if (minutesSinceLast >= requiredGap) {
         const newCount = active.notify_count + 1;
         db.prepare('UPDATE alert_state SET last_notified = datetime(\'now\'), notify_count = ? WHERE id = ?').run(newCount, active.id);
         toSend.push({ ...alert, reminderNumber: newCount - 1 });
@@ -478,4 +497,4 @@ async function runAlerts(db: Database.Database, config: EvaluatorConfig): Promis
   }
 }
 
-module.exports = { evaluateAlerts, processAlerts, runAlerts };
+module.exports = { evaluateAlerts, processAlerts, runAlerts, requiredReminderGap };

--- a/hub/src/alerts/sender.ts
+++ b/hub/src/alerts/sender.ts
@@ -64,8 +64,12 @@ function formatBody(alert: AlertItem): string {
 
   lines.push('');
   lines.push('---');
-  lines.push('This alert will repeat every cooldown period until resolved.');
-  lines.push('Set INSIGHTD_ALERTS_ENABLED=false to disable alerts.');
+  if (alert.isResolution) {
+    lines.push('Set INSIGHTD_ALERTS_ENABLED=false to disable alerts.');
+  } else {
+    lines.push('Reminders slow down as the alert persists, up to once per day until resolved.');
+    lines.push('Set INSIGHTD_ALERTS_ENABLED=false to disable alerts.');
+  }
 
   return lines.join('\n');
 }

--- a/hub/src/config.ts
+++ b/hub/src/config.ts
@@ -64,6 +64,8 @@ const config = Object.freeze({
     enabled: process.env.INSIGHTD_ALERTS_ENABLED === 'true',
     to: process.env.INSIGHTD_ALERTS_TO || process.env.INSIGHTD_DIGEST_TO || '',
     cooldownMinutes: parseInt(process.env.INSIGHTD_ALERT_COOLDOWN || '60', 10),
+    reminderBackoff: process.env.INSIGHTD_ALERT_REMINDER_BACKOFF !== 'false',
+    reminderMaxMinutes: parseInt(process.env.INSIGHTD_ALERT_REMINDER_MAX || '1440', 10),
     cpuPercent: parseInt(process.env.INSIGHTD_ALERT_CPU || '90', 10),
     memoryMb: parseInt(process.env.INSIGHTD_ALERT_MEMORY || '0', 10),
     diskPercent: parseInt(process.env.INSIGHTD_ALERT_DISK || '90', 10),

--- a/hub/src/db/settings.ts
+++ b/hub/src/db/settings.ts
@@ -48,6 +48,8 @@ interface AlertsConfig {
   enabled: boolean;
   to: string;
   cooldownMinutes: number;
+  reminderBackoff: boolean;
+  reminderMaxMinutes: number;
   cpuPercent: number;
   memoryMb: number;
   diskPercent: number;
@@ -94,7 +96,9 @@ const SETTING_DEFS: SettingDef[] = [
   // Alerts
   { key: 'alerts.enabled', env: 'INSIGHTD_ALERTS_ENABLED', type: 'bool', category: 'Alerts', label: 'Alerts Enabled', hotReload: true, default: 'false' },
   { key: 'alerts.to', env: 'INSIGHTD_ALERTS_TO', type: 'string', category: 'Alerts', label: 'Alert Recipient', hotReload: true, default: '' },
-  { key: 'alerts.cooldownMinutes', env: 'INSIGHTD_ALERT_COOLDOWN', type: 'int', category: 'Alerts', label: 'Cooldown (minutes)', hotReload: true, default: '60' },
+  { key: 'alerts.cooldownMinutes', env: 'INSIGHTD_ALERT_COOLDOWN', type: 'int', category: 'Alerts', label: 'Cooldown (minutes)', hotReload: true, default: '60', description: 'Minutes between the first reminders for a persistent alert. With backoff on, each subsequent reminder doubles this gap up to the cap.' },
+  { key: 'alerts.reminderBackoff', env: 'INSIGHTD_ALERT_REMINDER_BACKOFF', type: 'bool', category: 'Alerts', label: 'Slow down reminders', hotReload: true, default: 'true', description: 'Double the gap between reminders each time (1h → 2h → 4h → 8h → capped). Prevents spam for long-lasting alerts.' },
+  { key: 'alerts.reminderMaxMinutes', env: 'INSIGHTD_ALERT_REMINDER_MAX', type: 'int', category: 'Alerts', label: 'Max reminder gap (minutes)', hotReload: true, default: '1440', description: 'Upper bound on the gap between reminders. Default 1440 = once per day.' },
   { key: 'alerts.cpuPercent', env: 'INSIGHTD_ALERT_CPU', type: 'int', category: 'Alerts', label: 'Container CPU Threshold (%)', hotReload: true, default: '90' },
   { key: 'alerts.memoryMb', env: 'INSIGHTD_ALERT_MEMORY', type: 'int', category: 'Alerts', label: 'Container Memory Threshold (MB)', hotReload: true, default: '0' },
   { key: 'alerts.diskPercent', env: 'INSIGHTD_ALERT_DISK', type: 'int', category: 'Alerts', label: 'Disk Threshold (%)', hotReload: true, default: '90' },
@@ -246,6 +250,8 @@ function getEffectiveConfig(db: Database.Database, baseConfig: BaseConfig): Base
       enabled: get('alerts.enabled'),
       to: get('alerts.to') || baseConfig.alerts?.to || '',
       cooldownMinutes: get('alerts.cooldownMinutes') || baseConfig.alerts?.cooldownMinutes || 60,
+      reminderBackoff: get('alerts.reminderBackoff'),
+      reminderMaxMinutes: get('alerts.reminderMaxMinutes') || baseConfig.alerts?.reminderMaxMinutes || 1440,
       cpuPercent: get('alerts.cpuPercent'),
       memoryMb: get('alerts.memoryMb'),
       diskPercent: get('alerts.diskPercent'),

--- a/src/alerts/evaluator.ts
+++ b/src/alerts/evaluator.ts
@@ -24,7 +24,23 @@ interface AlertsConfig {
   endpointDown?: boolean;
   endpointFailureThreshold?: number;
   cooldownMinutes: number;
+  reminderBackoff?: boolean;
+  reminderMaxMinutes?: number;
   to: string;
+}
+
+/**
+ * Required minutes between reminders. With backoff enabled, the gap doubles
+ * each reminder (base, 2×, 4×, 8×, …) and caps at reminderMaxMinutes — so a
+ * persistent alert settles into at most one notification per cap window.
+ * notifyCount is the cumulative count *before* the next reminder (so after
+ * the initial send it's 1, meaning "wait base minutes for reminder #1").
+ */
+function requiredReminderGap(notifyCount: number, baseMinutes: number, capMinutes: number, backoff: boolean): number {
+  if (!backoff) return baseMinutes;
+  const exponent = Math.max(0, notifyCount - 1);
+  const scaled = baseMinutes * Math.pow(2, Math.min(exponent, 30));
+  return Math.min(scaled, capMinutes);
 }
 
 interface EvaluatorConfig {
@@ -305,6 +321,8 @@ function getResolutionMessage(type: string, target: string, hostId: string): str
 function processAlerts(db: Database.Database, config: EvaluatorConfig, { triggered, resolved }: EvaluationResult): AlertItem[] {
   const toSend: AlertItem[] = [];
   const cooldownMinutes = config.alerts.cooldownMinutes;
+  const backoff = config.alerts.reminderBackoff !== false;
+  const capMinutes = config.alerts.reminderMaxMinutes ?? 1440;
 
   for (const alert of triggered) {
     const active = db.prepare(`
@@ -323,7 +341,8 @@ function processAlerts(db: Database.Database, config: EvaluatorConfig, { trigger
         "SELECT (julianday('now') - julianday(?)) * 1440 as minutes"
       ).get(active.last_notified) as { minutes: number }).minutes;
 
-      if (minutesSinceLast >= cooldownMinutes) {
+      const requiredGap = requiredReminderGap(active.notify_count, cooldownMinutes, capMinutes, backoff);
+      if (minutesSinceLast >= requiredGap) {
         const newCount = active.notify_count + 1;
         db.prepare('UPDATE alert_state SET last_notified = datetime(\'now\'), notify_count = ? WHERE id = ?').run(newCount, active.id);
         toSend.push({ ...alert, reminderNumber: newCount - 1 });
@@ -371,4 +390,4 @@ async function runAlerts(db: Database.Database, config: EvaluatorConfig): Promis
   }
 }
 
-module.exports = { evaluateAlerts, processAlerts, runAlerts };
+module.exports = { evaluateAlerts, processAlerts, runAlerts, requiredReminderGap };

--- a/src/alerts/sender.ts
+++ b/src/alerts/sender.ts
@@ -64,8 +64,12 @@ function formatBody(alert: AlertItem): string {
 
   lines.push('');
   lines.push('---');
-  lines.push('This alert will repeat every cooldown period until resolved.');
-  lines.push('Set INSIGHTD_ALERTS_ENABLED=false to disable alerts.');
+  if (alert.isResolution) {
+    lines.push('Set INSIGHTD_ALERTS_ENABLED=false to disable alerts.');
+  } else {
+    lines.push('Reminders slow down as the alert persists, up to once per day until resolved.');
+    lines.push('Set INSIGHTD_ALERTS_ENABLED=false to disable alerts.');
+  }
 
   return lines.join('\n');
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,8 @@ const config = Object.freeze({
     enabled: process.env.INSIGHTD_ALERTS_ENABLED === 'true',
     to: process.env.INSIGHTD_ALERTS_TO || process.env.INSIGHTD_DIGEST_TO || '',
     cooldownMinutes: parseInt(process.env.INSIGHTD_ALERT_COOLDOWN || '60', 10),
+    reminderBackoff: process.env.INSIGHTD_ALERT_REMINDER_BACKOFF !== 'false',
+    reminderMaxMinutes: parseInt(process.env.INSIGHTD_ALERT_REMINDER_MAX || '1440', 10),
     cpuPercent: parseInt(process.env.INSIGHTD_ALERT_CPU || '90', 10),
     memoryMb: parseInt(process.env.INSIGHTD_ALERT_MEMORY || '0', 10),
     diskPercent: parseInt(process.env.INSIGHTD_ALERT_DISK || '90', 10),

--- a/tests/unit/evaluator.test.ts
+++ b/tests/unit/evaluator.test.ts
@@ -351,4 +351,132 @@ describe('processAlerts', () => {
     const row = db.prepare('SELECT resolved_at FROM alert_state WHERE target = ?').get('nginx');
     assert.ok(row.resolved_at !== null);
   });
+
+  describe('reminder backoff', () => {
+    const backoffConfig = { alerts: { cooldownMinutes: 60, reminderBackoff: true, reminderMaxMinutes: 1440 } };
+
+    function hoursAgo(hours: number): string {
+      return ts(new Date(NOW - hours * 60 * 60 * 1000));
+    }
+
+    it('suppresses reminder #1 during base cooldown window', () => {
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(1), lastNotified: hoursAgo(0.5), notifyCount: 1 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, backoffConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 0);
+    });
+
+    it('sends reminder #1 once base cooldown has elapsed', () => {
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(2), lastNotified: hoursAgo(1.1), notifyCount: 1 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, backoffConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 1);
+      assert.equal(toSend[0].reminderNumber, 1);
+    });
+
+    it('doubles gap before reminder #2 (suppresses after only 1h)', () => {
+      // notify_count=2 means the initial send + one reminder already happened.
+      // Required gap = base * 2 = 120 minutes. 61 min < 120 → suppress.
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(3), lastNotified: ts(new Date(NOW - 61 * 60 * 1000)), notifyCount: 2 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, backoffConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 0);
+    });
+
+    it('sends reminder #2 once 2× base has elapsed', () => {
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(4), lastNotified: hoursAgo(2.1), notifyCount: 2 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, backoffConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 1);
+      assert.equal(toSend[0].reminderNumber, 2);
+    });
+
+    it('caps the gap at reminderMaxMinutes', () => {
+      // notify_count=10 would request base*2^9 = 30720 minutes; cap is 1440.
+      // Last notified 25h ago → should fire.
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(200), lastNotified: hoursAgo(25), notifyCount: 10 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, backoffConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 1);
+      assert.equal(toSend[0].reminderNumber, 10);
+    });
+
+    it('suppresses when within the cap window', () => {
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(200), lastNotified: hoursAgo(23), notifyCount: 10 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, backoffConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 0);
+    });
+
+    it('falls back to flat cooldown when backoff disabled', () => {
+      const flatConfig = { alerts: { cooldownMinutes: 60, reminderBackoff: false, reminderMaxMinutes: 1440 } };
+      // notify_count=5 — with backoff this would require 960 minutes, but flat should require only 60.
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(10), lastNotified: hoursAgo(1.1), notifyCount: 5 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, flatConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 1);
+      assert.equal(toSend[0].reminderNumber, 5);
+    });
+
+    it('defaults to backoff on when flag is omitted', () => {
+      // No reminderBackoff key at all — must default to true, so notify_count=5 → 960 min required.
+      const defaultConfig = { alerts: { cooldownMinutes: 60 } };
+      seedAlertState(db, [
+        { type: 'container_down', target: 'nginx', triggeredAt: hoursAgo(10), lastNotified: hoursAgo(1.1), notifyCount: 5 },
+      ]);
+      const triggered = [{ type: 'container_down', hostId: 'local', target: 'nginx', message: 'test' }];
+      const toSend = processAlerts(db, defaultConfig, { triggered, resolved: [] });
+      assert.equal(toSend.length, 0);
+    });
+  });
+});
+
+describe('requiredReminderGap', () => {
+  let requiredReminderGap: Function;
+  beforeEach(() => {
+    delete require.cache[require.resolve('../../src/alerts/evaluator')];
+    requiredReminderGap = require('../../src/alerts/evaluator').requiredReminderGap;
+  });
+
+  it('returns base for notifyCount=1 (first reminder)', () => {
+    assert.equal(requiredReminderGap(1, 60, 1440, true), 60);
+  });
+
+  it('doubles for each successive reminder', () => {
+    assert.equal(requiredReminderGap(2, 60, 1440, true), 120);
+    assert.equal(requiredReminderGap(3, 60, 1440, true), 240);
+    assert.equal(requiredReminderGap(4, 60, 1440, true), 480);
+    assert.equal(requiredReminderGap(5, 60, 1440, true), 960);
+  });
+
+  it('caps at reminderMaxMinutes', () => {
+    assert.equal(requiredReminderGap(6, 60, 1440, true), 1440);
+    assert.equal(requiredReminderGap(20, 60, 1440, true), 1440);
+    assert.equal(requiredReminderGap(100, 60, 1440, true), 1440);
+  });
+
+  it('returns base when backoff disabled', () => {
+    assert.equal(requiredReminderGap(1, 60, 1440, false), 60);
+    assert.equal(requiredReminderGap(10, 60, 1440, false), 60);
+  });
+
+  it('honours custom base and cap', () => {
+    assert.equal(requiredReminderGap(1, 30, 720, true), 30);
+    assert.equal(requiredReminderGap(5, 30, 720, true), 480);
+    assert.equal(requiredReminderGap(6, 30, 720, true), 720);
+  });
 });


### PR DESCRIPTION
## Summary
- Persistent alerts no longer spam the inbox. Reminder gaps double each time (1h → 2h → 4h → 8h → …) and cap at once per day, so an alert stuck for a day produces ~5 emails on day one and one per day after, instead of 24+ every day.
- Two new hot-reloadable settings: `alerts.reminderBackoff` (default **true**) and `alerts.reminderMaxMinutes` (default **1440**). Env overrides: `INSIGHTD_ALERT_REMINDER_BACKOFF`, `INSIGHTD_ALERT_REMINDER_MAX`.
- Resolution emails are unchanged — they still fire immediately when the condition clears.
- No schema change. The backoff is computed from the existing `notify_count` column on `alert_state`.

## Behavior change on upgrade
`reminderBackoff` defaults to **true**, so existing users will see fewer reminder emails for long-running alerts after upgrading. This was the motivating use case (AdGuard down for a day → 24 emails). Users who prefer the old flat cadence can flip `alerts.reminderBackoff` off in Settings → Alerts.

## Notes
- Webhooks (Slack/Discord/ntfy/generic) inherit the new cadence automatically because `dispatchAlertWebhooks` runs for the same alerts `processAlerts` decides to send.
- If an alert resolves and re-fires, `notify_count` resets with the new `alert_state` row, so you get the fast first-round reminders again. That's the intended behavior.
- Per-alert-type overrides (e.g. disk-full reminding more often than high-CPU) were considered and deferred — flat cap is enough to solve the reported pain.

## Test plan
- [x] `npm test` — 555/555 pass, 13 new cases in `tests/unit/evaluator.test.ts` covering backoff math, cap enforcement, flat fallback, and the default-on flag behavior
- [x] `npm run typecheck` — clean
- [x] Deploy to local VM and confirm the persistent AdGuard unhealthy alert stops spamming
- [x] Verify Settings → Alerts renders the two new knobs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)