### PR TITLE
feat(diagnosis): robust baselines + S-H-ESD (schema v24) — Phase 2/4

### DIFF
--- a/hub/src/db/schema.ts
+++ b/hub/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import logger = require('../../../shared/utils/logger');
 
-const SCHEMA_VERSION = 23;
+const SCHEMA_VERSION = 24;
 
 function bootstrap(db: Database.Database): void {
   db.exec(`
@@ -175,20 +175,22 @@ function bootstrap(db: Database.Database): void {
       ON service_group_members (host_id, container_name);
 
     CREATE TABLE IF NOT EXISTS baselines (
-      id           INTEGER PRIMARY KEY AUTOINCREMENT,
-      entity_type  TEXT NOT NULL,
-      entity_id    TEXT NOT NULL,
-      metric       TEXT NOT NULL,
-      time_bucket  TEXT NOT NULL,
-      p50          REAL,
-      p75          REAL,
-      p90          REAL,
-      p95          REAL,
-      p99          REAL,
-      min_val      REAL,
-      max_val      REAL,
-      sample_count INTEGER NOT NULL DEFAULT 0,
-      computed_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      entity_type      TEXT NOT NULL,
+      entity_id        TEXT NOT NULL,
+      metric           TEXT NOT NULL,
+      time_bucket      TEXT NOT NULL,
+      p50              REAL,
+      p75              REAL,
+      p90              REAL,
+      p95              REAL,
+      p99              REAL,
+      min_val          REAL,
+      max_val          REAL,
+      mad              REAL,
+      mad_sample_count INTEGER,
+      sample_count     INTEGER NOT NULL DEFAULT 0,
+      computed_at      TEXT NOT NULL DEFAULT (datetime('now')),
       UNIQUE(entity_type, entity_id, metric, time_bucket)
     );
 
@@ -348,6 +350,22 @@ function bootstrap(db: Database.Database): void {
       sample_count    INTEGER NOT NULL,
       PRIMARY KEY (endpoint_id, bucket)
     );
+
+    CREATE TABLE IF NOT EXISTS rollup_anomalies (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      entity_type  TEXT NOT NULL,
+      entity_id    TEXT NOT NULL,
+      metric       TEXT NOT NULL,
+      bucket       TEXT NOT NULL,
+      value        REAL NOT NULL,
+      residual     REAL NOT NULL,
+      robust_z     REAL NOT NULL,
+      detected_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(entity_type, entity_id, metric, bucket)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_rollup_anomalies_entity
+      ON rollup_anomalies (entity_type, entity_id, detected_at);
   `);
 
   // Track schema version and run migrations
@@ -530,6 +548,11 @@ function migrate(db: Database.Database, fromVersion: number): void {
   }
   if (fromVersion < 23) {
     // log_templates table + index created via CREATE TABLE IF NOT EXISTS in bootstrap
+  }
+  if (fromVersion < 24) {
+    try { db.exec('ALTER TABLE baselines ADD COLUMN mad REAL'); } catch { /* already exists */ }
+    try { db.exec('ALTER TABLE baselines ADD COLUMN mad_sample_count INTEGER'); } catch { /* already exists */ }
+    // rollup_anomalies table + index created via CREATE TABLE IF NOT EXISTS in bootstrap
   }
 }
 

--- a/hub/src/insights/anomaly/shesd.ts
+++ b/hub/src/insights/anomaly/shesd.ts
@@ -1,0 +1,179 @@
+/**
+ * Seasonal Hybrid ESD (S-H-ESD) anomaly detection on hourly rollups.
+ *
+ * Based on Twitter's AnomalyDetection (Vallis et al., 2014). We strip a
+ * simple seasonal component via a rolling median, then run generalized ESD
+ * on the residuals to detect points that deviate more than ~3.5 MAD units
+ * from their seasonal neighborhood.
+ *
+ * Why rolling median instead of full STL decomposition:
+ *   - At homelab scale (up to ~500 hourly samples per series) an O(n·window)
+ *     rolling median is still sub-millisecond per pass, and STL's extra
+ *     smoothing layers don't materially change detection quality.
+ *   - It degrades gracefully when the series is short (< 7 days): we skip
+ *     detection rather than produce flaky anomalies from an unstable model.
+ *
+ * Results are written to `rollup_anomalies` so diagnosers and the UI can
+ * surface them without re-running the math. The table has UNIQUE
+ * (entity_type, entity_id, metric, bucket) so re-runs are idempotent.
+ */
+
+import type Database from 'better-sqlite3';
+import logger = require('../../../../shared/utils/logger');
+import { rollingMedian, mad as madFn, esdTest, median } from '../stats';
+
+const MIN_SERIES_LENGTH = 168;      // 7 days of hourly samples
+const SEASONAL_WINDOW = 24 * 7;     // 1 week sliding window
+const MAX_SERIES_LENGTH = 24 * 14;  // 14 days cap so we don't waste cycles
+const MAX_OUTLIER_FRACTION = 0.02;  // at most 2% of points can be anomalies
+const ROBUST_Z_THRESHOLD = 3.5;     // matches Phase 2 detector/context bands
+
+interface RollupRow {
+  bucket: string;
+  value: number;
+}
+
+interface AnomalySpec {
+  entityType: string;
+  entityId: string;
+  metric: string;
+  loader: (db: Database.Database) => RollupRow[];
+}
+
+/**
+ * One definition per (entity, metric) pair we want to watch. Only hourly
+ * rollups the engine already computes — no new collection.
+ */
+function buildSpecs(db: Database.Database): AnomalySpec[] {
+  const hosts = db.prepare('SELECT DISTINCT host_id FROM host_rollups').all() as Array<{ host_id: string }>;
+  const containers = db.prepare(
+    'SELECT DISTINCT host_id, container_name FROM container_rollups'
+  ).all() as Array<{ host_id: string; container_name: string }>;
+
+  const specs: AnomalySpec[] = [];
+
+  for (const { host_id } of hosts) {
+    for (const metric of ['cpu_max', 'mem_used_max'] as const) {
+      specs.push({
+        entityType: 'host',
+        entityId: host_id,
+        metric,
+        loader: (d) => d.prepare(
+          `SELECT bucket, ${metric} AS value FROM host_rollups
+           WHERE host_id = ? AND ${metric} IS NOT NULL
+           ORDER BY bucket DESC LIMIT ${MAX_SERIES_LENGTH}`,
+        ).all(host_id) as RollupRow[],
+      });
+    }
+  }
+
+  for (const { host_id, container_name } of containers) {
+    for (const metric of ['cpu_max', 'mem_max'] as const) {
+      specs.push({
+        entityType: 'container',
+        entityId: `${host_id}/${container_name}`,
+        metric,
+        loader: (d) => d.prepare(
+          `SELECT bucket, ${metric} AS value FROM container_rollups
+           WHERE host_id = ? AND container_name = ? AND ${metric} IS NOT NULL
+           ORDER BY bucket DESC LIMIT ${MAX_SERIES_LENGTH}`,
+        ).all(host_id, container_name) as RollupRow[],
+      });
+    }
+  }
+
+  return specs;
+}
+
+interface AnomalyRow {
+  entityType: string;
+  entityId: string;
+  metric: string;
+  bucket: string;
+  value: number;
+  residual: number;
+  robustZ: number;
+}
+
+function runSpec(db: Database.Database, spec: AnomalySpec): AnomalyRow[] {
+  const raw = spec.loader(db);
+  if (raw.length < MIN_SERIES_LENGTH) return [];
+
+  // DESC load for performance; flip to ASC for analysis.
+  const series = raw.slice().reverse();
+  const values = series.map((r) => r.value);
+
+  const seasonal = rollingMedian(values, SEASONAL_WINDOW);
+  const residuals = values.map((v, i) => v - seasonal[i]!);
+
+  // Use a standalone median/MAD on residuals to report the per-anomaly
+  // robust-z cleanly (esdTest only returns indices, not the final score).
+  const med = median(residuals.slice());
+  const d = madFn(residuals);
+  if (med == null || d == null || d === 0) return [];
+
+  const maxOutliers = Math.max(1, Math.floor(residuals.length * MAX_OUTLIER_FRACTION));
+  const indices = esdTest(residuals, maxOutliers, ROBUST_Z_THRESHOLD);
+
+  const results: AnomalyRow[] = [];
+  for (const i of indices) {
+    const value = values[i]!;
+    const residual = residuals[i]!;
+    const z = Math.abs(residual - med) / d;
+    results.push({
+      entityType: spec.entityType,
+      entityId: spec.entityId,
+      metric: spec.metric,
+      bucket: series[i]!.bucket,
+      value,
+      residual,
+      robustZ: Math.round(z * 100) / 100,
+    });
+  }
+  return results;
+}
+
+/**
+ * Run S-H-ESD across every eligible (entity, metric) series and upsert
+ * detected anomalies into `rollup_anomalies`. Never throws — errors are
+ * logged and the pass continues with the next series.
+ */
+export function runAnomalyDetection(db: Database.Database): number {
+  const specs = buildSpecs(db);
+  const upsert = db.prepare(`
+    INSERT INTO rollup_anomalies
+      (entity_type, entity_id, metric, bucket, value, residual, robust_z)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(entity_type, entity_id, metric, bucket) DO UPDATE SET
+      value = excluded.value,
+      residual = excluded.residual,
+      robust_z = excluded.robust_z,
+      detected_at = datetime('now')
+  `);
+
+  let total = 0;
+  const tx = db.transaction((rows: AnomalyRow[]) => {
+    for (const r of rows) {
+      upsert.run(r.entityType, r.entityId, r.metric, r.bucket, r.value, r.residual, r.robustZ);
+    }
+  });
+
+  for (const spec of specs) {
+    try {
+      const rows = runSpec(db, spec);
+      if (rows.length > 0) {
+        tx(rows);
+        total += rows.length;
+      }
+    } catch (err) {
+      logger.warn('anomaly', `S-H-ESD failed for ${spec.entityType} ${spec.entityId} ${spec.metric}: ${(err as Error).message}`);
+    }
+  }
+
+  if (total > 0) {
+    logger.info('anomaly', `S-H-ESD detected ${total} rollup anomalies across ${specs.length} series`);
+  }
+  return total;
+}
+
+module.exports = { runAnomalyDetection };

--- a/hub/src/insights/baselines.ts
+++ b/hub/src/insights/baselines.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3';
 import logger = require('../../../shared/utils/logger');
+import { mad as robustMad } from './stats';
 
 const HOST_METRICS: string[] = [
   'cpu_percent', 'memory_used_mb', 'load_1', 'load_5', 'swap_used_mb',
@@ -41,6 +42,8 @@ interface Percentiles {
   p99: number | null;
   min: number | undefined;
   max: number | undefined;
+  mad: number | null;
+  mad_sample_count: number;
   count: number;
 }
 
@@ -57,10 +60,20 @@ function percentile(sorted: number[], p: number): number | null {
 }
 
 function computePercentiles(values: number[]): Percentiles {
+  const p50 = percentile(values, 50);
+  // MAD uses the same sorted values; pass the median we just computed so the
+  // shared helper doesn't re-sort. Skipped for fewer than 10 samples — the
+  // estimate is too noisy to be useful below that.
+  const madValue = values.length >= 10 && p50 != null
+    ? robustMad(values, p50)
+    : null;
   return {
-    p50: percentile(values, 50), p75: percentile(values, 75), p90: percentile(values, 90),
+    p50, p75: percentile(values, 75), p90: percentile(values, 90),
     p95: percentile(values, 95), p99: percentile(values, 99),
-    min: values[0], max: values[values.length - 1], count: values.length,
+    min: values[0], max: values[values.length - 1],
+    mad: madValue != null ? Math.round(madValue * 100) / 100 : null,
+    mad_sample_count: madValue != null ? values.length : 0,
+    count: values.length,
   };
 }
 
@@ -88,17 +101,19 @@ type BaselineCache = Map<string, Record<string, Percentiles & { sample_count: nu
 function computeBaselines(db: Database.Database): BaselineCache {
   const cache: BaselineCache = new Map();
   const upsert = db.prepare(`
-    INSERT INTO baselines (entity_type, entity_id, metric, time_bucket, p50, p75, p90, p95, p99, min_val, max_val, sample_count, computed_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    INSERT INTO baselines (entity_type, entity_id, metric, time_bucket, p50, p75, p90, p95, p99, min_val, max_val, mad, mad_sample_count, sample_count, computed_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
     ON CONFLICT(entity_type, entity_id, metric, time_bucket) DO UPDATE SET
       p50=excluded.p50, p75=excluded.p75, p90=excluded.p90, p95=excluded.p95, p99=excluded.p99,
-      min_val=excluded.min_val, max_val=excluded.max_val, sample_count=excluded.sample_count, computed_at=excluded.computed_at
+      min_val=excluded.min_val, max_val=excluded.max_val,
+      mad=excluded.mad, mad_sample_count=excluded.mad_sample_count,
+      sample_count=excluded.sample_count, computed_at=excluded.computed_at
   `);
 
   function upsertBucket(entityType: string, entityId: string, metric: string, bucket: string, values: number[]): boolean {
     if (values.length === 0) return false;
     const p = computePercentiles(values);
-    upsert.run(entityType, entityId, metric, bucket, p.p50, p.p75, p.p90, p.p95, p.p99, p.min, p.max, p.count);
+    upsert.run(entityType, entityId, metric, bucket, p.p50, p.p75, p.p90, p.p95, p.p99, p.min, p.max, p.mad, p.mad_sample_count, p.count);
     // Cache the 'all' bucket for downstream use
     if (bucket === 'all') {
       const key = `${entityType}:${entityId}`;

--- a/hub/src/insights/detector.ts
+++ b/hub/src/insights/detector.ts
@@ -585,10 +585,10 @@ function getBaselines(db: Database.Database, entityType: string, entityId: strin
   const period = getTimePeriod(hour);
 
   const allRows = db.prepare(
-    "SELECT metric, p50, p75, p90, p95, p99, sample_count FROM baselines WHERE entity_type = ? AND entity_id = ? AND time_bucket = 'all'"
+    "SELECT metric, p50, p75, p90, p95, p99, mad, mad_sample_count, sample_count FROM baselines WHERE entity_type = ? AND entity_id = ? AND time_bucket = 'all'"
   ).all(entityType, entityId) as BaselineRow[];
   const periodRows = db.prepare(
-    'SELECT metric, p50, p75, p90, p95, p99, sample_count FROM baselines WHERE entity_type = ? AND entity_id = ? AND time_bucket = ?'
+    'SELECT metric, p50, p75, p90, p95, p99, mad, mad_sample_count, sample_count FROM baselines WHERE entity_type = ? AND entity_id = ? AND time_bucket = ?'
   ).all(entityType, entityId, period) as BaselineRow[];
 
   const map: Record<string, BaselineRow> = {};

--- a/hub/src/insights/diagnosis/context.ts
+++ b/hub/src/insights/diagnosis/context.ts
@@ -10,9 +10,21 @@ import type {
   DiagnosisContext, DiagnosisEntity, BaselineRow, ContainerSnapshotRow,
   TrendDirection, BaselineComparison, DiagnosisLogs,
 } from './types';
+import { robustZ as computeRobustZ } from '../stats';
 
 const { getBaselines } = require('../detector') as {
   getBaselines: (db: Database.Database, entityType: string, entityId: string, hour?: number) => Record<string, BaselineRow>;
+};
+
+// Noise floor per metric: below this absolute deviation from the median we
+// short-circuit to 'normal' regardless of robust-z. Prevents idle containers
+// (0.3% CPU with a MAD of 0.05) from looking "critical" on tiny fluctuations.
+// Mirrors the MIN_ABSOLUTE_DEVIATION constants in detector.ts.
+const ROBUST_NOISE_FLOOR: Record<string, number> = {
+  cpu_percent: 10,
+  memory_mb: 50,
+  memory_used_mb: 100,
+  load_5: 1,
 };
 
 interface LatestContainerRow {
@@ -74,10 +86,38 @@ function computeTrend(values: (number | null)[]): TrendDirection {
 }
 
 /**
- * Compare a value to the P95 baseline, returning a qualitative rating.
- * "normal" = below P95, "elevated" = above P95, "critical" = >30% above P95.
+ * Rate a value against its baseline using a robust z-score
+ * (`|value − p50| / mad`). Bands: `normal` < 2.0 ≤ `elevated` < 3.5 ≤ `critical`.
+ * Falls back to the legacy P95 comparison when `mad` is null (e.g. on a
+ * baseline that existed before schema v24 and hasn't been recomputed yet),
+ * and short-circuits to `normal` when the absolute deviation from the median
+ * is below a per-metric noise floor.
  */
-function compareToBaseline(value: number | null, baseline: BaselineRow | undefined): BaselineComparison {
+function rateAgainstBaseline(
+  metric: string,
+  value: number | null,
+  baseline: BaselineRow | undefined,
+): BaselineComparison {
+  if (value == null || !baseline || baseline.p50 == null) {
+    return legacyP95Compare(value, baseline);
+  }
+  const med = baseline.p50;
+  const madValue = baseline.mad;
+  if (madValue == null || madValue === 0) {
+    return legacyP95Compare(value, baseline);
+  }
+  const absDev = Math.abs(value - med);
+  const floor = ROBUST_NOISE_FLOOR[metric] ?? 0;
+  if (absDev < floor) return 'normal';
+
+  const z = computeRobustZ(value, med, madValue);
+  if (z == null) return legacyP95Compare(value, baseline);
+  if (z < 2.0) return 'normal';
+  if (z < 3.5) return 'elevated';
+  return 'critical';
+}
+
+function legacyP95Compare(value: number | null, baseline: BaselineRow | undefined): BaselineComparison {
   if (value == null || !baseline || baseline.p95 == null) return null;
   const p95 = baseline.p95;
   if (value <= p95) return 'normal';
@@ -123,8 +163,8 @@ export function buildContext(db: Database.Database, entity: DiagnosisEntity, log
   // --- Baselines ---
   const entityId = `${hostId}/${containerName}`;
   const baselines = getBaselines(db, 'container', entityId);
-  const memoryVsP95 = compareToBaseline(latestRow.memory_mb, baselines.memory_mb);
-  const cpuVsP95 = compareToBaseline(latestRow.cpu_percent, baselines.cpu_percent);
+  const memoryVsP95 = rateAgainstBaseline('memory_mb', latestRow.memory_mb, baselines.memory_mb);
+  const cpuVsP95 = rateAgainstBaseline('cpu_percent', latestRow.cpu_percent, baselines.cpu_percent);
 
   // --- Unhealthy episode: when did the current unhealthy streak start? ---
   let unhealthySince: string | null = null;

--- a/hub/src/insights/diagnosis/types.ts
+++ b/hub/src/insights/diagnosis/types.ts
@@ -15,6 +15,8 @@ export interface BaselineRow {
   p90: number | null;
   p95: number | null;
   p99: number | null;
+  mad: number | null;
+  mad_sample_count: number | null;
   sample_count: number;
 }
 

--- a/hub/src/insights/stats.ts
+++ b/hub/src/insights/stats.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared statistical primitives for the insights engine.
+ *
+ * Kept in one module so that baselines, the diagnosis context builder, the
+ * S-H-ESD anomaly pass, and later phases (graph RCA, evidence ranking) all
+ * use exactly the same math. No external dependencies — all O(n log n) or
+ * better and safe to call from the hot path.
+ */
+
+/**
+ * Median of a numeric array. Mutates the input in-place by sorting.
+ * Returns `null` for an empty array.
+ */
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  values.sort((a, b) => a - b);
+  const mid = values.length >> 1;
+  if (values.length % 2 === 1) return values[mid]!;
+  return (values[mid - 1]! + values[mid]!) / 2;
+}
+
+/**
+ * Median absolute deviation scaled by the Gaussian consistency constant
+ * 1.4826 so that, for normal data, `mad` approximates the standard deviation.
+ *
+ * Returns `null` when there is not enough data; callers should treat `null`
+ * as "no MAD available, fall back to P95 heuristics".
+ *
+ * IMPORTANT: does not mutate the input array — makes a copy of the absolute
+ * deviations before sorting, so callers can safely reuse `values`.
+ */
+export function mad(values: number[], precomputedMedian?: number): number | null {
+  if (values.length === 0) return null;
+  const m = precomputedMedian ?? median([...values]);
+  if (m == null) return null;
+  const deviations = values.map((v) => Math.abs(v - m));
+  const d = median(deviations);
+  if (d == null) return null;
+  return d * 1.4826;
+}
+
+/**
+ * Robust z-score: |value − median| / mad. Returns `null` when mad is null
+ * or zero (a degenerate constant series).
+ */
+export function robustZ(value: number, med: number, madValue: number | null): number | null {
+  if (madValue == null || madValue === 0) return null;
+  return Math.abs(value - med) / madValue;
+}
+
+/**
+ * Pearson correlation coefficient between two equally-long series.
+ * Returns `null` for empty inputs or constant series (where variance is 0).
+ * Used by Phase 3's RCA edge-weight computation.
+ */
+export function pearson(xs: number[], ys: number[]): number | null {
+  if (xs.length !== ys.length || xs.length < 2) return null;
+  const n = xs.length;
+  let sumX = 0;
+  let sumY = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += xs[i]!;
+    sumY += ys[i]!;
+  }
+  const meanX = sumX / n;
+  const meanY = sumY / n;
+
+  let num = 0;
+  let denX = 0;
+  let denY = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i]! - meanX;
+    const dy = ys[i]! - meanY;
+    num += dx * dy;
+    denX += dx * dx;
+    denY += dy * dy;
+  }
+  if (denX === 0 || denY === 0) return null;
+  return num / Math.sqrt(denX * denY);
+}
+
+/**
+ * Generalized ESD test for outliers (Rosner 1983). Given residuals, iteratively
+ * removes the point with the largest |z-score| (computed with robust median/MAD)
+ * and returns the indices that exceed a critical threshold.
+ *
+ * Simplified for homelab scale: we use a fixed critical multiplier on robust-z
+ * instead of computing the exact t-distribution critical value. With
+ * `alpha = 0.05` and typical sample sizes of 14–30 days × 24 hours, a
+ * robust-z threshold of ~3.5 corresponds to α ≈ 0.05 while staying cheap.
+ *
+ * @param residuals — the values to test (post-seasonal-decomposition)
+ * @param maxOutliers — upper bound on how many anomalies to return
+ * @param threshold — critical robust-z to exceed (default 3.5)
+ * @returns indices of detected anomalies, in descending order of severity
+ */
+export function esdTest(
+  residuals: number[],
+  maxOutliers: number,
+  threshold = 3.5,
+): number[] {
+  if (residuals.length < 5 || maxOutliers <= 0) return [];
+  const remaining = residuals.map((v, i) => ({ v, i }));
+  const detected: Array<{ i: number; z: number }> = [];
+
+  for (let k = 0; k < maxOutliers && remaining.length >= 3; k++) {
+    const values = remaining.map((r) => r.v);
+    const med = median([...values]);
+    const d = mad(values, med ?? undefined);
+    if (med == null || d == null || d === 0) break;
+    let bestIdx = -1;
+    let bestZ = -Infinity;
+    for (let j = 0; j < remaining.length; j++) {
+      const z = Math.abs(remaining[j]!.v - med) / d;
+      if (z > bestZ) {
+        bestZ = z;
+        bestIdx = j;
+      }
+    }
+    if (bestIdx < 0 || bestZ < threshold) break;
+    detected.push({ i: remaining[bestIdx]!.i, z: bestZ });
+    remaining.splice(bestIdx, 1);
+  }
+  return detected.map((d) => d.i);
+}
+
+/**
+ * Rolling median with a fixed-length window. For S-H-ESD this is the cheap
+ * seasonal estimator: slide a window over the series, emit the window's median
+ * at each position. For positions where the window doesn't fit (near the
+ * edges), the window shrinks to whatever is available.
+ *
+ * Not efficient for massive windows (we sort per position), but homelab-scale
+ * inputs are ≤500 points so this is fine.
+ */
+export function rollingMedian(values: number[], window: number): number[] {
+  const out: number[] = new Array(values.length);
+  const half = Math.floor(window / 2);
+  for (let i = 0; i < values.length; i++) {
+    const start = Math.max(0, i - half);
+    const end = Math.min(values.length, i + half + 1);
+    const slice = values.slice(start, end);
+    const m = median(slice);
+    out[i] = m ?? values[i]!;
+  }
+  return out;
+}
+
+module.exports = {
+  median,
+  mad,
+  robustZ,
+  pearson,
+  esdTest,
+  rollingMedian,
+};

--- a/hub/src/scheduler.ts
+++ b/hub/src/scheduler.ts
@@ -88,10 +88,12 @@ function startHubScheduler(db: Database.Database, config: HubConfig): void {
     const { computeBaselines } = require('./insights/baselines');
     const { computeHealthScores } = require('./insights/health');
     const { generateInsights } = require('./insights/detector');
+    const { runAnomalyDetection } = require('./insights/anomaly/shesd');
     // Compute baselines once and pass the cache to downstream functions
     const baselineCache = await safeCollect('baselines', () => computeBaselines(db));
     await safeCollect('health-scores', () => computeHealthScores(db, baselineCache));
     await safeCollect('insights', () => generateInsights(db, baselineCache));
+    await safeCollect('anomaly-detection', () => runAnomalyDetection(db));
   }, { timezone: config.timezone }));
   logger.info('scheduler', 'Insights engine scheduled: every 15 minutes');
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import logger = require('../utils/logger');
 
-const SCHEMA_VERSION = 23;
+const SCHEMA_VERSION = 24;
 
 function bootstrap(db: Database.Database): void {
   db.exec(`
@@ -175,20 +175,22 @@ function bootstrap(db: Database.Database): void {
       ON service_group_members (host_id, container_name);
 
     CREATE TABLE IF NOT EXISTS baselines (
-      id           INTEGER PRIMARY KEY AUTOINCREMENT,
-      entity_type  TEXT NOT NULL,
-      entity_id    TEXT NOT NULL,
-      metric       TEXT NOT NULL,
-      time_bucket  TEXT NOT NULL,
-      p50          REAL,
-      p75          REAL,
-      p90          REAL,
-      p95          REAL,
-      p99          REAL,
-      min_val      REAL,
-      max_val      REAL,
-      sample_count INTEGER NOT NULL DEFAULT 0,
-      computed_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      entity_type      TEXT NOT NULL,
+      entity_id        TEXT NOT NULL,
+      metric           TEXT NOT NULL,
+      time_bucket      TEXT NOT NULL,
+      p50              REAL,
+      p75              REAL,
+      p90              REAL,
+      p95              REAL,
+      p99              REAL,
+      min_val          REAL,
+      max_val          REAL,
+      mad              REAL,
+      mad_sample_count INTEGER,
+      sample_count     INTEGER NOT NULL DEFAULT 0,
+      computed_at      TEXT NOT NULL DEFAULT (datetime('now')),
       UNIQUE(entity_type, entity_id, metric, time_bucket)
     );
 
@@ -348,6 +350,22 @@ function bootstrap(db: Database.Database): void {
       sample_count    INTEGER NOT NULL,
       PRIMARY KEY (endpoint_id, bucket)
     );
+
+    CREATE TABLE IF NOT EXISTS rollup_anomalies (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      entity_type  TEXT NOT NULL,
+      entity_id    TEXT NOT NULL,
+      metric       TEXT NOT NULL,
+      bucket       TEXT NOT NULL,
+      value        REAL NOT NULL,
+      residual     REAL NOT NULL,
+      robust_z     REAL NOT NULL,
+      detected_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(entity_type, entity_id, metric, bucket)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_rollup_anomalies_entity
+      ON rollup_anomalies (entity_type, entity_id, detected_at);
   `);
 
   // Track schema version and run migrations
@@ -530,6 +548,11 @@ function migrate(db: Database.Database, fromVersion: number): void {
   }
   if (fromVersion < 23) {
     // log_templates table + index created via CREATE TABLE IF NOT EXISTS in bootstrap
+  }
+  if (fromVersion < 24) {
+    try { db.exec('ALTER TABLE baselines ADD COLUMN mad REAL'); } catch { /* already exists */ }
+    try { db.exec('ALTER TABLE baselines ADD COLUMN mad_sample_count INTEGER'); } catch { /* already exists */ }
+    // rollup_anomalies table + index created via CREATE TABLE IF NOT EXISTS in bootstrap
   }
 }
 

--- a/tests/integration/web-api.test.ts
+++ b/tests/integration/web-api.test.ts
@@ -78,7 +78,7 @@ describe('Web API integration', () => {
     assert.equal(res.status, 200);
     const data = res.json();
     assert.equal(data.status, 'ok');
-    assert.equal(data.schemaVersion, 23);
+    assert.equal(data.schemaVersion, 24);
   });
 
   it('GET /api/hosts returns host list', async () => {

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -22,7 +22,7 @@ describe('queries', () => {
     it('returns status ok with schema version', () => {
       const health = getHealth(db);
       assert.equal(health.status, 'ok');
-      assert.equal(health.schemaVersion, 23);
+      assert.equal(health.schemaVersion, 24);
       assert.equal(typeof health.uptime, 'number');
     });
   });

--- a/tests/unit/shesd.test.ts
+++ b/tests/unit/shesd.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { createTestDb } = require('../helpers/db');
+const { suppressConsole } = require('../helpers/mocks');
+const { runAnomalyDetection } = require('../../hub/src/insights/anomaly/shesd');
+
+function seedHostRollups(db: any, hostId: string, values: number[], metric: 'cpu_max' | 'mem_used_max' = 'cpu_max'): void {
+  const insert = db.prepare(`
+    INSERT INTO host_rollups (host_id, bucket, cpu_avg, cpu_max, mem_used_avg, mem_used_max, mem_total, sample_count)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (let i = 0; i < values.length; i++) {
+    const bucket = new Date(Date.now() - (values.length - i) * 3600_000)
+      .toISOString()
+      .slice(0, 13) + ':00:00';
+    const cpuMax = metric === 'cpu_max' ? values[i]! : 10;
+    const memMax = metric === 'mem_used_max' ? values[i]! : 500;
+    insert.run(hostId, bucket, cpuMax - 1, cpuMax, memMax - 10, memMax, 4000, 12);
+  }
+}
+
+describe('S-H-ESD anomaly detection', () => {
+  let db: any;
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = suppressConsole();
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    restore();
+    db.close();
+  });
+
+  it('returns 0 detected when series is too short', () => {
+    // Need ≥ 168 hourly samples (7 days) — seed only 50.
+    seedHostRollups(db, 'h1', Array.from({ length: 50 }, () => 30));
+    const detected = runAnomalyDetection(db);
+    assert.equal(detected, 0);
+  });
+
+  it('detects an injected spike in a flat series', () => {
+    // 14 days of hourly samples, flat at 30% CPU with an injected 90% spike.
+    const values = Array.from({ length: 336 }, () => 30 + (Math.random() - 0.5) * 2);
+    values[200] = 95; // clear outlier
+    seedHostRollups(db, 'h1', values);
+
+    const detected = runAnomalyDetection(db);
+    assert.ok(detected >= 1, `expected ≥1 anomaly, got ${detected}`);
+
+    const rows = db.prepare(
+      "SELECT * FROM rollup_anomalies WHERE entity_type = 'host' AND entity_id = 'h1' AND metric = 'cpu_max'"
+    ).all();
+    assert.ok(rows.length >= 1);
+    // The spike should be the largest-z anomaly.
+    const spike = rows.find((r: any) => r.value === 95);
+    assert.ok(spike, 'expected a detected row for the 95% spike');
+    assert.ok(spike.robust_z >= 3.5, `expected robust_z ≥ 3.5, got ${spike.robust_z}`);
+  });
+
+  it('is idempotent — re-running does not duplicate anomalies', () => {
+    // Tiny background noise so MAD is non-zero.
+    const values = Array.from({ length: 336 }, () => 30 + (Math.random() - 0.5) * 2);
+    values[100] = 95;
+    seedHostRollups(db, 'h1', values);
+
+    runAnomalyDetection(db);
+    runAnomalyDetection(db);
+
+    const rows = db.prepare('SELECT COUNT(*) AS n FROM rollup_anomalies').get() as { n: number };
+    // Unique on (entity, metric, bucket) — duplicates should upsert.
+    assert.ok(rows.n >= 1);
+    const spikes = db.prepare('SELECT COUNT(*) AS n FROM rollup_anomalies WHERE value = 95').get() as { n: number };
+    assert.equal(spikes.n, 1);
+  });
+
+  it('skips constant series (MAD is zero)', () => {
+    const values = Array.from({ length: 336 }, () => 30);
+    seedHostRollups(db, 'h1', values);
+    const detected = runAnomalyDetection(db);
+    assert.equal(detected, 0);
+  });
+});

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,0 +1,140 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { median, mad, robustZ, pearson, esdTest, rollingMedian } = require('../../hub/src/insights/stats');
+
+describe('stats.median', () => {
+  it('returns the middle value for odd-length arrays', () => {
+    assert.equal(median([1, 2, 3, 4, 5]), 3);
+  });
+
+  it('averages the two middle values for even-length arrays', () => {
+    assert.equal(median([1, 2, 3, 4]), 2.5);
+  });
+
+  it('sorts unsorted input', () => {
+    assert.equal(median([5, 1, 3, 2, 4]), 3);
+  });
+
+  it('returns null for empty input', () => {
+    assert.equal(median([]), null);
+  });
+});
+
+describe('stats.mad', () => {
+  it('computes MAD with Gaussian consistency (1.4826)', () => {
+    // Values [1, 2, 3, 4, 5] — median 3, deviations [2,1,0,1,2], median dev 1
+    // 1.4826 * 1 = 1.4826
+    const m = mad([1, 2, 3, 4, 5]);
+    assert.ok(Math.abs(m - 1.4826) < 0.001);
+  });
+
+  it('returns 0 for a constant series', () => {
+    assert.equal(mad([7, 7, 7, 7, 7]), 0);
+  });
+
+  it('does not mutate the input array', () => {
+    const values = [5, 1, 3, 2, 4];
+    const copy = [...values];
+    mad(values);
+    assert.deepEqual(values, copy);
+  });
+
+  it('accepts a precomputed median', () => {
+    const values = [1, 2, 3, 4, 5];
+    const m1 = mad(values);
+    const m2 = mad(values, 3);
+    assert.equal(m1, m2);
+  });
+
+  it('returns null for empty input', () => {
+    assert.equal(mad([]), null);
+  });
+});
+
+describe('stats.robustZ', () => {
+  it('returns deviation in MAD units', () => {
+    // (10 − 5) / 2 = 2.5
+    assert.equal(robustZ(10, 5, 2), 2.5);
+  });
+
+  it('returns null when MAD is 0 (degenerate series)', () => {
+    assert.equal(robustZ(10, 5, 0), null);
+  });
+
+  it('returns null when MAD is null', () => {
+    assert.equal(robustZ(10, 5, null), null);
+  });
+
+  it('takes the absolute value (symmetric)', () => {
+    assert.equal(robustZ(0, 5, 2), 2.5);
+  });
+});
+
+describe('stats.pearson', () => {
+  it('returns 1 for perfectly correlated series', () => {
+    const r = pearson([1, 2, 3, 4, 5], [2, 4, 6, 8, 10]);
+    assert.ok(Math.abs(r - 1) < 1e-9);
+  });
+
+  it('returns -1 for perfectly anti-correlated series', () => {
+    const r = pearson([1, 2, 3, 4, 5], [10, 8, 6, 4, 2]);
+    assert.ok(Math.abs(r - -1) < 1e-9);
+  });
+
+  it('returns ~0 for uncorrelated series', () => {
+    const r = pearson([1, 2, 3, 4, 5], [3, 1, 4, 1, 5]);
+    assert.ok(Math.abs(r) < 0.5);
+  });
+
+  it('returns null for constant series (variance 0)', () => {
+    assert.equal(pearson([1, 1, 1], [1, 2, 3]), null);
+  });
+
+  it('returns null for mismatched lengths', () => {
+    assert.equal(pearson([1, 2, 3], [1, 2]), null);
+  });
+});
+
+describe('stats.esdTest', () => {
+  it('returns empty for too-small input', () => {
+    assert.deepEqual(esdTest([1, 2, 3], 2), []);
+  });
+
+  it('detects an injected spike in an otherwise quiet series', () => {
+    const residuals = [0.1, -0.2, 0.0, 0.1, 50.0, -0.1, 0.2, 0.0, -0.1, 0.1];
+    const idx = esdTest(residuals, 2, 3.5);
+    assert.ok(idx.includes(4), `expected spike at index 4 in detected set ${idx}`);
+  });
+
+  it('respects maxOutliers', () => {
+    // Tiny noise so MAD is non-zero; two clear spikes.
+    const residuals = [0.1, -0.1, 0.2, -0.2, 100, 0.1, -0.1, 0.2, 200, -0.2];
+    const idx = esdTest(residuals, 1, 3.5);
+    assert.equal(idx.length, 1);
+  });
+
+  it('returns empty when no residual exceeds threshold', () => {
+    const residuals = [1, 2, 3, 2, 1, 2, 3, 2, 1, 2];
+    const idx = esdTest(residuals, 3, 3.5);
+    assert.deepEqual(idx, []);
+  });
+});
+
+describe('stats.rollingMedian', () => {
+  it('returns a series of the same length', () => {
+    const out = rollingMedian([1, 2, 3, 4, 5], 3);
+    assert.equal(out.length, 5);
+  });
+
+  it('smooths a step function', () => {
+    const out = rollingMedian([1, 1, 1, 1, 5, 1, 1, 1, 1], 5);
+    // The spike at index 4 should be smoothed away by the surrounding 1s.
+    assert.ok(out[4]! < 2);
+  });
+
+  it('degrades gracefully at the edges', () => {
+    const out = rollingMedian([1, 2, 3], 5);
+    assert.equal(out.length, 3);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the \`value > P95 × 1.3\` heuristic with **median + MAD** robust z-score bands, and adds a **Seasonal-Hybrid ESD** anomaly pass on hourly rollups. Based on Leys et al. (MAD) and Vallis et al. ("Twitter AnomalyDetection / S-H-ESD," 2014).

**Phase 2 of 4** — stacks on [#120](https://github.com/goldenproductions/insightd/pull/120).

## What's in this PR

- **Schema v23 → v24**: \`baselines.mad\` + \`baselines.mad_sample_count\` columns, new \`rollup_anomalies\` table (unique per entity/metric/bucket)
- **Shared stats module** (\`hub/src/insights/stats.ts\`): median, mad (with 1.4826 Gaussian consistency constant), robustZ, pearson, esdTest, rollingMedian — pure functions, reused by Phases 3+4
- **baselines.ts**: computes MAD in the same sorted-values pass as percentiles, skips series below 10 samples (too noisy), persists via \`INSERT ... ON CONFLICT UPDATE\`
- **diagnosis/context.ts**: new \`rateAgainstBaseline()\` uses \`|value - p50| / mad\` with bands \`normal < 2.0 ≤ elevated < 3.5 ≤ critical\`. Short-circuits to normal when \`|value − p50|\` is below a per-metric absolute noise floor (reused from detector.ts MIN_ABSOLUTE_DEVIATION). Falls back to the legacy P95 comparison when \`mad\` is null — so old baselines keep working until the next computeBaselines cycle
- **S-H-ESD anomaly pass** (\`hub/src/insights/anomaly/shesd.ts\`): 14-day hourly window, rolling 7-day-median seasonal decomposition, ESD on residuals at robust-z ≥ 3.5. Skips series below 168 samples and degenerate (MAD=0) series. Upserts detected anomalies — idempotent across re-runs
- **Scheduler**: \`runAnomalyDetection(db)\` after \`generateInsights\` on the \`*/15\` cron

## Why this approach

MAD is robust against outliers, so a baseline dominated by one spike doesn't inflate the threshold. S-H-ESD handles seasonality properly (daily patterns are normal, not anomalies). At <500 hourly samples per series the math is cheap enough to run every 15 min across the whole fleet (<1s).

## Test plan

- [x] 29 new tests: \`stats.test.ts\` (median/mad/robustZ/pearson/esdTest golden data, non-mutating inputs, degenerate constant-series handling), \`shesd.test.ts\` (spike injection in a noisy flat series, idempotence, constant-series safety)
- [x] Full backend suite: **617/617 passing**
- [x] Typecheck clean
- [ ] VM deployment: verify \`baselines.mad\` populates for all metrics within 15 min of deploy and \`rollup_anomalies\` starts receiving rows

## Notes for reviewer

This PR stacks on [#120](https://github.com/goldenproductions/insightd/pull/120) — when that merges, GitHub should auto-retarget this one to \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)