### PR TITLE
fix(ux): blank container detail page — Neighbor shape mismatch

### DIFF
--- a/hub/src/web/frontend/src/components/FindingCard.tsx
+++ b/hub/src/web/frontend/src/components/FindingCard.tsx
@@ -213,25 +213,31 @@ export function FindingCard({ finding, technicalDetails, liveSnapshot, primaryAc
       )}
 
       {/* Related services — PPR neighbors as clickable links. Replaces the
-          old inline "Correlated with: X (same_host)" text buried in evidence. */}
+          old inline "Correlated with: X (same_host)" text buried in evidence.
+          Shape comes from Finding.neighbors which is camelCase and carries
+          an edgeTypes[] array (a pair can share multiple edge types — e.g.
+          same_host AND metric_corr). Primary type drives the pill color. */}
       {neighbors.length > 0 && (
         <div>
           <div className="text-[10px] font-semibold uppercase tracking-wide text-muted mb-1">Related services</div>
           <ul className="flex flex-wrap gap-2 text-xs">
-            {neighbors.map((n, i) => (
-              <li key={i}>
-                <Link
-                  to={neighborLink(n.entity_id)}
-                  className="inline-flex items-center gap-1 rounded border border-muted/30 bg-bg-secondary px-2 py-0.5 text-fg hover:bg-muted/20 transition-colors"
-                  title={`${n.entity_id} — weight ${Math.round(n.weight * 100) / 100}`}
-                >
-                  <span>{neighborLabel(n.entity_id)}</span>
-                  <span className={`rounded-full px-1 text-[9px] ${EDGE_STYLES[n.edge_type] ?? 'bg-muted/20 text-muted'}`}>
-                    {n.edge_type.replace('_', ' ')}
-                  </span>
-                </Link>
-              </li>
-            ))}
+            {neighbors.map((n, i) => {
+              const primaryType = n.edgeTypes[0] ?? 'same_host';
+              return (
+                <li key={i}>
+                  <Link
+                    to={neighborLink(n.entityId)}
+                    className="inline-flex items-center gap-1 rounded border border-muted/30 bg-bg-secondary px-2 py-0.5 text-fg hover:bg-muted/20 transition-colors"
+                    title={`${n.entityId} — PPR score ${n.score}, edge types: ${n.edgeTypes.join(', ')}`}
+                  >
+                    <span>{neighborLabel(n.entityId)}</span>
+                    <span className={`rounded-full px-1 text-[9px] ${EDGE_STYLES[primaryType] ?? 'bg-muted/20 text-muted'}`}>
+                      {primaryType.replace('_', ' ')}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}

--- a/hub/src/web/frontend/src/types/api.ts
+++ b/hub/src/web/frontend/src/types/api.ts
@@ -151,9 +151,12 @@ export interface RankedEvidence {
 }
 
 export interface Neighbor {
-  entity_id: string;
-  edge_type: string;
-  weight: number;
+  /** camelCase fields mirror the backend Neighbor interface from
+   *  hub/src/insights/diagnosis/types.ts — populated by the unified
+   *  diagnoser from the PPR result, not from raw rca_edges rows. */
+  entityId: string;
+  score: number;
+  edgeTypes: string[];
 }
 
 export interface RollupAnomaly {
@@ -197,10 +200,11 @@ export interface ContainerDetail extends ContainerSnapshot {
   alerts: Alert[];
   /** v26 — recent S-H-ESD rollup anomalies for this container. */
   anomalies?: RollupAnomaly[];
-  /** v26 — top-K PPR neighbors pulled from `rca_edges`. */
-  neighbors?: Neighbor[];
   /** v26 — Drain log templates mined for this container's image. */
   logTemplates?: LogTemplate[];
+  // NOTE: per-finding PPR neighbors live on `Finding.neighbors` (camelCase).
+  // The top-level `neighbors` field used to hold raw rca_edges rows, which
+  // caused a shape clash — removed in fix/neighbor-type-mismatch.
 }
 
 export interface HostDetail extends Host {

--- a/hub/src/web/handlers.ts
+++ b/hub/src/web/handlers.ts
@@ -268,11 +268,13 @@ function handleContainerDetail(req: HandlerReq, res: ServerResponse, db: Databas
     }
   }
 
-  // v26 observability surfaces: S-H-ESD anomalies, PPR neighbors, Drain templates.
-  // Best-effort lookups — any failure degrades to empty arrays so the detail
-  // page still renders.
+  // v26 observability surfaces: S-H-ESD anomalies, Drain templates.
+  // PPR neighbors are NOT queried here — they come through the Finding
+  // object via the unified diagnoser (Finding.neighbors), which already
+  // uses the correct camelCase shape that FindingCard expects.
+  // Best-effort lookups — any failure degrades to empty arrays so the
+  // detail page still renders.
   let anomalies: any[] = [];
-  let neighbors: any[] = [];
   let logTemplates: any[] = [];
   try {
     const entityId = `${params.hostId}/${params.containerName}`;
@@ -282,14 +284,6 @@ function handleContainerDetail(req: HandlerReq, res: ServerResponse, db: Databas
        WHERE entity_type = 'container' AND entity_id = ?
        ORDER BY detected_at DESC LIMIT 10`,
     ).all(entityId);
-    neighbors = db.prepare(
-      `SELECT to_entity AS entity_id, edge_type, weight
-       FROM rca_edges WHERE from_entity = ?
-       UNION ALL
-       SELECT from_entity AS entity_id, edge_type, weight
-       FROM rca_edges WHERE to_entity = ?
-       ORDER BY weight DESC LIMIT 10`,
-    ).all(entityId, entityId);
     const { resolveImageKey } = require('../insights/diagnosis/logCache') as {
       resolveImageKey: (db: Database.Database, hostId: string, containerName: string) => string;
     };
@@ -312,7 +306,6 @@ function handleContainerDetail(req: HandlerReq, res: ServerResponse, db: Databas
     history: queries.getContainerHistory(db, params.hostId, params.containerName, hours),
     alerts: queries.getContainerAlerts(db, params.hostId, params.containerName),
     anomalies,
-    neighbors,
     logTemplates,
   };
 }


### PR DESCRIPTION
## Summary

ContainerDetailPage rendered as a **blank white page** after #126 landed. Root cause: a shape mismatch between the backend \`Finding.neighbors\` (camelCase) and the frontend \`Neighbor\` type I defined (snake_case).

## What happened

\`Finding.neighbors\` is populated by the unified diagnoser from the PPR result, which uses the backend \`Neighbor\` interface at \`hub/src/insights/diagnosis/types.ts\`:

\`\`\`ts
interface Neighbor { entityId: string; score: number; edgeTypes: string[] }
\`\`\`

But in #126 I wrote the frontend type as:

\`\`\`ts
interface Neighbor { entity_id: string; edge_type: string; weight: number }
\`\`\`

(modeled after raw \`rca_edges\` rows, which is what \`handleContainerDetail\` was querying separately under a top-level \`neighbors\` field.)

\`FindingCard\` consumed \`finding.neighbors\` (camelCase), so every access like \`n.entity_id\` returned \`undefined\`. The offending line was:

\`\`\`tsx
<Link to={neighborLink(n.entity_id)}>  // → to={undefined}
\`\`\`

React Router's \`<Link>\` throws when \`to\` is undefined. No error boundary → whole ContainerDetailPage tree unmounted → blank page.

## Fix

1. **Frontend \`Neighbor\` type** now matches the backend: \`{ entityId, score, edgeTypes[] }\`.
2. **\`FindingCard\`** reads \`n.entityId\` / \`n.edgeTypes[0]\`. The pill shows the primary edge type, the tooltip lists all types (a single pair can have both \`same_host\` AND \`metric_corr\`).
3. **\`handleContainerDetail\`** drops its separate \`rca_edges\` query and the top-level \`neighbors\` field — redundant with \`Finding.neighbors\` and the source of my confusion. One source of truth.

## Test plan

- [x] Backend + frontend typecheck clean
- [x] Full suite **681/681 passing**
- [ ] Rebuild + redeploy: ContainerDetailPage renders for \`AdGuard/adguardhome\`, Related services shows \`insightd-agent\` as a clickable chip with a \`same host\` pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)