### PR TITLE
fix(dashboard): split hero into score breakdown + scroll-to-concerns

### DIFF
--- a/hub/src/web/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/hub/src/web/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -66,7 +66,9 @@ export function DashboardPage() {
       </div>
 
       {/* Feed cards — 24px from summary unit, 16px between peer cards */}
-      <FeedCard className="mt-6" title="Needs Attention" items={acuteItems} />
+      <div id="needs-attention" className="scroll-mt-4">
+        <FeedCard className="mt-6" title="Needs Attention" items={acuteItems} />
+      </div>
       <FeedCard
         className={acuteItems.length > 0 ? 'mt-4' : 'mt-6'}
         title="Insights"
@@ -208,30 +210,44 @@ function HealthHero({ systemHealthScore, availability, concernCount }: { systemH
     : availability.overallPercent >= 95 ? 'text-warning'
     : 'text-danger';
 
+  const scrollToNeedsAttention = () => {
+    const el = document.getElementById('needs-attention');
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   return (
     <div className="py-2">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center gap-5 rounded-lg p-2 -m-2 text-left transition-opacity hover:opacity-90"
-        aria-expanded={expanded}
-        aria-controls="health-breakdown"
-      >
+      <div className="flex items-start gap-5">
         {systemHealthScore && <HealthBadge score={systemHealthScore.score} size="lg" />}
         <div className="min-w-0 flex-1">
-          <div className={`text-xl font-semibold ${concernCount === 0 ? 'text-fg' : 'text-warning'}`}>
-            {stateLabel}
-          </div>
+          {concernCount > 0 ? (
+            <button
+              type="button"
+              onClick={scrollToNeedsAttention}
+              className="rounded text-left text-xl font-semibold text-warning transition-opacity hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-warning/40"
+            >
+              {stateLabel}
+            </button>
+          ) : (
+            <div className="text-xl font-semibold text-fg">{stateLabel}</div>
+          )}
           <div className={`mt-0.5 text-sm ${availColor}`}>
             {availText}
           </div>
           {systemHealthScore && (
-            <div className="mt-1 flex items-center gap-1 text-xs text-muted">
-              <span>{expanded ? 'Hide details' : 'Why this score?'}</span>
+            <button
+              type="button"
+              onClick={() => setExpanded(!expanded)}
+              className="mt-1 flex items-center gap-1 rounded text-xs text-muted transition-colors hover:text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-border"
+              aria-expanded={expanded}
+              aria-controls="health-breakdown"
+            >
+              <span>{expanded ? 'Hide score breakdown' : 'Show health score breakdown'}</span>
               <Chevron expanded={expanded} />
-            </div>
+            </button>
           )}
         </div>
-      </button>
+      </div>
 
       {expanded && systemHealthScore?.hostBreakdown && (
         <div id="health-breakdown" className="mt-4 rounded-xl border border-border bg-surface p-4">


### PR DESCRIPTION
## Summary

The dashboard hero currently conflates two unrelated things:

- **"N items need attention"** — counts acute feed items from `useFeedItems` (active alerts + container downtime)
- **Expanded chevron** — shows per-host health score breakdown (CPU/memory/load/online/alerts factor ratings), labeled "Why this score?"

Clicking anywhere in the hero opens the score breakdown, which doesn't match the count on the line above it. You can have 4 active container alerts on hosts whose factors all read "All factors normal" — container health isn't a host factor, so the counts diverge by design, but the UX makes it look like a bug.

This PR decouples the two:

- The **"N items need attention"** text is now a button (warning-colored, underlined on hover) that smooth-scrolls to the "Needs Attention" feed card below.
- A separate, smaller button under the availability line toggles the score breakdown. Copy changed from "Why this score?" → **"Show health score breakdown"** / "Hide score breakdown" to make it obvious it's not the concern list.
- Added `id="needs-attention"` + `scroll-mt-4` anchor on the Needs Attention FeedCard wrapper so the scroll lands cleanly.
- Kept the "hero=expanded" URL query param so the breakdown is still deep-linkable.

When `concernCount === 0` the label renders as a plain div ("All clear"), not a button — no pointer cursor on something that's not actionable.

## Why

A user reported: "the top status says 4 items need attention, but when I expand it I can only see three items that don't have 'All factors normal'." They were clicking the hero chevron expecting to see the 4 items and instead got the score breakdown. The fix keeps both affordances but makes their targets match the copy next to them.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 725 passing (no frontend tests touch this page; no regressions)
- [ ] Post-merge on VM: load dashboard, verify clicking the concern count scrolls to the Needs Attention card, and the separate "Show health score breakdown" button still expands + collapses per-host factors
- [ ] Verify `?hero=expanded` URL still opens the breakdown on load
- [ ] Healthy-state check: when `concernCount === 0` the label renders as plain text, chevron still works

## Non-goals

- Not merging the breakdown and the feed list into one UI (they show different data from different sources — unifying them is a separate redesign).
- No changes to `useFeedItems` or the underlying count logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)