### PR TITLE
feat(ux): surface v26 diagnosis engine in the UI (8 audit fixes)

### DIFF
--- a/hub/src/insights/diagnosis/diagnosers/unified.ts
+++ b/hub/src/insights/diagnosis/diagnosers/unified.ts
@@ -85,6 +85,7 @@ export function diagnoseUnified(
       kind: 'ppr_root',
       severity: 'info',
       confidence: 'medium',
+      shortLabel: `Correlated with ${neighbors.length} service${neighbors.length === 1 ? '' : 's'}`,
       conclusion: `Upstream correlations detected`,
       action: '',
       evidence: [formatNeighbors(neighbors)],
@@ -98,6 +99,7 @@ export function diagnoseUnified(
       kind: 'fallback',
       severity: 'warning',
       confidence: 'low',
+      shortLabel: 'Unclassified',
       conclusion: `${containerName} is reporting unhealthy`,
       action: '',
       evidence: [],
@@ -163,6 +165,7 @@ export function diagnoseUnified(
     suggestedAction: primary.action,
     signals,
     evidenceRanked: rankEvidence(signals),
+    neighbors: neighbors.length > 0 ? neighbors : undefined,
   }];
 }
 

--- a/hub/src/insights/diagnosis/rank.ts
+++ b/hub/src/insights/diagnosis/rank.ts
@@ -68,7 +68,9 @@ export function rankEvidence(signals: FindingSignal[]): RankedEvidence[] {
     const explanatoryPower = surprise / total;
     return {
       kind: signal.kind,
-      label: signal.conclusion,
+      // Prefer the short semantic label for UI chips; fall back to the long
+      // conclusion text for signals that don't yet ship a shortLabel.
+      label: signal.shortLabel ?? signal.conclusion,
       surprise: Math.round(surprise * 100) / 100,
       explanatoryPower: Math.round(explanatoryPower * 100) / 100,
       score: Math.round(surprise * explanatoryPower * 100) / 100,

--- a/hub/src/insights/diagnosis/signals/appErrors.ts
+++ b/hub/src/insights/diagnosis/signals/appErrors.ts
@@ -27,6 +27,7 @@ export function detectAppErrors(ctx: DiagnosisContext): FindingSignal | null {
     kind: 'app_errors',
     severity: 'warning',
     confidence: 'medium',
+    shortLabel: `App errors: ${topLabel}`,
     conclusion: `${containerName} is reporting application errors (${topLabel})`,
     action: `The container is running and resources are normal, but the application is logging errors. Check recent application logs and investigate recent config changes or upstream dependencies.`,
     evidence: burstEvidence.length > 0

--- a/hub/src/insights/diagnosis/signals/cascade.ts
+++ b/hub/src/insights/diagnosis/signals/cascade.ts
@@ -18,6 +18,7 @@ export function detectCascade(ctx: DiagnosisContext): FindingSignal | null {
     kind: 'cascade',
     severity: 'warning',
     confidence: 'medium',
+    shortLabel: 'Cascade failure',
     conclusion: `${containerName} is part of a wider failure on ${hostId}`,
     action: `Multiple containers on ${hostId} are affected simultaneously. This is not isolated — investigate host-level issues: network, storage, a shared dependency (database, cache), or a recent host restart.`,
     evidence: [

--- a/hub/src/insights/diagnosis/signals/crashLoop.ts
+++ b/hub/src/insights/diagnosis/signals/crashLoop.ts
@@ -15,6 +15,7 @@ export function detectCrashLoop(ctx: DiagnosisContext): FindingSignal | null {
     kind: 'crash_loop',
     severity: 'critical',
     confidence: 'high',
+    shortLabel: 'Crash loop',
     conclusion: `${containerName} is crash-looping`,
     action: `The container has restarted ${restarts} times recently but is still failing its health check. Check container logs for the crash cause — if logs show startup errors, inspect config/volumes. If OOM, increase memory limit.`,
     evidence: [`${restarts} restarts in the last 2 hours`],

--- a/hub/src/insights/diagnosis/signals/hostPressure.ts
+++ b/hub/src/insights/diagnosis/signals/hostPressure.ts
@@ -20,6 +20,7 @@ export function detectHostPressure(ctx: DiagnosisContext): FindingSignal | null 
     kind: 'host_pressure',
     severity: 'warning',
     confidence: 'medium',
+    shortLabel: 'Host under pressure',
     conclusion: `${containerName}'s health check is failing while the host is under resource pressure`,
     action: `Host ${hostId} is heavily loaded. The container may be getting starved for CPU or memory. Reduce load on ${hostId} or investigate what else is consuming resources.`,
     evidence: [`Host ${hostId} is under pressure (${parts.join(', ')})`],

--- a/hub/src/insights/diagnosis/signals/hungService.ts
+++ b/hub/src/insights/diagnosis/signals/hungService.ts
@@ -16,6 +16,7 @@ export function detectHungService(ctx: DiagnosisContext): FindingSignal | null {
     kind: 'hung_service',
     severity: 'warning',
     confidence: 'medium',
+    shortLabel: 'Hung service',
     conclusion: `${containerName}'s service is responding too slowly to health checks`,
     action: `The service may be hung, deadlocked, or processing a long-running operation. Check application logs for stuck operations. A restart will clear any stuck state.`,
     evidence: [`Docker reports: ${ctx.latest.healthCheckOutput}`],

--- a/hub/src/insights/diagnosis/signals/oom.ts
+++ b/hub/src/insights/diagnosis/signals/oom.ts
@@ -20,6 +20,7 @@ export function detectOom(ctx: DiagnosisContext): FindingSignal | null {
       kind: 'oom_confirmed',
       severity: 'critical',
       confidence: 'high',
+      shortLabel: 'OOM killed',
       conclusion: `${containerName} has been killed by the OS for using too much memory`,
       action: `Logs show out-of-memory errors. Increase the container's memory limit or investigate what's allocating memory.`,
       evidence: [
@@ -36,6 +37,7 @@ export function detectOom(ctx: DiagnosisContext): FindingSignal | null {
       kind: 'oom_risk',
       severity: 'critical',
       confidence: 'high',
+      shortLabel: 'OOM risk',
       conclusion: `${containerName} is running out of memory`,
       action: `Memory is significantly above baseline and rising. Increase the container's memory limit, investigate for a memory leak, or check \`docker inspect ${containerName}\` for OOMKilled state.`,
       evidence: formatMemoryEvidence(ctx),

--- a/hub/src/insights/diagnosis/signals/zombieListener.ts
+++ b/hub/src/insights/diagnosis/signals/zombieListener.ts
@@ -18,6 +18,7 @@ export function detectZombieListener(ctx: DiagnosisContext): FindingSignal | nul
     kind: 'zombie_listener',
     severity: 'warning',
     confidence: 'medium',
+    shortLabel: 'Zombie listener',
     conclusion: `${containerName}'s service port is not responding, but the process is still running with normal resources`,
     action: `This looks like the application's listener crashed independently while the process stayed alive (a zombie listener). Restart the container to recover. If this recurs, it may be a known issue with the application.`,
     evidence: [

--- a/hub/src/insights/diagnosis/types.ts
+++ b/hub/src/insights/diagnosis/types.ts
@@ -161,7 +161,14 @@ export interface FindingSignal {
     | 'fallback';
   severity: 'critical' | 'warning' | 'info';
   confidence: 'high' | 'medium' | 'low';
-  /** Short headline for this signal (used as finding conclusion when primary). */
+  /**
+   * Short semantic name for this signal (e.g. "Zombie listener", "OOM risk").
+   * Used by the evidence ranker + UI chip labels so users don't see long
+   * conclusion sentences duplicated in every rendering location. Optional
+   * for back-compat with any signal emitters that don't yet set it.
+   */
+  shortLabel?: string;
+  /** Long-form headline for this signal (used as finding conclusion when primary). */
   conclusion: string;
   /** Suggested action if this signal is the primary explanation. */
   action: string;
@@ -231,6 +238,12 @@ export interface Finding {
    * older persisted findings keep rendering.
    */
   evidenceRanked?: RankedEvidence[];
+  /**
+   * Top-K PPR neighbors exposed as structured data so the UI can render
+   * them as clickable links. The unified diagnoser populates this from
+   * its internal PPR result when graph data is available.
+   */
+  neighbors?: Neighbor[];
 }
 
 export type Diagnoser = (ctx: DiagnosisContext) => Finding[];

--- a/hub/src/web/frontend/src/components/AnomaliesList.tsx
+++ b/hub/src/web/frontend/src/components/AnomaliesList.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import type { RollupAnomaly } from '@/types/api';
+import { Card } from '@/components/Card';
+import { timeAgo } from '@/lib/formatters';
+
+interface Props {
+  anomalies?: RollupAnomaly[];
+  /** 'container' drops the metric-host prefix; 'host' keeps it. */
+  scope: 'container' | 'host';
+}
+
+const METRIC_LABELS: Record<string, string> = {
+  cpu_max: 'CPU peak',
+  mem_max: 'Memory peak',
+  mem_used_max: 'Memory used (peak)',
+};
+
+function formatMetric(metric: string): string {
+  return METRIC_LABELS[metric] ?? metric;
+}
+
+function formatValue(metric: string, value: number): string {
+  if (metric.includes('cpu')) return `${Math.round(value * 10) / 10}%`;
+  if (metric.includes('mem')) return `${Math.round(value)} MB`;
+  return value.toString();
+}
+
+function severityOf(z: number): 'critical' | 'warning' | 'info' {
+  if (z >= 10) return 'critical';
+  if (z >= 5) return 'warning';
+  return 'info';
+}
+
+const BADGE: Record<'critical' | 'warning' | 'info', string> = {
+  critical: 'bg-danger/10 text-danger',
+  warning: 'bg-warning/10 text-warning',
+  info: 'bg-info/10 text-info',
+};
+
+/**
+ * Historical S-H-ESD anomalies for this entity. Rendered as a collapsible
+ * Card so it doesn't eat vertical space on the detail page when there's
+ * nothing interesting.
+ */
+export function AnomaliesList({ anomalies, scope }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  if (!anomalies || anomalies.length === 0) return null;
+
+  const summary = `${anomalies.length} historical spike${anomalies.length === 1 ? '' : 's'} detected`;
+
+  return (
+    <Card
+      title="Historical anomalies"
+      actions={
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="text-xs text-muted hover:text-fg transition-colors"
+        >
+          {expanded ? 'Hide' : 'Show'}
+        </button>
+      }
+    >
+      <p className="text-xs text-muted">{summary} by S-H-ESD over the last 14 days of hourly rollups.</p>
+      {expanded && (
+        <ul className="mt-3 space-y-2">
+          {anomalies.map((a, i) => {
+            const sev = severityOf(a.robust_z);
+            return (
+              <li
+                key={i}
+                className="flex items-center justify-between gap-3 rounded border border-border/50 bg-bg-secondary/50 px-3 py-2 text-xs"
+              >
+                <div className="flex items-center gap-2">
+                  <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase ${BADGE[sev]}`}>
+                    z = {Math.round(a.robust_z * 10) / 10}
+                  </span>
+                  <span className="font-medium text-fg">{formatMetric(a.metric)}</span>
+                  <span className="text-muted">peaked at {formatValue(a.metric, a.value)}</span>
+                </div>
+                <span className="text-muted tabular-nums" title={a.detected_at}>
+                  {scope === 'host' ? 'host' : 'container'} · {timeAgo(a.detected_at)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/hub/src/web/frontend/src/components/FindingCard.tsx
+++ b/hub/src/web/frontend/src/components/FindingCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import type { Finding } from '@/types/api';
+import { Link } from 'react-router-dom';
+import type { Finding, Neighbor } from '@/types/api';
 import { timeAgo } from '@/lib/formatters';
 import { DiagnosisCard, severityStyles } from '@/components/DiagnosisCard';
 import { Button } from '@/components/FormField';
@@ -20,6 +21,13 @@ export interface FindingPrimaryAction {
   title?: string;
 }
 
+export interface FindingFeedbackCallbacks {
+  onHelpful: () => void;
+  onNotHelpful: () => void;
+  /** Current vote state — drives button styling. */
+  current: 'helpful' | 'unhelpful' | null;
+}
+
 interface Props {
   finding: Finding;
   /** Optional raw technical details to show in an expandable section (e.g. Docker health check output) */
@@ -36,12 +44,26 @@ interface Props {
    * diagnosis so the user doesn't have to hunt for the button elsewhere.
    */
   primaryAction?: FindingPrimaryAction;
+  /**
+   * Optional feedback callbacks. When provided, renders thumbs-up/down
+   * buttons in the card footer that feed into Phase 4 confidence
+   * calibration via the insight-feedback endpoint.
+   */
+  feedback?: FindingFeedbackCallbacks;
 }
 
 const CONFIDENCE_STYLES: Record<Finding['confidence'], string> = {
   high: 'bg-success/10 text-success',
   medium: 'bg-warning/10 text-warning',
   low: 'bg-muted/20 text-muted',
+};
+
+// Pill classes for the PPR edge-type badges next to each neighbor.
+const EDGE_STYLES: Record<string, string> = {
+  same_host: 'bg-muted/20 text-muted',
+  same_compose: 'bg-info/10 text-info',
+  same_group: 'bg-info/10 text-info',
+  metric_corr: 'bg-warning/10 text-warning',
 };
 
 function formatCpu(v: number | null | undefined): string {
@@ -54,15 +76,38 @@ function formatMem(v: number | null | undefined): string {
   return `${Math.round(v)} MB`;
 }
 
-export function FindingCard({ finding, technicalDetails, liveSnapshot, primaryAction }: Props) {
+function neighborLink(entityId: string): string {
+  const parts = entityId.split('/');
+  if (parts.length === 2) {
+    return `/hosts/${encodeURIComponent(parts[0]!)}/containers/${encodeURIComponent(parts[1]!)}`;
+  }
+  return `/hosts/${encodeURIComponent(entityId)}`;
+}
+
+function neighborLabel(entityId: string): string {
+  const parts = entityId.split('/');
+  return parts.length === 2 ? parts[1]! : entityId;
+}
+
+export function FindingCard({ finding, technicalDetails, liveSnapshot, primaryAction, feedback }: Props) {
   const [showAllEvidence, setShowAllEvidence] = useState(false);
   const [showTechnical, setShowTechnical] = useState(false);
   const [showLive, setShowLive] = useState(false);
   const styles = severityStyles(finding.severity);
 
-  const TOP_EVIDENCE = 4;
-  const visibleEvidence = showAllEvidence ? finding.evidence : finding.evidence.slice(0, TOP_EVIDENCE);
-  const hiddenCount = Math.max(0, finding.evidence.length - TOP_EVIDENCE);
+  // Filter out "ppr_root" from the chip row — it's rendered as a dedicated
+  // Related services block below so users can click neighbors.
+  const rankedChips = (finding.evidenceRanked ?? []).filter((e) => e.kind !== 'ppr_root');
+
+  // Evidence visible by default — the single most common complaint from the
+  // v26 audit was that the "good stuff" was hidden behind an expander.
+  const EVIDENCE_VISIBLE_DEFAULT = 6;
+  const visibleEvidence = showAllEvidence
+    ? finding.evidence
+    : finding.evidence.slice(0, EVIDENCE_VISIBLE_DEFAULT);
+  const hiddenCount = Math.max(0, finding.evidence.length - EVIDENCE_VISIBLE_DEFAULT);
+
+  const neighbors: Neighbor[] = finding.neighbors ?? [];
 
   const hasLive = liveSnapshot && (
     liveSnapshot.status != null ||
@@ -82,16 +127,40 @@ export function FindingCard({ finding, technicalDetails, liveSnapshot, primaryAc
       </span>
       <span
         className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase ${CONFIDENCE_STYLES[finding.confidence]}`}
-        title="How sure we are based on signal strength and coincident failures."
+        title="Phase 4 calibrated posterior. Updates as you give feedback."
       >
         {finding.confidence} confidence
       </span>
     </>
   );
 
-  const footer = finding.diagnosedAt ? (
-    <span title={finding.diagnosedAt}>Analysis updated {timeAgo(finding.diagnosedAt)}</span>
-  ) : undefined;
+  const footer = (
+    <div className="flex items-center justify-between gap-2">
+      {finding.diagnosedAt && (
+        <span title={finding.diagnosedAt}>Analysis updated {timeAgo(finding.diagnosedAt)}</span>
+      )}
+      {feedback && (
+        <div className="flex items-center gap-1" role="group" aria-label="Was this diagnosis helpful?">
+          <button
+            onClick={feedback.onHelpful}
+            className={`rounded p-1 text-sm transition-colors ${feedback.current === 'helpful' ? 'bg-success/20 text-success' : 'text-muted hover:bg-muted/10 hover:text-fg'}`}
+            title="Helpful — record a positive calibration vote"
+            aria-pressed={feedback.current === 'helpful'}
+          >
+            👍
+          </button>
+          <button
+            onClick={feedback.onNotHelpful}
+            className={`rounded p-1 text-sm transition-colors ${feedback.current === 'unhelpful' ? 'bg-danger/20 text-danger' : 'text-muted hover:bg-muted/10 hover:text-fg'}`}
+            title="Not helpful — record a negative calibration vote"
+            aria-pressed={feedback.current === 'unhelpful'}
+          >
+            👎
+          </button>
+        </div>
+      )}
+    </div>
+  );
 
   return (
     <DiagnosisCard
@@ -101,41 +170,27 @@ export function FindingCard({ finding, technicalDetails, liveSnapshot, primaryAc
       pills={pills}
       footer={footer}
     >
-      {/* Evidence list: when the diagnoser shipped `evidenceRanked`, show the
-          top 3 most-explanatory signals first with their headlines, then
-          a "show details" expander that reveals the full evidence text. */}
-      {finding.evidenceRanked && finding.evidenceRanked.length > 0 ? (
-        <div>
-          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted mb-1">Top signals</div>
-          <ul className="space-y-1 text-xs text-fg">
-            {finding.evidenceRanked.map((e, i) => (
-              <li key={i} className="flex gap-2" title={`surprise ${e.surprise}, explains ${Math.round(e.explanatoryPower * 100)}% of total`}>
-                <span className="text-muted mt-0.5">•</span>
-                <span className="flex-1">{e.label}</span>
-                <span className="text-muted text-[10px] tabular-nums">{Math.round(e.explanatoryPower * 100)}%</span>
-              </li>
-            ))}
-          </ul>
-          {finding.evidence.length > 0 && (
-            <button
-              onClick={() => setShowAllEvidence(v => !v)}
-              className="mt-1 text-[11px] text-muted hover:text-fg transition-colors"
+      {/* Signal chips: short semantic labels (e.g. "Zombie listener", "OOM risk")
+          with severity coloring. Only show when there's more than one signal
+          contributing — a single-signal finding is just the title restated. */}
+      {rankedChips.length > 1 && (
+        <div className="flex flex-wrap gap-1">
+          {rankedChips.map((chip, i) => (
+            <span
+              key={i}
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${styles.bg} ${styles.text}`}
+              title={`${chip.kind} — surprise ${chip.surprise}, explains ${Math.round(chip.explanatoryPower * 100)}%`}
             >
-              {showAllEvidence ? 'Hide details' : `Show ${finding.evidence.length} evidence item${finding.evidence.length === 1 ? '' : 's'}`}
-            </button>
-          )}
-          {showAllEvidence && finding.evidence.length > 0 && (
-            <ul className="mt-2 space-y-1 border-t border-muted/20 pt-2 text-xs text-fg">
-              {finding.evidence.map((e, i) => (
-                <li key={i} className="flex gap-2">
-                  <span className="text-muted mt-0.5">•</span>
-                  <span className="flex-1">{e}</span>
-                </li>
-              ))}
-            </ul>
-          )}
+              {chip.label}
+              <span className="tabular-nums opacity-70">{Math.round(chip.explanatoryPower * 100)}%</span>
+            </span>
+          ))}
         </div>
-      ) : finding.evidence.length > 0 && (
+      )}
+
+      {/* Evidence list — visible by default. The stable, bucketed values live
+          here; anything "live" moves to the expander at the bottom. */}
+      {finding.evidence.length > 0 && (
         <div>
           <div className="text-[10px] font-semibold uppercase tracking-wide text-muted mb-1">What we observed</div>
           <ul className="space-y-1 text-xs text-fg">
@@ -154,6 +209,30 @@ export function FindingCard({ finding, technicalDetails, liveSnapshot, primaryAc
               {showAllEvidence ? 'Show fewer' : `Show ${hiddenCount} more`}
             </button>
           )}
+        </div>
+      )}
+
+      {/* Related services — PPR neighbors as clickable links. Replaces the
+          old inline "Correlated with: X (same_host)" text buried in evidence. */}
+      {neighbors.length > 0 && (
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted mb-1">Related services</div>
+          <ul className="flex flex-wrap gap-2 text-xs">
+            {neighbors.map((n, i) => (
+              <li key={i}>
+                <Link
+                  to={neighborLink(n.entity_id)}
+                  className="inline-flex items-center gap-1 rounded border border-muted/30 bg-bg-secondary px-2 py-0.5 text-fg hover:bg-muted/20 transition-colors"
+                  title={`${n.entity_id} — weight ${Math.round(n.weight * 100) / 100}`}
+                >
+                  <span>{neighborLabel(n.entity_id)}</span>
+                  <span className={`rounded-full px-1 text-[9px] ${EDGE_STYLES[n.edge_type] ?? 'bg-muted/20 text-muted'}`}>
+                    {n.edge_type.replace('_', ' ')}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/hub/src/web/frontend/src/components/LogTemplatesList.tsx
+++ b/hub/src/web/frontend/src/components/LogTemplatesList.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import type { LogTemplate } from '@/types/api';
+import { Card } from '@/components/Card';
+import { Badge } from '@/components/Badge';
+import { timeAgo } from '@/lib/formatters';
+
+interface Props {
+  templates?: LogTemplate[];
+}
+
+// Keep in sync with SEMANTIC_RULES in hub/src/insights/diagnosis/templateClassifier.ts.
+// Frontend doesn't have access to the backend module so we duplicate the
+// tag→label map here. Unknown tags fall through as capitalized raw strings.
+const TAG_LABELS: Record<string, string> = {
+  oom: 'Out of memory',
+  panic: 'Panic',
+  segfault: 'Segfault',
+  fatal: 'Fatal',
+  conn_refused: 'Conn refused',
+  conn_reset: 'Conn reset',
+  conn_timeout: 'Conn timeout',
+  dns_fail: 'DNS failure',
+  permission: 'Permission',
+  disk_full: 'Disk full',
+  too_many_files: 'Too many files',
+  db_locked: 'DB locked',
+  http_401: 'HTTP 401',
+  http_403: 'HTTP 403',
+  http_404: 'HTTP 404',
+  http_502: 'HTTP 502',
+  http_503: 'HTTP 503',
+};
+
+const TAG_COLORS: Record<string, string> = {
+  oom: 'red',
+  panic: 'red',
+  segfault: 'red',
+  fatal: 'red',
+  conn_refused: 'yellow',
+  conn_reset: 'yellow',
+  conn_timeout: 'yellow',
+  dns_fail: 'yellow',
+  disk_full: 'red',
+  db_locked: 'yellow',
+  http_502: 'red',
+  http_503: 'red',
+};
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}
+
+function isRecent(timestamp: string, windowMs: number): boolean {
+  const t = new Date(timestamp.replace(' ', 'T') + 'Z').getTime();
+  return !isNaN(t) && Date.now() - t < windowMs;
+}
+
+/**
+ * Drain-mined log templates for this container's image. Grouped by
+ * occurrence count, with semantic tag badges and a "NEW" pill for
+ * templates first-seen in the last 5 minutes.
+ */
+export function LogTemplatesList({ templates }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  if (!templates || templates.length === 0) return null;
+
+  const newTemplates = templates.filter((t) => isRecent(t.first_seen, 5 * 60_000));
+  const summary = `${templates.length} log pattern${templates.length === 1 ? '' : 's'} mined`
+    + (newTemplates.length > 0 ? ` · ${newTemplates.length} new` : '');
+
+  return (
+    <Card
+      title="Known log patterns"
+      actions={
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="text-xs text-muted hover:text-fg transition-colors"
+        >
+          {expanded ? 'Hide' : 'Show'}
+        </button>
+      }
+    >
+      <p className="text-xs text-muted">{summary} via Drain template mining on the 5-minute log cache window.</p>
+      {expanded && (
+        <ul className="mt-3 space-y-2">
+          {templates.map((t) => (
+            <li
+              key={t.template_hash}
+              className="rounded border border-border/50 bg-bg-secondary/50 p-2 text-xs"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <code className="flex-1 break-words font-mono text-[11px] text-fg">
+                  {truncate(t.template, 240)}
+                </code>
+                <div className="flex shrink-0 items-center gap-1">
+                  {isRecent(t.first_seen, 5 * 60_000) && (
+                    <Badge text="NEW" color="blue" />
+                  )}
+                  {t.semantic_tag && (
+                    <Badge
+                      text={TAG_LABELS[t.semantic_tag] ?? t.semantic_tag}
+                      color={TAG_COLORS[t.semantic_tag] ?? 'gray'}
+                    />
+                  )}
+                  <span className="text-muted tabular-nums">×{t.occurrence_count}</span>
+                </div>
+              </div>
+              <div className="mt-1 text-[10px] text-muted">
+                first seen <span title={t.first_seen}>{timeAgo(t.first_seen)}</span>
+                {' · '}
+                last seen <span title={t.last_seen}>{timeAgo(t.last_seen)}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/hub/src/web/frontend/src/pages/InsightsPage.tsx
+++ b/hub/src/web/frontend/src/pages/InsightsPage.tsx
@@ -151,6 +151,28 @@ function InsightCard({ insight, isExpanded, onToggle, feedback }: {
   const icon = CATEGORY_ICONS[insight.category] || '\u2139\ufe0f';
   const severityColor = SEVERITY_COLORS[insight.severity] || 'blue';
 
+  // Parse the persisted evidence JSON (schema v20+). Falls back to an empty
+  // array for older rows without the column — still renders cleanly.
+  const evidenceList: string[] = (() => {
+    if (!insight.evidence) return [];
+    try {
+      const parsed = JSON.parse(insight.evidence);
+      return Array.isArray(parsed) ? parsed.filter((s) => typeof s === 'string') : [];
+    } catch {
+      return [];
+    }
+  })();
+  const topEvidence = evidenceList[0];
+
+  // Map category → (diagnoser, conclusion_tag) for Phase 4 calibration.
+  // Only the 'health' category comes from the unified diagnoser today; the
+  // others go through detector.ts with no signal structure, so they remain
+  // view-only (calibration stays empty for those rows).
+  const calibrationKey = insight.category === 'health' ? {
+    diagnoser: 'unified',
+    conclusion_tag: insight.title.toLowerCase().replace(/[^a-z0-9]+/g, '_').slice(0, 64),
+  } : null;
+
   const feedbackMutation = useMutation({
     mutationFn: (helpful: boolean) =>
       apiAuth('POST', '/insights/feedback', {
@@ -159,6 +181,7 @@ function InsightCard({ insight, isExpanded, onToggle, feedback }: {
         category: insight.category,
         metric: insight.metric,
         helpful,
+        ...(calibrationKey ?? {}),
       }, token),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.insightFeedback() }),
   });
@@ -175,6 +198,9 @@ function InsightCard({ insight, isExpanded, onToggle, feedback }: {
             <span className="text-sm font-medium text-fg">{insight.title}</span>
             <Badge text={CATEGORY_LABELS[insight.category] || insight.category} color={severityColor} />
           </div>
+          {topEvidence && (
+            <p className="mt-0.5 text-xs text-muted">{topEvidence}</p>
+          )}
           <p className="mt-1 text-sm leading-relaxed text-secondary">{insight.message}</p>
         </div>
         <span className="mt-1 shrink-0 text-xs text-muted">{isExpanded ? '\u25b2' : '\u25bc'}</span>

--- a/hub/src/web/frontend/src/pages/containers/ContainerDetailPage.tsx
+++ b/hub/src/web/frontend/src/pages/containers/ContainerDetailPage.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { api, apiAuth } from '@/lib/api';
 import { useAuth } from '@/context/AuthContext';
-import type { ContainerDetail, ContainerAvailability, BaselineRow, ContainerSnapshot } from '@/types/api';
+import type { ContainerDetail, ContainerAvailability, BaselineRow, ContainerSnapshot, Finding } from '@/types/api';
 import { Card } from '@/components/Card';
 import { Button } from '@/components/FormField';
 import { BarChart } from '@/components/BarChart';
@@ -24,19 +24,46 @@ import { MetricGauge } from './MetricGauge';
 import { getAnalogy, findBaseline } from '@/lib/analogies';
 import { ContainerHistoryTab } from './ContainerHistoryTab';
 import { FindingCard } from '@/components/FindingCard';
+import { AnomaliesList } from '@/components/AnomaliesList';
+import { LogTemplatesList } from '@/components/LogTemplatesList';
 import { AIDiagnosisCard } from '@/components/AIDiagnosisCard';
 import { queryKeys } from '@/lib/queryKeys';
+
+function findingConclusionTag(finding: Finding): string {
+  // Mirror conclusionTag() in hub/src/insights/diagnosis/calibration.ts:
+  // prefer the top ranked evidence kind (which maps 1:1 to primary signal),
+  // fall back to a slug of the conclusion text.
+  const topKind = finding.evidenceRanked?.find((e) => e.kind !== 'ppr_root')?.kind;
+  if (topKind) return topKind;
+  return finding.conclusion.toLowerCase().replace(/[^a-z0-9]+/g, '_').slice(0, 64);
+}
 
 export function ContainerDetailPage() {
   const { hostId, containerName } = useParams();
   const hid = encodeURIComponent(hostId!);
   const cname = encodeURIComponent(containerName!);
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, token } = useAuth();
   const [activeTab, setActiveTab] = useState('overview');
   const [showCharts, setShowCharts] = useState(true);
+  // Per-tag feedback state so the thumbs buttons reflect the user's vote
+  // immediately. Submitted votes also go to the calibration table via the
+  // mutation below.
+  const [feedbackState, setFeedbackState] = useState<Record<string, 'helpful' | 'unhelpful'>>({});
   const navigate = useNavigate();
   const { confirm, dialogProps } = useConfirm();
   const { actionLoading, actionResult, runAction, removeContainer } = useContainerAction(hostId!, [['container', hostId, containerName]], confirm);
+
+  const feedbackMutation = useMutation({
+    mutationFn: (vars: { tag: string; helpful: boolean }) =>
+      apiAuth('POST', '/insights/feedback', {
+        entity_type: 'container',
+        entity_id: `${hostId}/${containerName}`,
+        category: 'health',
+        helpful: vars.helpful,
+        diagnoser: 'unified',
+        conclusion_tag: vars.tag,
+      }, token),
+  });
 
   const { data, error, isLoading } = useQuery({
     queryKey: queryKeys.container(hostId, containerName),
@@ -300,6 +327,18 @@ export function ContainerDetailPage() {
                 disabled: actionLoading != null,
                 title: 'Restart (r)',
               } : undefined;
+              const tag = findingConclusionTag(finding);
+              const feedbackCbs = isAuthenticated ? {
+                current: feedbackState[tag] ?? null,
+                onHelpful: () => {
+                  setFeedbackState((s) => ({ ...s, [tag]: 'helpful' }));
+                  feedbackMutation.mutate({ tag, helpful: true });
+                },
+                onNotHelpful: () => {
+                  setFeedbackState((s) => ({ ...s, [tag]: 'unhelpful' }));
+                  feedbackMutation.mutate({ tag, helpful: false });
+                },
+              } : undefined;
               return (
                 <FindingCard
                   key={i}
@@ -313,6 +352,7 @@ export function ContainerDetailPage() {
                     restartCount: data.restart_count,
                   }}
                   primaryAction={primaryAction}
+                  feedback={feedbackCbs}
                 />
               );
             })}
@@ -323,6 +363,12 @@ export function ContainerDetailPage() {
             containers it moves to the detail layer so it's still reachable
             without competing with the calm-by-default state. */}
         {showHealthFailure && <AIDiagnosisCard hostId={hostId!} containerName={containerName!} />}
+
+        {/* v26 observability: historical anomalies + Drain template patterns.
+            These are secondary to the main finding, so they live outside the
+            hero as collapsible cards that only render when data is present. */}
+        <AnomaliesList anomalies={data.anomalies} scope="container" />
+        <LogTemplatesList templates={data.logTemplates} />
       </section>
 
       <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />

--- a/hub/src/web/frontend/src/pages/hosts/HostDetailPage.tsx
+++ b/hub/src/web/frontend/src/pages/hosts/HostDetailPage.tsx
@@ -19,6 +19,7 @@ import { queryKeys } from '@/lib/queryKeys';
 import { HostOverviewTab } from './HostOverviewTab';
 import { HostResourcesTab } from './HostResourcesTab';
 import { HostAlertsTab } from './HostAlertsTab';
+import { AnomaliesList } from '@/components/AnomaliesList';
 
 export function HostDetailPage() {
   const { hostId } = useParams();
@@ -95,6 +96,10 @@ export function HostDetailPage() {
       {activeTab === 'alerts' && (
         <HostAlertsTab data={data} events={events} />
       )}
+
+      {/* v26 — historical S-H-ESD anomalies for this host. Always visible
+          (but the card hides itself when there's nothing to show). */}
+      <AnomaliesList anomalies={data.anomalies} scope="host" />
 
       <ConfirmDialog {...dialogProps} />
     </div>

--- a/hub/src/web/frontend/src/types/api.ts
+++ b/hub/src/web/frontend/src/types/api.ts
@@ -150,6 +150,30 @@ export interface RankedEvidence {
   score: number;
 }
 
+export interface Neighbor {
+  entity_id: string;
+  edge_type: string;
+  weight: number;
+}
+
+export interface RollupAnomaly {
+  metric: string;
+  bucket: string;
+  value: number;
+  residual: number;
+  robust_z: number;
+  detected_at: string;
+}
+
+export interface LogTemplate {
+  template_hash: string;
+  template: string;
+  occurrence_count: number;
+  semantic_tag: string | null;
+  first_seen: string;
+  last_seen: string;
+}
+
 export interface Finding {
   diagnoser: string;
   severity: 'critical' | 'warning' | 'info';
@@ -161,6 +185,8 @@ export interface Finding {
   diagnosedAt?: string;
   /** Phase 4 ranked top-3 evidence (optional). */
   evidenceRanked?: RankedEvidence[];
+  /** Phase 3 PPR neighbors exposed as structured data for clickable rendering. */
+  neighbors?: Neighbor[];
 }
 
 export interface ContainerDetail extends ContainerSnapshot {
@@ -169,6 +195,12 @@ export interface ContainerDetail extends ContainerSnapshot {
   findings: Finding[];
   history: ContainerHistory[];
   alerts: Alert[];
+  /** v26 — recent S-H-ESD rollup anomalies for this container. */
+  anomalies?: RollupAnomaly[];
+  /** v26 — top-K PPR neighbors pulled from `rca_edges`. */
+  neighbors?: Neighbor[];
+  /** v26 — Drain log templates mined for this container's image. */
+  logTemplates?: LogTemplate[];
 }
 
 export interface HostDetail extends Host {
@@ -178,6 +210,8 @@ export interface HostDetail extends Host {
   updates: UpdateCheck[];
   hostMetrics: HostMetrics | null;
   diskForecast: DiskForecastItem[];
+  /** v26 — recent S-H-ESD rollup anomalies for this host. */
+  anomalies?: RollupAnomaly[];
 }
 
 // Alerts
@@ -438,6 +472,12 @@ export interface InsightRow {
   metric: string | null;
   current_value: number | null;
   baseline_value: number | null;
+  /** JSON-encoded array of evidence strings (schema v20+). */
+  evidence?: string | null;
+  /** Long-form suggested action text (schema v20+). */
+  suggested_action?: string | null;
+  /** Calibrated confidence from the diagnoser (schema v20+). */
+  confidence?: 'high' | 'medium' | 'low' | null;
   computed_at: string;
 }
 

--- a/hub/src/web/handlers.ts
+++ b/hub/src/web/handlers.ts
@@ -182,7 +182,19 @@ function handleHostDetail(req: HandlerReq, res: ServerResponse, db: Database.Dat
     res.statusCode = 404;
     return { error: 'Host not found' };
   }
-  return detail;
+  // v26 observability surface: historical S-H-ESD rollup anomalies for this host.
+  let anomalies: any[] = [];
+  try {
+    anomalies = db.prepare(
+      `SELECT metric, bucket, value, residual, robust_z, detected_at
+       FROM rollup_anomalies
+       WHERE entity_type = 'host' AND entity_id = ?
+       ORDER BY detected_at DESC LIMIT 10`,
+    ).all(params.hostId);
+  } catch {
+    // Best-effort — degrade to empty.
+  }
+  return { ...detail, anomalies };
 }
 
 function handleHostContainers(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): any {
@@ -256,6 +268,42 @@ function handleContainerDetail(req: HandlerReq, res: ServerResponse, db: Databas
     }
   }
 
+  // v26 observability surfaces: S-H-ESD anomalies, PPR neighbors, Drain templates.
+  // Best-effort lookups — any failure degrades to empty arrays so the detail
+  // page still renders.
+  let anomalies: any[] = [];
+  let neighbors: any[] = [];
+  let logTemplates: any[] = [];
+  try {
+    const entityId = `${params.hostId}/${params.containerName}`;
+    anomalies = db.prepare(
+      `SELECT metric, bucket, value, residual, robust_z, detected_at
+       FROM rollup_anomalies
+       WHERE entity_type = 'container' AND entity_id = ?
+       ORDER BY detected_at DESC LIMIT 10`,
+    ).all(entityId);
+    neighbors = db.prepare(
+      `SELECT to_entity AS entity_id, edge_type, weight
+       FROM rca_edges WHERE from_entity = ?
+       UNION ALL
+       SELECT from_entity AS entity_id, edge_type, weight
+       FROM rca_edges WHERE to_entity = ?
+       ORDER BY weight DESC LIMIT 10`,
+    ).all(entityId, entityId);
+    const { resolveImageKey } = require('../insights/diagnosis/logCache') as {
+      resolveImageKey: (db: Database.Database, hostId: string, containerName: string) => string;
+    };
+    const imageKey = resolveImageKey(db, params.hostId, params.containerName);
+    logTemplates = db.prepare(
+      `SELECT template_hash, template, occurrence_count, semantic_tag, first_seen, last_seen
+       FROM log_templates
+       WHERE image = ?
+       ORDER BY occurrence_count DESC LIMIT 20`,
+    ).all(imageKey);
+  } catch {
+    // Swallow — degraded rendering is better than a 500.
+  }
+
   return {
     ...latest,
     host_id: params.hostId,
@@ -263,6 +311,9 @@ function handleContainerDetail(req: HandlerReq, res: ServerResponse, db: Databas
     findings,
     history: queries.getContainerHistory(db, params.hostId, params.containerName, hours),
     alerts: queries.getContainerAlerts(db, params.hostId, params.containerName),
+    anomalies,
+    neighbors,
+    logTemplates,
   };
 }
 
@@ -657,7 +708,15 @@ function handleGetHostInsights(req: HandlerReq, res: ServerResponse, db: Databas
 }
 
 async function handleInsightFeedback(req: HandlerReq, res: ServerResponse, db: Database.Database): Promise<any> {
-  const body = await readBody(req) as { entity_type?: string; entity_id?: string; category?: string; metric?: string | null; helpful?: boolean };
+  const body = await readBody(req) as {
+    entity_type?: string;
+    entity_id?: string;
+    category?: string;
+    metric?: string | null;
+    helpful?: boolean;
+    diagnoser?: string;
+    conclusion_tag?: string;
+  };
   if (!body.entity_type || !body.entity_id || !body.category || body.helpful == null) {
     res.statusCode = 400;
     return { error: 'entity_type, entity_id, category, and helpful are required' };
@@ -674,13 +733,31 @@ async function handleInsightFeedback(req: HandlerReq, res: ServerResponse, db: D
   `).get(body.entity_type, body.entity_id, body.category, metric, metric) as { id: number } | undefined;
 
   if (existing) {
-    db.prepare("UPDATE insight_feedback SET helpful = ?, created_at = datetime('now') WHERE id = ?").run(helpful, existing.id);
+    db.prepare(
+      "UPDATE insight_feedback SET helpful = ?, created_at = datetime('now'), diagnoser = ?, finding_hash = ? WHERE id = ?",
+    ).run(helpful, body.diagnoser ?? null, body.conclusion_tag ?? null, existing.id);
   } else {
     db.prepare(`
-      INSERT INTO insight_feedback (entity_type, entity_id, category, metric, helpful)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(body.entity_type, body.entity_id, body.category, metric, helpful);
+      INSERT INTO insight_feedback (entity_type, entity_id, category, metric, helpful, diagnoser, finding_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(body.entity_type, body.entity_id, body.category, metric, helpful, body.diagnoser ?? null, body.conclusion_tag ?? null);
   }
+
+  // Update Phase 4 calibration counts when the caller supplied a diagnoser +
+  // conclusion tag (typically from a live Finding on ContainerDetailPage).
+  // The old InsightsPage path still works without these fields; calibration
+  // just stays untouched for those rows.
+  if (body.diagnoser && body.conclusion_tag) {
+    try {
+      const { recordFeedback } = require('../insights/diagnosis/calibration') as {
+        recordFeedback: (db: Database.Database, diagnoser: string, tag: string, helpful: boolean) => void;
+      };
+      recordFeedback(db, body.diagnoser, body.conclusion_tag, body.helpful);
+    } catch {
+      // Calibration update is best-effort — never fail the feedback request.
+    }
+  }
+
   return { ok: true };
 }
 

--- a/tests/integration/web-api.test.ts
+++ b/tests/integration/web-api.test.ts
@@ -547,6 +547,41 @@ describe('Web API integration', () => {
     assert.equal(res.status, 400);
   });
 
+  it('POST /api/insights/feedback records calibration when diagnoser + conclusion_tag provided', async () => {
+    // Submit 5 positive votes on the same (diagnoser, tag) — calibration
+    // should accumulate in confidence_calibration and total helpful_count.
+    for (let i = 0; i < 5; i++) {
+      await fetchMethod(port, 'POST', '/api/insights/feedback', {
+        entity_type: 'container',
+        entity_id: `h1/web-${i}`, // different entities so insight_feedback unique constraint doesn't collide
+        category: 'health',
+        metric: null,
+        helpful: true,
+        diagnoser: 'unified',
+        conclusion_tag: 'zombie_listener',
+      });
+    }
+    const row = db.prepare(
+      `SELECT helpful_count, unhelpful_count FROM confidence_calibration
+       WHERE diagnoser = 'unified' AND conclusion_tag = 'zombie_listener'`,
+    ).get();
+    assert.ok(row, 'calibration row should exist after votes with diagnoser+tag');
+    assert.equal(row.helpful_count, 5);
+    assert.equal(row.unhelpful_count, 0);
+  });
+
+  it('POST /api/insights/feedback skips calibration when diagnoser/tag absent', async () => {
+    // Vote without the new fields — confidence_calibration should stay empty
+    // (the insight_feedback row still gets written, just no posterior update).
+    await fetchMethod(port, 'POST', '/api/insights/feedback', {
+      entity_type: 'host', entity_id: 'h2', category: 'trend', metric: null, helpful: true,
+    });
+    const row = db.prepare(
+      `SELECT COUNT(*) AS n FROM confidence_calibration WHERE diagnoser = 'unified' AND conclusion_tag = 'trend'`,
+    ).get();
+    assert.equal(row.n, 0);
+  });
+
   it('GET /api/insights/feedback returns the feedback list', async () => {
     await fetchMethod(port, 'POST', '/api/insights/feedback', {
       entity_type: 'container', entity_id: 'h1/nginx', category: 'memory', metric: 'memory_mb', helpful: true,

--- a/tests/unit/rank.test.ts
+++ b/tests/unit/rank.test.ts
@@ -3,12 +3,13 @@ import assert from 'node:assert/strict';
 
 const { rankEvidence } = require('../../hub/src/insights/diagnosis/rank');
 
-function signal(kind: string, confidence: string = 'medium'): any {
+function signal(kind: string, confidence: string = 'medium', shortLabel?: string): any {
   return {
     kind,
     severity: 'warning',
     confidence,
-    conclusion: `${kind} detected`,
+    shortLabel,
+    conclusion: `${kind} detected somewhere in the system with extra words`,
     action: '',
     evidence: [],
     priority: 1,
@@ -54,5 +55,15 @@ describe('rankEvidence', () => {
       assert.ok(Math.abs(r.score - expected) < 0.02,
         `score ${r.score} should match surprise×explanatoryPower = ${expected} for ${r.kind}`);
     }
+  });
+
+  it('uses shortLabel for the RankedEvidence label when present', () => {
+    const ranked = rankEvidence([signal('oom_risk', 'high', 'OOM risk')]);
+    assert.equal(ranked[0].label, 'OOM risk');
+  });
+
+  it('falls back to conclusion when shortLabel is absent', () => {
+    const ranked = rankEvidence([signal('oom_risk', 'high')]);
+    assert.match(ranked[0].label, /oom_risk detected/);
   });
 });

--- a/tests/unit/signals.test.ts
+++ b/tests/unit/signals.test.ts
@@ -91,6 +91,31 @@ describe('detectOom', () => {
   });
 });
 
+describe('signal shortLabel coverage', () => {
+  // Every detector should ship a non-empty shortLabel so the FindingCard
+  // can render a meaningful chip instead of the long conclusion sentence.
+  const detectors: Array<[string, (ctx: any) => any]> = [
+    ['oom_risk', (c) => detectOom({ ...c, memoryVsP95: 'critical', recent: { ...c.recent, memoryTrend: 'rising' }, latest: { ...c.latest, memoryMb: 700 }, baselines: { memory_mb: { p95: 400 } } })],
+    ['oom_confirmed', (c) => detectOom({ ...c, logs: { available: true, errorPatterns: ['oom'] } })],
+    ['crash_loop', (c) => detectCrashLoop({ ...c, recent: { ...c.recent, restartsInWindow: 3 } })],
+    ['cascade', (c) => detectCascade({ ...c, coincident: { activeAlerts: [], recentFailures: ['a', 'b'], cascadeDetected: true } })],
+    ['host_pressure', (c) => detectHostPressure({ ...c, host: { ...c.host, underPressure: true, cpuPercent: 92 } })],
+    ['app_errors', (c) => detectAppErrors({ ...c, logs: { available: true, errorPatterns: ['fatal'] } })],
+    ['zombie_listener', (c) => detectZombieListener({ ...c, latest: { ...c.latest, healthCheckOutput: 'connection refused' } })],
+    ['hung_service', (c) => detectHungService({ ...c, latest: { ...c.latest, healthCheckOutput: 'timed out' } })],
+  ];
+
+  for (const [name, fire] of detectors) {
+    it(`${name} sets a non-empty shortLabel`, () => {
+      const signal = fire(makeCtx());
+      assert.ok(signal, `${name} should have fired`);
+      assert.ok(signal.shortLabel, `${name} should have a shortLabel`);
+      assert.ok(signal.shortLabel.length > 0 && signal.shortLabel.length <= 40,
+        `${name} shortLabel "${signal.shortLabel}" should be concise (1-40 chars)`);
+    });
+  }
+});
+
 describe('detectCrashLoop', () => {
   it('fires on ≥2 restarts in window', () => {
     const ctx = makeCtx({ recent: { restartsInWindow: 3 } });


### PR DESCRIPTION
## Summary

Follow-up to the v22 → v26 research-grounded diagnosis engine upgrade. Backend produces rich structured data (ranked signals, PPR neighbors, Drain templates, S-H-ESD anomalies, Beta-posterior calibration) but the UI was stuck in a halfway state: chips echoed the card title, neighbors were plain text, calibration feedback wasn't wired, and three backend surfaces had zero UX.

Fixes all **8 items from the UX audit** in one PR — no schema changes, all data already persists in v26 tables.

## What changed

### FindingCard rework (audit items 1–3)

- **Short semantic chip labels.** New \`FindingSignal.shortLabel\` field. Each of the 7 signal detectors sets a concise label: \"OOM risk\", \"OOM killed\", \"Crash loop\", \"Cascade failure\", \"Host under pressure\", \"App errors: X\", \"Zombie listener\", \"Hung service\". \`rank.ts\` uses \`signal.shortLabel ?? signal.conclusion\`. Chips only render when multiple signals contributed — single-signal findings no longer echo their own title.
- **Evidence visible by default.** Up to 6 items inline, expander for the rest. The old \"Show N evidence items\" click gate is gone.
- **Related services** — PPR neighbors as clickable \`Link\` chips with edge-type pills (\`same_host\` / \`same_compose\` / \`metric_corr\`). \`Finding.neighbors\` is now structured data populated by \`diagnoseUnified\` from the PPR result.

### Calibration feedback wired (audit item 4) 🔴

- **FindingCard** gains optional thumbs-up/down buttons in the footer.
- **ContainerDetailPage** wires a mutation passing \`diagnoser\` + \`conclusion_tag\` derived from \`Finding.evidenceRanked[0].kind\`.
- **\`handleInsightFeedback\`** accepts the new optional fields and calls \`recordFeedback(db, diagnoser, tag, helpful)\` from Phase 4 calibration. \`confidence_calibration\` now accumulates real data and \`calibrateFindings()\` actually calibrates. Phase 4 is no longer dead code.

### New observability surfaces (audit items 5, 6, 7)

- **\`AnomaliesList.tsx\`** — rendered on both ContainerDetailPage (scope=container) and HostDetailPage (scope=host). Collapsible card listing the top-10 recent S-H-ESD detections with severity badges (\`critical\` ≥ robust_z 10, \`warning\` ≥ 5, \`info\` otherwise). Populated from \`handleContainerDetail\` / \`handleHostDetail\`.
- **\`LogTemplatesList.tsx\`** — rendered on ContainerDetailPage. Shows the image's top 20 Drain-mined templates with occurrence count, semantic_tag badge (OOM/panic/etc.), and a \"NEW\" pill for templates first-seen in the last 5 minutes. Populated from \`handleContainerDetail\`.
- **RCA graph** is surfaced via the FindingCard \"Related services\" section (seed-centric list of top-K neighbors, as planned).

### InsightsPage polish (audit item 8)

- Parses the persisted \`evidence\` JSON column and renders the first line as a dim one-line summary under each insight title.
- Feedback mutation also passes \`diagnoser='unified'\` + slugged tag for health-category insights, so calibration works from both FindingCard *and* the Insights page.

## Files

**Backend (10 files, ~150 LOC)**
- \`diagnosis/types.ts\` — \`FindingSignal.shortLabel\`, \`Finding.neighbors\`
- \`diagnosis/signals/*.ts\` — 7 detectors set \`shortLabel\`
- \`diagnosis/rank.ts\` — use shortLabel in \`RankedEvidence.label\`
- \`diagnosis/diagnosers/unified.ts\` — populate \`Finding.neighbors\`
- \`web/handlers.ts\` — feedback → \`recordFeedback\`; detail endpoints include \`anomalies\` / \`neighbors\` / \`logTemplates\`

**Frontend (9 files, ~485 LOC including 2 new components)**
- \`types/api.ts\` — new types + field extensions
- \`components/FindingCard.tsx\` — ~100 LOC rework
- \`components/AnomaliesList.tsx\` (NEW)
- \`components/LogTemplatesList.tsx\` (NEW)
- \`pages/containers/ContainerDetailPage.tsx\` — feedback wiring + new sections
- \`pages/hosts/HostDetailPage.tsx\` — anomalies section
- \`pages/InsightsPage.tsx\` — evidence summary + calibration fields

## Test plan

- [x] **12 new test cases:**
  - 8 signal shortLabel coverage assertions (every detector returns a 1-40 char label)
  - 2 rank.ts shortLabel fallback cases
  - 2 integration: calibration accumulates with diagnoser+tag; stays empty without them
- [x] **Full suite 681/681 passing** (was 669)
- [x] **Backend typecheck clean**
- [x] **Frontend typecheck clean**
- [ ] Deploy to VM + visually verify FindingCard renders \"Zombie listener\" chip for AdGuard, Related services shows insightd-agent as clickable, Log patterns expander works, 5 thumbs-up votes move the confidence posterior

## Not in scope

- Dedicated \`/topology\` / \`/anomalies\` pages — chose per-entity integration per homelab minimalism.
- Calibration decay — the Beta prior is stationary; revisit if thousands of votes accumulate.
- Semantic-tag backfill on existing log_templates rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)