### PR TITLE
fix(hub): raise Node heap limit from 40MB to 256MB

### DIFF
--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -32,7 +32,7 @@ ENV INSIGHTD_VERSION=$INSIGHTD_VERSION
 
 RUN mkdir -p /data
 
-ENV NODE_OPTIONS="--max-old-space-size=40"
+ENV NODE_OPTIONS="--max-old-space-size=256"
 
 VOLUME ["/data"]
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- The 40MB `--max-old-space-size` cap was set in the initial hub commit years ago and has been untouched since.
- Recent work (dashboard warmup in #108, insights cron at */15, correlation diagnosis engine) pushed steady-state heap past the limit, causing the hub to crash-loop on startup during the warmup phase with "Reached heap limit Allocation failed — JavaScript heap out of memory".
- 256MB is still conservative for a homelab-scale hub and leaves headroom for future features.

## Test plan
- [x] Hub boots and serves the dashboard locally
- [ ] No regression on agent side (agent has its own Dockerfile, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)