### PR TITLE
fix(diagnosis): run calibration AFTER sticky so feedback updates confidence

### DIFF
--- a/hub/src/insights/diagnosis/run.ts
+++ b/hub/src/insights/diagnosis/run.ts
@@ -49,16 +49,17 @@ export function runDiagnosis(
   }
 
   const raw: Finding[] = diagnoseUnified(ctx, { db });
-  // Recalibrate confidence from historical feedback before sticky-cacheing
-  // so the cache entry reflects the posterior estimate, not the diagnoser's
-  // self-assigned prior. Calibration is a pure function over DB state —
-  // safe to run on every diagnosis pass.
-  const fresh = calibrateFindings(db, raw);
 
-  // Run through the sticky layer so evidence + diagnosedAt stay stable
-  // across re-runs when the conclusion hasn't actually changed. This is
-  // what users see on the container detail page.
-  const findings = stickyFindings(entity.hostId, entity.containerName, fresh);
+  // Run through the sticky layer first so evidence + diagnosedAt stay stable
+  // across re-runs when the conclusion hasn't actually changed.
+  const stable = stickyFindings(entity.hostId, entity.containerName, raw);
+
+  // Calibrate confidence AFTER the sticky layer — confidence is the one
+  // field that should update as users vote, even when the conclusion and
+  // evidence are frozen. Running calibrateFindings first and then sticky
+  // would cache-freeze the calibrated confidence and new votes wouldn't
+  // surface until the conclusion itself changed.
+  const findings = calibrateFindings(db, stable);
 
   if (options.persistCategory && findings.length > 0) {
     persistFindings(db, entity, options.persistCategory, findings);


### PR DESCRIPTION
## Summary

Phase 4 calibration was silently discarded by the sticky-findings cache. This is a bug that only shows up at runtime when both layers cooperate — unit tests mock the sticky cache so it never surfaced.

## The bug

\`runDiagnosis\` was:
\`\`\`
raw → calibrateFindings → stickyFindings
\`\`\`

\`calibrateFindings\` correctly computed the Beta posterior from \`confidence_calibration\` and overrode the diagnoser's self-assigned confidence. But then \`stickyFindings\` ran: it compared the new finding's \`conclusion + severity\` against the cache entry (same → cache hit), and spread the **cached** finding — including its **pre-vote** confidence — back out to the caller. New votes never surfaced until the conclusion or severity changed.

## Reproduction

On the live VM right after merging #126:

1. AdGuard/adguardhome shows the \`zombie_listener\` finding at \`medium\` confidence
2. \`POST /api/insights/feedback\` × 5 with \`{diagnoser: 'unified', conclusion_tag: 'zombie_listener', helpful: true}\`
3. Check \`confidence_calibration\` → \`helpful_count = 5\` ✓
4. Beta posterior: \`(5+2)/(5+0+2+2) = 0.778\`, above the 0.75 \`high\` threshold ✓
5. Fresh GET \`/api/hosts/AdGuard/containers/adguardhome\` → still returns \`medium\` ❌

## Fix

Swap the order. Sticky first (stabilize evidence + \`diagnosedAt\`), calibration last (reflect latest posterior):
\`\`\`
raw → stickyFindings → calibrateFindings
\`\`\`

Confidence is the one field that legitimately updates between runs even when nothing else moves, which matches the user mental-model of feedback.

## Test plan

- [x] Full suite **681/681 passing** (no test changes — the bug only surfaces when both layers run together, and adding a regression test would require plumbing the sticky cache into the calibration integration test, which is more infrastructure than the fix deserves)
- [x] Typecheck clean
- [ ] Redeploy to VM and verify the \`zombie_listener\` finding flips from \`medium\` → \`high\` after the calibration table already has 5 helpful votes

🤖 Generated with [Claude Code](https://claude.com/claude-code)