### PR TITLE
agent: harden Kubernetes support (kubeletUrl, health output, warnings)

### DIFF
--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -20,6 +20,10 @@ const config = Object.freeze({
   nodeName: process.env.NODE_NAME || '',
   nodeIp: process.env.NODE_IP || '',
 
+  // Optional kubelet URL override. Defaults to https://${NODE_IP}:10250.
+  // Useful for k3s/flatcar or clusters where the kubelet listens on a non-standard port.
+  kubeletUrl: process.env.INSIGHTD_KUBELET_URL || '',
+
   // Docker
   dockerSocket: process.env.DOCKER_HOST || '/var/run/docker.sock',
 
@@ -54,6 +58,17 @@ function validate(): string[] {
   if (!config.mqttUrl) errors.push('INSIGHTD_MQTT_URL is required');
   if (!config.hostId || config.hostId === 'local') {
     errors.push('INSIGHTD_HOST_ID should be set to identify this host (e.g., "proxmox-01")');
+  }
+  // In Kubernetes mode, remote updates and container actions are not supported:
+  // pod lifecycle and image updates are managed by the cluster control plane.
+  // Warn the operator if they've turned these on so the intent is visible.
+  const isK8s = config.runtime === 'kubernetes'
+    || (config.runtime === 'auto' && !!process.env.KUBERNETES_SERVICE_HOST);
+  if (isK8s && config.allowUpdates) {
+    errors.push('INSIGHTD_ALLOW_UPDATES=true is ignored in Kubernetes mode (agent updates are managed by the cluster)');
+  }
+  if (isK8s && config.allowActions) {
+    errors.push('INSIGHTD_ALLOW_ACTIONS=true is ignored in Kubernetes mode (pod lifecycle is managed by the cluster)');
   }
   return errors;
 }

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -8,6 +8,7 @@ const { config, validate } = require('./config') as {
     runtime: 'auto' | 'docker' | 'containerd' | 'kubernetes';
     nodeName: string;
     nodeIp: string;
+    kubeletUrl: string;
     dockerSocket: string;
     mqttUrl: string;
     mqttUser: string;
@@ -43,6 +44,7 @@ async function main(): Promise<void> {
       allowActions: config.allowActions,
       nodeName: config.nodeName,
       nodeIp: config.nodeIp,
+      kubeletUrl: config.kubeletUrl,
     });
   } catch (err) {
     logger.error('runtime', 'Cannot initialize container runtime', err);

--- a/agent/src/runtime/index.ts
+++ b/agent/src/runtime/index.ts
@@ -15,6 +15,8 @@ export interface RuntimeOptions {
   nodeName?: string;
   /** K8s node IP (optional, used to construct kubelet URL). From NODE_IP env. */
   nodeIp?: string;
+  /** Explicit kubelet URL override. From INSIGHTD_KUBELET_URL env. */
+  kubeletUrl?: string;
 }
 
 /**
@@ -42,6 +44,7 @@ export async function getRuntime(options: RuntimeOptions): Promise<ContainerRunt
       runtime = new KubernetesRuntime({
         nodeName: options.nodeName,
         nodeIp: options.nodeIp,
+        kubeletUrl: options.kubeletUrl,
       });
       break;
     default:

--- a/agent/src/runtime/kubernetes.ts
+++ b/agent/src/runtime/kubernetes.ts
@@ -24,8 +24,8 @@ interface K8sMeta {
 
 interface K8sContainerState {
   running?: { startedAt?: string };
-  waiting?: { reason?: string };
-  terminated?: { reason?: string };
+  waiting?: { reason?: string; message?: string };
+  terminated?: { reason?: string; message?: string };
 }
 
 interface K8sContainerStatus {
@@ -33,6 +33,7 @@ interface K8sContainerStatus {
   ready: boolean;
   restartCount: number;
   state?: K8sContainerState;
+  lastState?: K8sContainerState;
   image: string;
 }
 
@@ -294,12 +295,25 @@ export class KubernetesRuntime implements ContainerRuntime {
           healthStatus = 'starting';
         }
 
+        // Parity with Docker's healthCheckOutput: surface the reason/message from
+        // the current waiting state or the most recent termination so "why" is
+        // visible in alerts + diagnosis findings.
+        const waiting = cs.state?.waiting;
+        const terminated = cs.state?.terminated ?? cs.lastState?.terminated;
+        let healthCheckOutput: string | null = null;
+        if (waiting?.reason) {
+          healthCheckOutput = (waiting.message ? `${waiting.reason}: ${waiting.message}` : waiting.reason).slice(0, 500);
+        } else if (terminated?.reason) {
+          healthCheckOutput = (terminated.message ? `${terminated.reason}: ${terminated.message}` : terminated.reason).slice(0, 500);
+        }
+
         containers.push({
           name,
           id,
           status,
           restartCount: cs.restartCount || 0,
           healthStatus,
+          healthCheckOutput,
           labels: { ...podLabels }, // container-level labels don't exist in K8s
           image: cs.image,
         });

--- a/docs/kubernetes-setup.md
+++ b/docs/kubernetes-setup.md
@@ -87,10 +87,14 @@ k3d cluster create my-cluster --servers-memory 4G --agents-memory 4G
 ## What's not supported in k8s mode
 
 - **Container actions** (start/stop/restart/remove) — these would require
-  managing pods/deployments, which is the cluster's job
-- **Image update checks** — Kubernetes manages image updates via
-  deployments and rollouts; checking digests against Docker Hub is not
-  meaningful in this context
+  managing pods/deployments, which is the cluster's job. Setting
+  `INSIGHTD_ALLOW_ACTIONS=true` has no effect; the agent will log a
+  warning at startup if you set it.
+- **Image update checks and remote updates** — Kubernetes manages image
+  updates via deployments and rollouts; checking digests against Docker
+  Hub is not meaningful in this context. Setting
+  `INSIGHTD_ALLOW_UPDATES=true` has no effect; the agent will log a
+  warning at startup if you set it.
 
 If you need to perform actions or check image updates, use the Docker
 runtime mode instead.
@@ -133,10 +137,10 @@ By default the agent talks to `https://${NODE_IP}:10250`. If your kubelet
 listens on a different port or you need to override the URL, set
 `INSIGHTD_KUBELET_URL` in the DaemonSet env vars.
 
-## Standalone (non-DaemonSet) mode
+## In-cluster only
 
-You can also run the agent outside the cluster pointing at a kubeconfig.
-Set `INSIGHTD_RUNTIME=kubernetes` and `NODE_NAME` to the node you want
-to monitor. The agent will use the default kubeconfig (`~/.kube/config` or
-`KUBECONFIG` env var) to authenticate. This mode is mainly useful for
-development and testing — for production, use the DaemonSet.
+The agent requires in-cluster service account credentials (mounted at
+`/var/run/secrets/kubernetes.io/serviceaccount/`) and the
+`KUBERNETES_SERVICE_HOST` env var that the kubelet injects automatically.
+Running the agent outside the cluster pointing at a kubeconfig is **not
+supported** — use the DaemonSet.

--- a/tests/unit/agent-config.test.ts
+++ b/tests/unit/agent-config.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const CONFIG_PATH = require.resolve('../../agent/src/config');
+
+// Snapshot env vars we mutate so tests can roll them back.
+const ENV_KEYS = [
+  'INSIGHTD_MQTT_URL',
+  'INSIGHTD_HOST_ID',
+  'INSIGHTD_RUNTIME',
+  'INSIGHTD_ALLOW_UPDATES',
+  'INSIGHTD_ALLOW_ACTIONS',
+  'INSIGHTD_KUBELET_URL',
+  'KUBERNETES_SERVICE_HOST',
+  'NODE_NAME',
+];
+
+function loadFresh(): { config: any; validate: () => string[] } {
+  delete require.cache[CONFIG_PATH];
+  return require('../../agent/src/config');
+}
+
+describe('agent config validate()', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    // Baseline: valid minimal config that passes the required-var checks.
+    process.env.INSIGHTD_MQTT_URL = 'mqtt://broker.test:1883';
+    process.env.INSIGHTD_HOST_ID = 'test-host';
+    delete process.env.INSIGHTD_RUNTIME;
+    delete process.env.INSIGHTD_ALLOW_UPDATES;
+    delete process.env.INSIGHTD_ALLOW_ACTIONS;
+    delete process.env.INSIGHTD_KUBELET_URL;
+    delete process.env.KUBERNETES_SERVICE_HOST;
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    delete require.cache[CONFIG_PATH];
+  });
+
+  it('returns no warnings for a valid Docker-mode config', () => {
+    const { validate } = loadFresh();
+    assert.deepEqual(validate(), []);
+  });
+
+  it('warns when allowUpdates=true in explicit kubernetes mode', () => {
+    process.env.INSIGHTD_RUNTIME = 'kubernetes';
+    process.env.INSIGHTD_ALLOW_UPDATES = 'true';
+    const { validate } = loadFresh();
+    const warnings = validate();
+    assert.ok(
+      warnings.some(w => w.includes('INSIGHTD_ALLOW_UPDATES') && w.includes('Kubernetes')),
+      `expected k8s update warning, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('warns when allowActions=true in explicit kubernetes mode', () => {
+    process.env.INSIGHTD_RUNTIME = 'kubernetes';
+    process.env.INSIGHTD_ALLOW_ACTIONS = 'true';
+    const { validate } = loadFresh();
+    const warnings = validate();
+    assert.ok(
+      warnings.some(w => w.includes('INSIGHTD_ALLOW_ACTIONS') && w.includes('Kubernetes')),
+      `expected k8s actions warning, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('warns when runtime=auto and KUBERNETES_SERVICE_HOST is set (in-cluster auto-detect)', () => {
+    process.env.INSIGHTD_RUNTIME = 'auto';
+    process.env.KUBERNETES_SERVICE_HOST = '10.96.0.1';
+    process.env.INSIGHTD_ALLOW_ACTIONS = 'true';
+    const { validate } = loadFresh();
+    const warnings = validate();
+    assert.ok(
+      warnings.some(w => w.includes('INSIGHTD_ALLOW_ACTIONS')),
+      `expected k8s actions warning for auto-detect, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('does not warn about allowActions in Docker mode', () => {
+    process.env.INSIGHTD_RUNTIME = 'docker';
+    process.env.INSIGHTD_ALLOW_ACTIONS = 'true';
+    const { validate } = loadFresh();
+    const warnings = validate();
+    assert.equal(
+      warnings.filter(w => w.includes('Kubernetes')).length,
+      0,
+      `no k8s warnings expected in docker mode, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('exposes INSIGHTD_KUBELET_URL on the config object', () => {
+    process.env.INSIGHTD_KUBELET_URL = 'https://override.local:10250';
+    const { config } = loadFresh();
+    assert.equal(config.kubeletUrl, 'https://override.local:10250');
+  });
+
+  it('defaults kubeletUrl to empty string when unset', () => {
+    const { config } = loadFresh();
+    assert.equal(config.kubeletUrl, '');
+  });
+});

--- a/tests/unit/kubernetes-runtime.test.ts
+++ b/tests/unit/kubernetes-runtime.test.ts
@@ -283,3 +283,116 @@ describe('KubernetesRuntime.getHostMetrics', () => {
     assert.equal(m!.memoryTotalMb, 7800);
   });
 });
+
+describe('KubernetesRuntime constructor: kubeletUrl precedence', () => {
+  it('uses explicit kubeletUrl when provided', () => {
+    const runtime: any = new KubernetesRuntime({
+      nodeName: 'n1',
+      nodeIp: '10.0.0.5',
+      kubeletUrl: 'https://kubelet.example:4443',
+    });
+    assert.equal(runtime.kubeletUrl, 'https://kubelet.example:4443');
+  });
+
+  it('falls back to https://${nodeIp}:10250 when kubeletUrl is not set', () => {
+    const runtime: any = new KubernetesRuntime({ nodeName: 'n1', nodeIp: '10.0.0.5' });
+    assert.equal(runtime.kubeletUrl, 'https://10.0.0.5:10250');
+  });
+
+  it('falls back to loopback when neither kubeletUrl nor nodeIp is set', () => {
+    const runtime: any = new KubernetesRuntime({ nodeName: 'n1' });
+    assert.equal(runtime.kubeletUrl, 'https://127.0.0.1:10250');
+  });
+
+  it('prefers explicit kubeletUrl over nodeIp-derived URL', () => {
+    const runtime: any = new KubernetesRuntime({
+      nodeName: 'n1',
+      nodeIp: '10.0.0.5',
+      kubeletUrl: 'https://override:12345',
+    });
+    assert.equal(runtime.kubeletUrl, 'https://override:12345');
+  });
+});
+
+describe('KubernetesRuntime.listContainers: healthCheckOutput extraction', () => {
+  // Build a runtime with a stubbed coreApi that returns the given pods.
+  function makeRuntime(pods: any[]): any {
+    const runtime: any = new KubernetesRuntime({ nodeName: 'k3d-test', nodeIp: '127.0.0.1' });
+    runtime.coreApi = {
+      listPods: async () => ({ items: pods }),
+    };
+    runtime.appsApi = runtime.coreApi;
+    return runtime;
+  }
+
+  function basePod(containerStatus: any): any {
+    return {
+      metadata: { name: 'crashloop', namespace: 'default', uid: 'uid-1', labels: {} },
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app',
+          ready: false,
+          restartCount: 3,
+          image: 'busybox:latest',
+          ...containerStatus,
+        }],
+      },
+    };
+  }
+
+  it('extracts reason+message from state.waiting', async () => {
+    const runtime = makeRuntime([basePod({
+      state: { waiting: { reason: 'CrashLoopBackOff', message: 'back-off 5m0s restarting failed container' } },
+    })]);
+    const containers = await runtime.listContainers();
+    assert.equal(containers.length, 1);
+    assert.equal(containers[0].healthCheckOutput, 'CrashLoopBackOff: back-off 5m0s restarting failed container');
+  });
+
+  it('extracts reason-only from state.waiting when message is missing', async () => {
+    const runtime = makeRuntime([basePod({
+      state: { waiting: { reason: 'ImagePullBackOff' } },
+    })]);
+    const containers = await runtime.listContainers();
+    assert.equal(containers[0].healthCheckOutput, 'ImagePullBackOff');
+  });
+
+  it('extracts from lastState.terminated when state is running', async () => {
+    const runtime = makeRuntime([basePod({
+      ready: true,
+      state: { running: { startedAt: new Date().toISOString() } },
+      lastState: { terminated: { reason: 'OOMKilled' } },
+    })]);
+    const containers = await runtime.listContainers();
+    assert.equal(containers[0].healthCheckOutput, 'OOMKilled');
+  });
+
+  it('prefers current state.waiting over lastState.terminated', async () => {
+    const runtime = makeRuntime([basePod({
+      state: { waiting: { reason: 'CrashLoopBackOff' } },
+      lastState: { terminated: { reason: 'Error', message: 'exit 1' } },
+    })]);
+    const containers = await runtime.listContainers();
+    assert.equal(containers[0].healthCheckOutput, 'CrashLoopBackOff');
+  });
+
+  it('returns null when neither waiting nor terminated has a reason', async () => {
+    const runtime = makeRuntime([basePod({
+      ready: true,
+      state: { running: { startedAt: new Date().toISOString() } },
+    })]);
+    const containers = await runtime.listContainers();
+    assert.equal(containers[0].healthCheckOutput, null);
+  });
+
+  it('truncates long messages to 500 chars for column parity with Docker', async () => {
+    const longMessage = 'x'.repeat(1000);
+    const runtime = makeRuntime([basePod({
+      state: { waiting: { reason: 'Error', message: longMessage } },
+    })]);
+    const containers = await runtime.listContainers();
+    assert.equal(containers[0].healthCheckOutput!.length, 500);
+    assert.ok(containers[0].healthCheckOutput!.startsWith('Error: xxxx'));
+  });
+});


### PR DESCRIPTION
## Summary

Three small fixes that close parity gaps between Docker and Kubernetes agent modes. None touch hub or schema — this is agent-only and ships as \`agent-v0.12.0\`.

- **Wire \`INSIGHTD_KUBELET_URL\` through** — the env var has been in \`docs/kubernetes-setup.md\` for a while, but \`config.ts\` never read it and \`runtime/index.ts\` never passed it to \`KubernetesRuntime\` (whose constructor already accepts it). Dead documentation, now live.
- **Warn on k8s-incompatible settings at startup** — \`INSIGHTD_ALLOW_UPDATES=true\` and \`INSIGHTD_ALLOW_ACTIONS=true\` were silently ignored in k8s mode. MQTT handlers still reject them at runtime, but operators never saw a warning that their intent was impossible. \`validate()\` now surfaces a warning covering both explicit \`runtime=kubernetes\` and auto-detected in-cluster (\`KUBERNETES_SERVICE_HOST\` set).
- **Extract \`healthCheckOutput\` from k8s pod state** — Docker agents capture Docker health-check output (PR #82, schema v19) and the v26 \`FindingCard\` + alert templates surface it. K8s containers left the field \`null\` even though \`state.waiting.reason/message\` and \`lastState.terminated.reason/message\` were right there. Containers in \`CrashLoopBackOff\` / \`ImagePullBackOff\` / \`OOMKilled\` now explain *why* in alerts and diagnosis.
- **Docs cleanup** — named the unsupported env vars in the "What's not supported" section and replaced the stale "Standalone (non-DaemonSet) mode" section that claimed kubeconfig support (the lightweight runtime rewrite requires in-cluster service account credentials).

## Test plan

- [x] \`npm test\` — 743/743 passing (+13 new tests for kubeletUrl precedence, validate warnings, healthCheckOutput extraction)
- [x] \`npm run typecheck\` — clean
- [ ] Deploy to k3d-insightd-test-server-0 and verify end-to-end:
  - [ ] \`kubectl -n insightd set env ds/insightd-agent INSIGHTD_KUBELET_URL=https://bogus:10250\` → agent logs connection errors targeting \`bogus\` (proves wire-through)
  - [ ] \`kubectl -n insightd set env ds/insightd-agent INSIGHTD_ALLOW_ACTIONS=true\` → startup logs the warning line
  - [ ] \`kubectl run crashloop --image=busybox -- /bin/false\` → container detail shows \`healthCheckOutput: CrashLoopBackOff: ...\` and the \`FindingCard\` surfaces the reason in its evidence

## Deferred follow-ups (not in this PR)

- Agent liveness/readiness probe on the DaemonSet (needs a \`/health\` endpoint first).
- k3d CI integration test harness.
- Pinning the DaemonSet image tag away from \`:latest\`.
- Hub/UI runtime-type gating so Restart/Stop buttons disable on k8s containers — separate PR, different version track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)