### PR TITLE
fix(diagnosis): Drain tokenizer masks + unified evidence dedupe

### DIFF
--- a/hub/src/insights/diagnosis/diagnosers/unified.ts
+++ b/hub/src/insights/diagnosis/diagnosers/unified.ts
@@ -128,21 +128,31 @@ export function diagnoseUnified(
   const primary = signals.find((s) => s.kind !== 'ppr_root')!;
   const supporting = signals.filter((s) => s !== primary && s.kind !== 'ppr_root');
 
+  // Build evidence with dedupe: signal detectors often include the health
+  // check output line themselves (e.g. zombieListener, hungService), so we
+  // can't just append unconditionally — every push goes through the seen
+  // set so the same string never appears twice.
   const evidence: string[] = [];
+  const seen = new Set<string>();
+  const push = (line: string | null | undefined) => {
+    if (!line) return;
+    if (seen.has(line)) return;
+    seen.add(line);
+    evidence.push(line);
+  };
+
   if (ctx.unhealthy.durationMinutes != null) {
-    evidence.push(`Health check failing for ${formatDuration(ctx.unhealthy.durationMinutes)}`);
+    push(`Health check failing for ${formatDuration(ctx.unhealthy.durationMinutes)}`);
   }
   if (ctx.latest.healthCheckOutput) {
-    evidence.push(`Docker reports: ${ctx.latest.healthCheckOutput}`);
+    push(`Docker reports: ${ctx.latest.healthCheckOutput}`);
   }
-  evidence.push(...primary.evidence);
+  for (const e of primary.evidence) push(e);
   for (const s of supporting) {
-    for (const e of s.evidence) {
-      if (!evidence.includes(e)) evidence.push(e);
-    }
+    for (const e of s.evidence) push(e);
   }
-  evidence.push(...baseEvidence);
-  evidence.push(...neighborEvidence);
+  for (const e of baseEvidence) push(e);
+  for (const e of neighborEvidence) push(e);
 
   return [{
     diagnoser: 'unified',

--- a/hub/src/insights/diagnosis/drain.ts
+++ b/hub/src/insights/diagnosis/drain.ts
@@ -55,8 +55,14 @@ const MASK_RULES: Array<{ re: RegExp; mask: string }> = [
   { re: /^[0-9a-f]{8,}$/i, mask: WILDCARD },
   // Pure number (int or float), optionally with a unit suffix like `32ms` / `1.5s`
   { re: /^-?\d+(\.\d+)?(ms|s|us|ns|kb|mb|gb|tb|b|%)?$/i, mask: WILDCARD },
-  // ISO timestamps (e.g. 2026-04-13T10:21:00Z)
-  { re: /^\d{4}-\d{2}-\d{2}t?\d{0,2}:?\d{0,2}:?\d{0,2}(\.\d+)?z?$/i, mask: WILDCARD },
+  // ISO timestamps joined with T (e.g. 2026-04-13T10:21:00Z)
+  { re: /^\d{4}-\d{2}-\d{2}t\d{0,2}:?\d{0,2}:?\d{0,2}(\.\d+)?z?$/i, mask: WILDCARD },
+  // Dashed date (e.g. 2026-04-13)
+  { re: /^\d{4}-\d{1,2}-\d{1,2}$/, mask: WILDCARD },
+  // Slashed date (e.g. 2026/04/13) — common in syslog-style loggers
+  { re: /^\d{4}\/\d{1,2}\/\d{1,2}$/, mask: WILDCARD },
+  // Clock time (e.g. 14:47:54, 14:47:54.325239) — optional fractional seconds
+  { re: /^\d{1,2}:\d{2}:\d{2}(\.\d+)?$/, mask: WILDCARD },
 ];
 
 /**

--- a/tests/unit/diagnosis.test.ts
+++ b/tests/unit/diagnosis.test.ts
@@ -241,6 +241,29 @@ describe('diagnosis engine', () => {
     assert.equal(findings[0]!.confidence, 'low');
   });
 
+  it('dedupes the health-check-output line when a signal detector already included it', () => {
+    // zombieListener pushes a "Docker reports: …" evidence line itself.
+    // The unified diagnoser also prepends the same line from ctx.latest.
+    // Both should collapse to a single entry via the internal seen-set.
+    for (let i = 6; i >= 0; i--) {
+      seedSnapshot(db, {
+        name: 'adguard', health: i === 0 ? 'unhealthy' : 'healthy',
+        cpu: 5, mem: 110, restarts: 0,
+        healthOutput: i === 0 ? "wget: can't connect: connection refused" : null,
+        collectedAt: ts(new Date(NOW - i * 15 * 60_000)),
+      });
+    }
+    seedHostSnapshot(db, 'h1', 30, 4000, 16000, 1.0, ts(new Date(NOW - 60_000)));
+
+    const findings = runDiagnosis(db, { type: 'container', hostId: 'h1', containerName: 'adguard' });
+    assert.equal(findings.length, 1);
+    const dockerReports = findings[0]!.evidence.filter((e: string) => e.startsWith('Docker reports:'));
+    assert.equal(
+      dockerReports.length, 1,
+      `expected exactly one 'Docker reports:' line, got ${dockerReports.length}: ${JSON.stringify(findings[0]!.evidence)}`,
+    );
+  });
+
   it('persists findings when persistCategory is set', () => {
     seedSnapshot(db, {
       name: 'svc', health: 'unhealthy', cpu: 5, mem: 100,

--- a/tests/unit/drain.test.ts
+++ b/tests/unit/drain.test.ts
@@ -45,6 +45,28 @@ describe('drain tokenizer', () => {
       ['Fatal', 'error', 'cannot', 'bind'],
     );
   });
+
+  it('masks slashed dates common in syslog-style loggers', () => {
+    assert.deepEqual(tokenize('2026/04/13 request received'), ['<*>', 'request', 'received']);
+  });
+
+  it('masks clock times with optional fractional seconds', () => {
+    assert.deepEqual(tokenize('started at 14:47:54'), ['started', 'at', '<*>']);
+    assert.deepEqual(tokenize('started at 14:47:54.325239'), ['started', 'at', '<*>']);
+  });
+
+  it('collapses AdGuard-style timestamped logs to a single template', () => {
+    const tree = new DrainTree([]);
+    // Real log format from adguard/adguardhome.
+    const a = tree.match(tokenize('2026/04/13 14:47:54.325239 [error] dnsproxy exchange failed'));
+    const b = tree.match(tokenize('2026/04/13 14:52:53.196989 [error] dnsproxy exchange failed'));
+    const c = tree.match(tokenize('2026/04/13 15:00:06.699472 [error] dnsproxy exchange failed'));
+    assert.equal(a.templateHash, b.templateHash);
+    assert.equal(b.templateHash, c.templateHash);
+    assert.equal(a.isNew, true);
+    assert.equal(b.isNew, false);
+    assert.equal(c.isNew, false);
+  });
 });
 
 describe('drain hashTemplate', () => {


### PR DESCRIPTION
## Summary

Two small tuning fixes spotted during live VM validation of the research-grounded diagnosis engine upgrade (PRs #120-#123).

### 1. Drain tokenizer missed slash-dates and clock times

AdGuard (and most syslog-style loggers) write timestamps as \`2026/04/13 14:47:54.325239 [error] dnsproxy: ...\`. After tokenization, neither \`2026/04/13\` nor \`14:47:54.325239\` matched any mask rule, so every log line produced a distinct template. Validation on the live hub found 100 unique \`log_templates\` rows for a single container — one per log line — instead of the handful we'd expect from template mining.

Added three mask rules:
- Dashed date: \`2026-04-13\`
- Slashed date: \`2026/04/13\`
- Clock time with optional fractional seconds: \`14:47:54\` / \`14:47:54.325239\`

Also tightened the ISO-timestamp pattern to require a \`T\` separator (\`2026-04-13T14:47:54.325239Z\`), so it doesn't silently swallow plain dates.

Verified on real AdGuard log samples: three lines differing only in timestamp now collapse to one template via the new \`DrainTree\` test case.

### 2. Unified diagnoser double-printed \"Docker reports: …\"

The unified diagnoser unconditionally prepends \`Docker reports: \${healthCheckOutput}\` near the top of its evidence list, and signal detectors like \`zombieListener\` / \`hungService\` also include the same line in their own \`evidence\` array. Result on the live AdGuard finding:

\`\`\`
• Docker reports: wget: can't connect to remote host: Connection refused
• Docker reports: wget: can't connect to remote host: Connection refused  ← dup
• No recent restarts; host is healthy
• ...
\`\`\`

Replaced the raw \`evidence.push(...)\` chain with a \`seen\`-set-backed helper so the same line never appears twice regardless of which signal contributed it.

## Test plan

- [x] 4 new tests:
  - Tokenizer masks slashed dates
  - Tokenizer masks clock times with/without fractional seconds
  - Three AdGuard-style timestamped lines collapse to one template
  - Unified diagnoser emits exactly one \`Docker reports:\` evidence line for a zombie-listener case
- [x] Full suite **666/666 passing**
- [x] Backend + frontend typecheck clean
- [ ] Redeploy to VM and verify \`log_templates\` count drops substantially for adguard/adguardhome

## Notes

Target branch is \`main\` — no schema changes, no stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)