### PR TITLE
fix(ux): timeAgo 'NaNd ago' on FindingCard footer

### DIFF
--- a/hub/src/web/frontend/src/lib/formatters.ts
+++ b/hub/src/web/frontend/src/lib/formatters.ts
@@ -1,6 +1,14 @@
 export function timeAgo(dateStr: string | null | undefined): string {
   if (!dateStr) return 'never';
-  const diff = Date.now() - new Date(dateStr + 'Z').getTime();
+  // Two timestamp shapes show up in API payloads:
+  //   1. SQLite datetime('now'):       "2026-04-13 19:14:06"  (no tz — UTC implicit)
+  //   2. JavaScript Date#toISOString:  "2026-04-13T19:14:06.000Z" (already UTC)
+  // Treat anything with a T or Z as already-parsed-correctly; only the plain
+  // SQLite shape needs the explicit `Z` appended to force UTC interpretation.
+  const normalized = /[TZ]/.test(dateStr) ? dateStr : dateStr + 'Z';
+  const t = new Date(normalized).getTime();
+  if (Number.isNaN(t)) return 'never';
+  const diff = Date.now() - t;
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return 'just now';
   if (mins < 60) return `${mins}m ago`;


### PR DESCRIPTION
## Summary

FindingCard footer was rendering \`Analysis updated NaNd ago\` on the live VM.

Root cause: \`timeAgo()\` unconditionally appends \`Z\` to its input to force UTC interpretation. That's correct for SQLite \`datetime('now')\` strings (\`\"2026-04-13 19:14:06\"\`), which is what most callers pass. But \`sticky.ts\` stamps \`Finding.diagnosedAt\` via \`new Date(nowMs).toISOString()\`, which already ends in \`Z\`. Appending another \`Z\` produces \`\"2026-04-13T19:14:06.000ZZ\"\`, which parses to \`Invalid Date\` → \`NaN\` → \`NaNd ago\`.

## Fix

One-line behavioural fix in \`lib/formatters.ts\`:

\`\`\`ts
const normalized = /[TZ]/.test(dateStr) ? dateStr : dateStr + 'Z';
const t = new Date(normalized).getTime();
if (Number.isNaN(t)) return 'never';
\`\`\`

Detect whether the string already has a \`T\` or \`Z\` (already ISO) and only append \`Z\` for the plain SQLite shape. Also bail to \`'never'\` on Invalid Date so this class of bug never leaks into the UI as \`NaN…\` again.

## Test plan

- [x] Frontend typecheck clean
- [ ] Rebuild + redeploy: AdGuard finding shows \`Analysis updated Xm ago\` with a real number instead of \`NaNd\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)