### PR TITLE
fix(dashboard): exclude intentionally-stopped containers from downContainers

### DIFF
--- a/hub/src/web/queries.ts
+++ b/hub/src/web/queries.ts
@@ -461,6 +461,24 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
   `).all() as Array<{ host_id: string; container_name: string }>;
   const availRows: AvailabilityRow[] = [];
   if (activePairs.length > 0) {
+    // Skip containers whose latest snapshot is not 'running'. Mirrors the
+    // filter in hub/src/insights/detector.ts (PR #125): a currently-stopped
+    // container falls into one of three buckets, none of which want a
+    // "downtime" item on the dashboard:
+    //   1. Intentionally stopped (nginx/postgres/redis sitting exited for
+    //      weeks on proxmox-01) — pure noise, inflates concernCount.
+    //   2. Actively crashed — the container_unhealthy/container_down alert
+    //      path surfaces it via activeAlertsList.
+    //   3. Stopped moments ago — the alert will fire on the next evaluator
+    //      tick. No need to double-report it here.
+    // Only "was down briefly, is running again" is a legitimate entry in
+    // the availability feed, and that requires the latest snapshot to be
+    // running.
+    const latestStatusStmt = db.prepare(`
+      SELECT status FROM container_snapshots
+      WHERE host_id = ? AND container_name = ?
+      ORDER BY collected_at DESC LIMIT 1
+    `);
     const availStmt = db.prepare(`
       SELECT labels,
         COUNT(*) as total,
@@ -470,6 +488,9 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
         AND collected_at >= datetime('now', '-1 day')
     `);
     for (const pair of activePairs) {
+      const latest = latestStatusStmt.get(pair.host_id, pair.container_name) as
+        { status: string } | undefined;
+      if (!latest || latest.status !== 'running') continue;
       const row = availStmt.get(pair.host_id, pair.container_name) as
         { labels: string | null; total: number; running: number } | undefined;
       if (row && row.total > 0) {

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -256,6 +256,35 @@ describe('queries', () => {
       assert.equal(hs.score, 97);
     });
 
+    it('excludes intentionally-stopped containers from downContainers', () => {
+      // Simulates proxmox-01 with nginx sitting 'exited' for days — the agent
+      // still reports it every 5 min (docker ps -a), and the 24h availability
+      // query would show 0% uptime, but we don't want it in the feed.
+      seedHost(db, 'h1', recent);
+      // Seed 20 snapshots of an exited container, all within the last 24h and
+      // the most recent one inside the 15-minute active-pair window.
+      const snapshots: any[] = [];
+      for (let i = 0; i < 20; i++) {
+        const minutesAgo = 5 + i * 5;
+        snapshots.push({ hostId: 'h1', name: 'nginx', status: 'exited', at: ts(new Date(NOW - minutesAgo * 60 * 1000)) });
+      }
+      // Also seed a currently-running container with some historical dips
+      // (10 running + 2 exited = 83.3% uptime) — this SHOULD appear.
+      for (let i = 0; i < 10; i++) {
+        snapshots.push({ hostId: 'h1', name: 'webapp', status: 'running', at: ts(new Date(NOW - (5 + i * 5) * 60 * 1000)) });
+      }
+      snapshots.push({ hostId: 'h1', name: 'webapp', status: 'exited', at: ts(new Date(NOW - 60 * 60 * 1000)) });
+      snapshots.push({ hostId: 'h1', name: 'webapp', status: 'exited', at: ts(new Date(NOW - 65 * 60 * 1000)) });
+      seedContainerSnapshots(db, snapshots);
+
+      const dash = getDashboard(db, 10);
+      const downNames = dash.availability.downContainers.map((c: any) => c.name);
+      assert.ok(!downNames.includes('nginx'),
+        'intentionally-stopped nginx should not be in downContainers');
+      assert.ok(downNames.includes('webapp'),
+        'currently-running webapp with historical downtime should be in downContainers');
+    });
+
     it('leaves alerts factor alone when live count matches stored value', () => {
       seedHost(db, 'h1', recent);
       seedContainerSnapshots(db, [{ hostId: 'h1', name: 'nginx', status: 'running', at: recent }]);


### PR DESCRIPTION
## Summary

`hub/src/web/queries.ts::getDashboard` was populating `availability.downContainers` for any container whose 24h uptime percent was below 100 — including long-exited nginx/postgres/redis on proxmox-01 that the user hasn't touched in weeks. Those show 0/288 running over 24h and get pushed into the feed every dashboard refresh, inflating the "Needs Attention" count on a host whose health score reads 100 (all five factors normal).

This is the same bug pattern PR #125 fixed for the "had downtime" insight path in `hub/src/insights/detector.ts`. That fix never reached the dashboard's availability aggregation — they're parallel code paths with the same underlying query intent.

## Fix

Mirror detector.ts:256-260 in queries.ts: for each active pair, check the latest snapshot's status and skip the pair if it's not `running`. Currently-stopped containers fall into three buckets, none of which want a "downtime" card on the dashboard:

1. **Intentionally stopped** — noise, users don't expect them up.
2. **Actively crashed** — the `container_unhealthy`/`container_down` alert surfaces via `activeAlertsList` on the next evaluator tick.
3. **Stopped moments ago** — same alert path picks it up imminently.

Only _"was down briefly, is running again"_ is a legitimate retrospective entry, and that requires the latest row to be running.

## Verification on live data

Before writing the fix I queried the live DB (via a throwaway script) and confirmed the hypothesis exactly:

- **proxmox-01 health score = 100** — cpu 33.8%, memory 0.6%, load 1.6, online, 0 alerts. All factors `normal`.
- **nginx/postgres/redis latest snapshot**: all `status='exited'` at 2026-04-14 16:00:13 (3 min ago, so they pass the 15-min `activePairs` filter).
- **24h running/total**: 0/288 for each — pct = 0%, downMinutes ≈ 1440.
- **Active alerts**: none for any of the three (so the pre-existing `hasAlert` continue-check in `useFeedItems.ts` doesn't suppress them).

With the filter, all three are excluded from `downContainers` and `concernCount` drops by 3 on this host.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — **726 passing** (+1 new test in `tests/unit/queries.test.ts` covering both the exclusion and the positive case: a currently-running container with historical downtime still appears)
- [ ] Post-merge on VM: load dashboard for proxmox-01, verify nginx/postgres/redis no longer appear in the Needs Attention feed and `concernCount` reflects only real alerts
- [ ] Sanity: `availability.overallPercent` should go up slightly (the three 0% containers were pulling the average down)

## Non-goals

- No change to the `container_snapshots` storage or agent reporting — the agent still reports exited containers, the hub just doesn't surface them as a dashboard concern.
- No retroactive change to historical insights already persisted.
- No new setting — the behaviour is universally correct (if the user wants to track an intentionally-stopped container as "down", that's what alerts are for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)