### PR TITLE
fix(detector): capacity-aware host predictions + downtime filter

### DIFF
--- a/hub/src/insights/detector.ts
+++ b/hub/src/insights/detector.ts
@@ -245,21 +245,34 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
       }
     }
 
-    // Availability
-    const uptimeData = db.prepare(`
-      SELECT COUNT(*) as total, SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) as running
-      FROM container_snapshots WHERE host_id = ? AND container_name = ? AND collected_at >= datetime('now', '-1 day')
-    `).get(host_id, container_name) as UptimeRow;
+    // Availability — only flag "had downtime" for containers that have actually
+    // *recovered* (are running now). A container that's currently stopped falls
+    // into one of three cases, none of which want this insight:
+    //   1. Intentionally stopped (nginx/postgres/redis sitting exited for weeks) —
+    //      the user doesn't want recurring "had downtime" noise every 15 minutes
+    //   2. Actively crashed right now — the container_unhealthy alert handles it
+    //   3. Stopped recently but never seen — at worst, alert will fire on next tick
+    // Only "was down briefly, is running again" is a legitimate retrospective insight.
+    const latestSnap = db.prepare(
+      `SELECT status FROM container_snapshots WHERE host_id = ? AND container_name = ? ORDER BY collected_at DESC LIMIT 1`
+    ).get(host_id, container_name) as { status: string } | undefined;
 
-    if (uptimeData.total > 0) {
-      const uptimePct = (uptimeData.running / uptimeData.total) * 100;
-      if (uptimePct < 99 && uptimePct > 0) {
-        const downMinutes = Math.round((uptimeData.total - uptimeData.running) * 5);
-        insert.run('container', entityId, 'availability', uptimePct < 90 ? 'critical' : 'warning',
-          `${container_name} had downtime`,
-          `${container_name} was down for ~${downMinutes} minutes in the last 24 hours (${round(uptimePct)}% uptime)`,
-          null, uptimePct, 99);
-        count++;
+    if (latestSnap?.status === 'running') {
+      const uptimeData = db.prepare(`
+        SELECT COUNT(*) as total, SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) as running
+        FROM container_snapshots WHERE host_id = ? AND container_name = ? AND collected_at >= datetime('now', '-1 day')
+      `).get(host_id, container_name) as UptimeRow;
+
+      if (uptimeData.total > 0) {
+        const uptimePct = (uptimeData.running / uptimeData.total) * 100;
+        if (uptimePct < 99 && uptimePct > 0) {
+          const downMinutes = Math.round((uptimeData.total - uptimeData.running) * 5);
+          insert.run('container', entityId, 'availability', uptimePct < 90 ? 'critical' : 'warning',
+            `${container_name} had downtime`,
+            `${container_name} was down for ~${downMinutes} minutes in the last 24 hours but has recovered (${round(uptimePct)}% uptime)`,
+            null, uptimePct, 99);
+          count++;
+        }
       }
     }
 
@@ -335,7 +348,13 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
 
 /**
  * Generate predictive insights based on 7-day metric trends.
- * Pattern: same linear regression as disk forecast.
+ *
+ * Per the insights philosophy ("usage is healthy, saturation is the problem"),
+ * host predictions gate on *absolute capacity thresholds*, not baseline
+ * percentiles: the question is "will this host run out of resources soon?",
+ * not "will this host's metric wander above its recent average?". A media
+ * host sitting at 7% memory with a slow drift shouldn't fire a prediction
+ * just because its memory_used_mb is creeping above last week's P90.
  */
 function generatePredictions(db: Database.Database, insert: Database.Statement): number {
   let count = 0;
@@ -343,6 +362,13 @@ function generatePredictions(db: Database.Database, insert: Database.Statement):
   // Host predictions
   const hosts = db.prepare('SELECT DISTINCT host_id FROM hosts').all() as HostIdRow[];
   for (const { host_id } of hosts) {
+    // Resolve the host's total memory once — used by memory predictions to
+    // compute an 80%-of-capacity saturation ceiling.
+    const hostCapacity = db.prepare(
+      `SELECT memory_total_mb FROM host_snapshots WHERE host_id = ? ORDER BY collected_at DESC LIMIT 1`
+    ).get(host_id) as { memory_total_mb: number | null } | undefined;
+    const memoryTotalMb = hostCapacity?.memory_total_mb ?? null;
+
     for (const [metric, label, unit, table] of [
       ['cpu_percent', 'CPU', '%', 'host_snapshots'],
       ['memory_used_mb', 'Memory', ' MB', 'host_snapshots'],
@@ -350,25 +376,39 @@ function generatePredictions(db: Database.Database, insert: Database.Statement):
     ] as const) {
       const pred = computeMetricTrend(db, table, 'host_id', host_id, metric, null);
       if (!pred) continue;
+      if (pred.dailyGrowth <= 0) continue;
+
+      // Determine the saturation ceiling for this metric:
+      //   cpu_percent: 80% (same as the host CPU detector threshold)
+      //   memory_used_mb: 80% of memory_total_mb (skip if we don't know total)
+      //   load_5: 4 (same as the host load detector threshold)
+      let saturation: number | null = null;
+      if (metric === 'cpu_percent') saturation = 80;
+      else if (metric === 'load_5') saturation = 4;
+      else if (metric === 'memory_used_mb' && memoryTotalMb) saturation = memoryTotalMb * 0.8;
+      if (saturation == null) continue;
+      if (pred.current >= saturation) continue; // already saturated — detector handles it
+
+      // Will the metric actually breach the saturation ceiling within 14 days
+      // at the current growth rate? If not, this is normal drift, not a prediction.
+      const remaining = saturation - pred.current;
+      const daysUntil = Math.round(remaining / pred.dailyGrowth);
+      if (daysUntil > 14 || daysUntil <= 0) continue;
+
+      // The live value has to back the trend — if the latest snapshot is
+      // already well below the current average, the trend is fading.
       const bl = db.prepare(
         "SELECT p50, p75, p90 FROM baselines WHERE entity_type = 'host' AND entity_id = ? AND metric = ? AND time_bucket = 'all'"
       ).get(host_id, metric) as { p50: number | null; p75: number | null; p90: number | null } | undefined;
-      if (!bl || bl.p90 == null) continue;
-      if (pred.current >= bl.p90) continue; // already above threshold
-      if (pred.dailyGrowth <= 0) continue;
-      // If the live value is below P75, the trend doesn't match reality — skip
-      if (pred.liveValue != null && bl.p75 != null && pred.liveValue < bl.p75) continue;
-      const remaining = bl.p90 - pred.current;
-      const daysUntil = Math.round(remaining / pred.dailyGrowth);
-      if (daysUntil > 14 || daysUntil <= 0) continue;
-      // Predictions are inherently uncertain — only "critical" if live value also above P75
-      const liveSupports = pred.liveValue != null && bl.p75 != null && pred.liveValue >= bl.p75;
-      const severity = daysUntil <= 3 && liveSupports ? 'critical' : 'warning';
+      if (pred.liveValue != null && bl?.p75 != null && pred.liveValue < bl.p75) continue;
+
+      // Predictions are inherently uncertain — only "critical" within 3 days.
+      const severity = daysUntil <= 3 ? 'critical' : 'warning';
       const dayWord = daysUntil === 1 ? 'day' : 'days';
       insert.run('host', host_id, 'prediction', severity,
         `${label} trending up on ${host_id}`,
-        `${label} at ${round(pred.current)}${unit}, growing ${round(pred.dailyGrowth)}${unit}/day — will exceed P90 (${round(bl.p90)}${unit}) in ~${daysUntil} ${dayWord}`,
-        metric, pred.current, bl.p90);
+        `${label} at ${round(pred.current)}${unit}, growing ${round(pred.dailyGrowth)}${unit}/day — will reach ${round(saturation)}${unit} (saturation) in ~${daysUntil} ${dayWord}`,
+        metric, pred.current, saturation);
       count++;
     }
   }

--- a/tests/unit/detector.test.ts
+++ b/tests/unit/detector.test.ts
@@ -51,22 +51,23 @@ describe('detector', () => {
   });
 
   describe('predictions', () => {
-    it('generates prediction for steadily growing metric', () => {
+    it('generates prediction when memory trends toward 80% of total capacity', () => {
       const recent = ts(new Date(NOW - 2 * 60 * 1000));
       seedHost(db, 'h1', recent);
 
-      // Manually insert a baseline with known P90
+      // Baseline so the live-value-vs-P75 check doesn't skip us.
       db.prepare(`
         INSERT INTO baselines (entity_type, entity_id, metric, time_bucket, p50, p75, p90, p95, p99, min_val, max_val, sample_count, computed_at)
-        VALUES ('host', 'h1', 'memory_used_mb', 'all', 3000, 3200, 3500, 3700, 3900, 2800, 4000, 300, datetime('now'))
+        VALUES ('host', 'h1', 'memory_used_mb', 'all', 2800, 2900, 3000, 3050, 3100, 2500, 3100, 300, datetime('now'))
       `).run();
 
-      // Seed 7 days of steadily growing memory: 2800 → 3400 (below P90=3500, growing 100/day → exceeds in ~1 day)
+      // 4 GB total → saturation = 3200 MB. Grow from 2500 → 3100 MB over 7 days
+      // (~86 MB/day). Current 3100, remaining to 3200 = 100 → fires in ~1 day.
       for (let day = 6; day >= 0; day--) {
         for (let sample = 0; sample < 12; sample++) {
-          const memUsed = 2800 + (6 - day) * 100;
+          const memUsed = 2500 + Math.round((6 - day) * 100);
           seedHostSnapshots(db, [{
-            hostId: 'h1', cpu: 35, memTotal: 8000, memUsed, memAvail: 8000 - memUsed,
+            hostId: 'h1', cpu: 35, memTotal: 4000, memUsed, memAvail: 4000 - memUsed,
             load1: 1, at: ts(new Date(NOW - day * 86400000 - sample * 300000)),
           }]);
         }
@@ -76,7 +77,35 @@ describe('detector', () => {
 
       const predictions = db.prepare("SELECT * FROM insights WHERE category = 'prediction'").all();
       assert.ok(predictions.length > 0, 'Should generate at least one prediction insight');
-      assert.ok(predictions[0].message.includes('growing'));
+      assert.ok(predictions[0].message.includes('saturation'),
+        `expected message to mention saturation, got: ${predictions[0].message}`);
+    });
+
+    it('does NOT generate prediction when memory is trending up but far from saturation', () => {
+      // Regression for the media-host false positive: 20 GB total memory, used
+      // around 1.5 GB, drifting slowly upward. P90 is tiny but saturation
+      // (80% of 20 GB = 16 GB) is nowhere near the current value — so no insight.
+      const recent = ts(new Date(NOW - 2 * 60 * 1000));
+      seedHost(db, 'h1', recent);
+
+      db.prepare(`
+        INSERT INTO baselines (entity_type, entity_id, metric, time_bucket, p50, p75, p90, p95, p99, min_val, max_val, sample_count, computed_at)
+        VALUES ('host', 'h1', 'memory_used_mb', 'all', 1400, 1500, 1600, 1700, 1800, 1300, 1900, 300, datetime('now'))
+      `).run();
+
+      for (let day = 6; day >= 0; day--) {
+        for (let sample = 0; sample < 12; sample++) {
+          const memUsed = 1400 + (6 - day) * 30; // 1400 → 1580 over a week
+          seedHostSnapshots(db, [{
+            hostId: 'h1', cpu: 20, memTotal: 20000, memUsed, memAvail: 20000 - memUsed,
+            load1: 1, at: ts(new Date(NOW - day * 86400000 - sample * 300000)),
+          }]);
+        }
+      }
+
+      generateInsights(db);
+      const predictions = db.prepare("SELECT * FROM insights WHERE category = 'prediction' AND metric = 'memory_used_mb'").all();
+      assert.equal(predictions.length, 0, 'Slow drift at 8% of capacity should not fire a prediction');
     });
 
     it('does not generate prediction for flat metrics', () => {
@@ -107,6 +136,44 @@ describe('detector', () => {
 
       const predictions = db.prepare("SELECT * FROM insights WHERE category = 'prediction'").all();
       assert.equal(predictions.length, 0, 'Should not generate prediction for flat metrics');
+    });
+  });
+
+  describe('downtime insight filter', () => {
+    it('flags a container that was briefly down but has recovered', () => {
+      const recent = ts(new Date(NOW - 2 * 60 * 1000));
+      seedHost(db, 'h1', recent);
+
+      // 6 hours down, then currently running.
+      for (let h = 23; h > 6; h--) {
+        seedContainerSnapshots(db, [{ hostId: 'h1', name: 'svc', status: 'running', cpu: 5, mem: 50, at: ts(new Date(NOW - h * 3600_000)) }]);
+      }
+      for (let h = 6; h > 1; h--) {
+        seedContainerSnapshots(db, [{ hostId: 'h1', name: 'svc', status: 'exited', cpu: 0, mem: 0, at: ts(new Date(NOW - h * 3600_000)) }]);
+      }
+      seedContainerSnapshots(db, [{ hostId: 'h1', name: 'svc', status: 'running', cpu: 5, mem: 50, at: recent }]);
+
+      generateInsights(db);
+      const rows = db.prepare("SELECT * FROM insights WHERE entity_id = 'h1/svc' AND category = 'availability'").all();
+      assert.equal(rows.length, 1);
+      assert.match(rows[0].message, /recovered/);
+    });
+
+    it('does NOT flag a long-stopped container as "had downtime"', () => {
+      // Regression for the proxmox-01/nginx noise: nginx was intentionally
+      // stopped 15 days ago, so the 24h uptime window sees near-0% running.
+      // The old filter `uptimePct > 0` let a single accidental running sample
+      // through as a critical "had downtime" insight on every detector run.
+      const recent = ts(new Date(NOW - 2 * 60 * 1000));
+      seedHost(db, 'h1', recent);
+
+      for (let i = 0; i < 50; i++) {
+        seedContainerSnapshots(db, [{ hostId: 'h1', name: 'old-nginx', status: 'exited', cpu: 0, mem: 0, at: ts(new Date(NOW - i * 300_000)) }]);
+      }
+
+      generateInsights(db);
+      const rows = db.prepare("SELECT * FROM insights WHERE entity_id = 'h1/old-nginx' AND category = 'availability'").all();
+      assert.equal(rows.length, 0, `long-stopped container should not produce a downtime insight, got: ${JSON.stringify(rows)}`);
     });
   });
 


### PR DESCRIPTION
## Summary

Two false positives found while walking the diagnosis engine across the 9-host VM fleet right after the v26 upgrade landed.

### 1. Host memory prediction fired on a host with 7% utilization

The \`media\` host was flagged with \`critical: Memory trending up on media\`. Reality: it uses ~1.5 GB out of 20 GB (7.5%), drifting from 1448 MB → 1624 MB over 3 days. At that rate it would take **2+ years** to saturate — but the engine said "will exceed P90 (1600 MB) in ~10 days" because the prediction gated on the baseline percentile, not absolute capacity.

Per the insights philosophy doc ("usage is healthy, saturation is the problem"), the fix gates host predictions on **absolute saturation thresholds**, same as the non-predictive detectors:

| Metric | Saturation threshold |
|--------|---------------------|
| \`cpu_percent\` | 80 |
| \`load_5\` | 4 |
| \`memory_used_mb\` | 80% of \`memory_total_mb\` (skipped if unknown) |

The message also now says "will reach 16000 MB (saturation) in ~10 days" instead of "will exceed P90 (1600 MB)…" — users were parsing P90 as a problem level when it's just "above normal drift".

### 2. Long-stopped containers flagged as "had downtime" every 15 min

\`nginx\`, \`postgres\`, \`redis\` on \`proxmox-01\` — intentionally stopped 15 days ago — were firing recurring \`critical: had downtime\` insights on every detector run. The old filter \`uptimePct > 0 && < 99\` let them through because 2 out of 287 recent snapshots happened to report 'running' (0.7%), presumably a transient race.

Fix: only emit the downtime insight when the container's **latest snapshot is currently running**, i.e. the container has actually recovered from a brief outage. Three cases:

- ✅ Container was down briefly and is running again → fires (the intended use case)
- ❌ Container has been stopped for days → skipped (no one wants "nginx had downtime" every 15 min for two weeks)
- ❌ Container is actively broken right now → skipped here, but \`container_unhealthy\` alert handles it via the live alerting path

The insight's message was also updated to say "was down for ~N minutes but has recovered" so users know it's retrospective, not active.

## Test plan

- [x] 3 new tests:
  - prediction fires when memory trends toward 80% of total capacity (new semantics)
  - prediction does NOT fire when memory drifts up but is far from saturation (media-host regression)
  - downtime flags a recovered container; does NOT flag a long-stopped one
- [x] 1 updated test: existing "generates prediction" rewritten for the saturation-aware path
- [x] Full suite **669/669 passing**
- [x] Backend + frontend typecheck clean
- [ ] Redeploy to VM and verify \`media\` host prediction disappears and \`proxmox-01\` nginx/postgres/redis insights clear on the next detector tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)