### PR TITLE
agent: map k8s non-transient waiting + failed termination to unhealthy

### DIFF
--- a/agent/src/runtime/kubernetes.ts
+++ b/agent/src/runtime/kubernetes.ts
@@ -61,6 +61,17 @@ interface K8sReplicaSet {
 
 interface K8sList<T> { items: T[] }
 
+/**
+ * Waiting reasons that represent normal startup. Anything not in this set
+ * (CrashLoopBackOff, ImagePullBackOff, ErrImagePull, CreateContainerError,
+ * CreateContainerConfigError, InvalidImageName, …) is treated as a failure
+ * and mapped to healthStatus='unhealthy' so alerts and diagnosis fire.
+ */
+const K8S_TRANSIENT_WAITING_REASONS = new Set<string>([
+  'ContainerCreating',
+  'PodInitializing',
+]);
+
 // ---- Lightweight K8s API client using raw HTTPS ----
 
 class K8sClient {
@@ -285,14 +296,25 @@ export class KubernetesRuntime implements ContainerRuntime {
         else if (cs.state?.waiting) status = cs.state.waiting.reason === 'Completed' ? 'exited' : 'created';
         else if (cs.state?.terminated) status = 'exited';
 
-        // Health: derive from ready flag + pod conditions
+        // Health: derive from ready flag + container state.
+        //
+        // A container in state.waiting is only "starting" while Kubernetes is
+        // genuinely bringing it up (ContainerCreating / PodInitializing).
+        // CrashLoopBackOff / ImagePullBackOff / ErrImagePull / CreateContainerError
+        // are failure states — the pod is stuck, not starting — so they must
+        // map to 'unhealthy' to trip the container_unhealthy alert. Similarly
+        // a terminated container with a non-Completed reason (OOMKilled, Error)
+        // is unhealthy, not neutral.
         let healthStatus: string | null = null;
         if (cs.ready) {
           healthStatus = 'healthy';
         } else if (cs.state?.running && !cs.ready) {
           healthStatus = 'unhealthy';
         } else if (cs.state?.waiting) {
-          healthStatus = 'starting';
+          const reason = cs.state.waiting.reason ?? '';
+          healthStatus = K8S_TRANSIENT_WAITING_REASONS.has(reason) ? 'starting' : 'unhealthy';
+        } else if (cs.state?.terminated && cs.state.terminated.reason && cs.state.terminated.reason !== 'Completed') {
+          healthStatus = 'unhealthy';
         }
 
         // Parity with Docker's healthCheckOutput: surface the reason/message from

--- a/tests/unit/kubernetes-runtime.test.ts
+++ b/tests/unit/kubernetes-runtime.test.ts
@@ -396,3 +396,78 @@ describe('KubernetesRuntime.listContainers: healthCheckOutput extraction', () =>
     assert.ok(containers[0].healthCheckOutput!.startsWith('Error: xxxx'));
   });
 });
+
+describe('KubernetesRuntime.listContainers: healthStatus mapping', () => {
+  function makeRuntime(pods: any[]): any {
+    const runtime: any = new KubernetesRuntime({ nodeName: 'k3d-test', nodeIp: '127.0.0.1' });
+    runtime.coreApi = { listPods: async () => ({ items: pods }) };
+    runtime.appsApi = runtime.coreApi;
+    return runtime;
+  }
+
+  function pod(containerStatus: any): any {
+    return {
+      metadata: { name: 'p', namespace: 'default', uid: 'uid-x', labels: {} },
+      status: {
+        phase: 'Running',
+        containerStatuses: [{
+          name: 'app', ready: false, restartCount: 0, image: 'busybox:latest',
+          ...containerStatus,
+        }],
+      },
+    };
+  }
+
+  it('maps running + ready to healthy', async () => {
+    const r = makeRuntime([pod({ ready: true, state: { running: { startedAt: new Date().toISOString() } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'healthy');
+  });
+
+  it('maps running + !ready to unhealthy', async () => {
+    const r = makeRuntime([pod({ ready: false, state: { running: { startedAt: new Date().toISOString() } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'unhealthy');
+  });
+
+  it('maps waiting + ContainerCreating to starting (genuine startup)', async () => {
+    const r = makeRuntime([pod({ state: { waiting: { reason: 'ContainerCreating' } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'starting');
+  });
+
+  it('maps waiting + PodInitializing to starting', async () => {
+    const r = makeRuntime([pod({ state: { waiting: { reason: 'PodInitializing' } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'starting');
+  });
+
+  it('maps waiting + CrashLoopBackOff to unhealthy (was incorrectly "starting")', async () => {
+    const r = makeRuntime([pod({
+      restartCount: 5,
+      state: { waiting: { reason: 'CrashLoopBackOff', message: 'back-off 5m0s restarting failed container' } },
+    })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'unhealthy');
+  });
+
+  it('maps waiting + ImagePullBackOff to unhealthy', async () => {
+    const r = makeRuntime([pod({ state: { waiting: { reason: 'ImagePullBackOff' } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'unhealthy');
+  });
+
+  it('maps waiting + ErrImagePull to unhealthy', async () => {
+    const r = makeRuntime([pod({ state: { waiting: { reason: 'ErrImagePull' } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'unhealthy');
+  });
+
+  it('maps terminated + OOMKilled to unhealthy', async () => {
+    const r = makeRuntime([pod({ state: { terminated: { reason: 'OOMKilled' } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'unhealthy');
+  });
+
+  it('maps terminated + Completed to null (clean exit, not unhealthy)', async () => {
+    const r = makeRuntime([pod({ state: { terminated: { reason: 'Completed' } } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, null);
+  });
+
+  it('maps waiting with no reason to unhealthy (failure by default)', async () => {
+    const r = makeRuntime([pod({ state: { waiting: {} } })]);
+    assert.equal((await r.listContainers())[0].healthStatus, 'unhealthy');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #141. While testing on \`k3d-insightd-test-server-0\` we noticed that a pod stuck in \`CrashLoopBackOff\` never produced a \`container_unhealthy\` alert. Root cause: the k8s runtime's health mapping treated **any** \`state.waiting\` as \`'starting'\`, including failure states.

\`\`\`ts
// before
else if (cs.state?.waiting) {
  healthStatus = 'starting';
}
\`\`\`

So a broken pod read as perpetually "starting", and both the hub's \`container_unhealthy\` alert and the v26 \`diagnoseUnified\` signal detectors (all of which key on \`health_status = 'unhealthy'\`) silently missed k8s pods.

**Fix:** only \`ContainerCreating\` and \`PodInitializing\` count as genuine startup. Everything else in \`state.waiting\` (\`CrashLoopBackOff\`, \`ImagePullBackOff\`, \`ErrImagePull\`, \`CreateContainerError\`, \`CreateContainerConfigError\`, \`InvalidImageName\`, etc.) maps to \`'unhealthy'\`. Also map \`state.terminated\` with a non-\`Completed\` reason (\`OOMKilled\`, \`Error\`) to \`'unhealthy'\` so crashed containers surface before they cycle back into waiting.

Since #141's \`healthCheckOutput\` extraction is already in place, the resulting alert message carries the reason automatically:

\`\`\`
Container "default/crashloop/crashloop" on k3d-worker1-0 is unhealthy — CrashLoopBackOff: back-off 5m0s restarting failed container
\`\`\`

## Test plan

- [x] \`npm test\` — 756/756 passing (+10 new health-status mapping tests covering healthy, running+!ready, ContainerCreating, PodInitializing, CrashLoopBackOff, ImagePullBackOff, ErrImagePull, OOMKilled, Completed, and bare-waiting-no-reason)
- [x] \`npm run typecheck\` clean
- [x] **End-to-end on k3d**: built agent from this branch, imported to \`insightd-test\`, created a BusyBox pod that exits with code 1. Verified:
  - \`/api/hosts/k3d-worker1-0/containers/default%2Fcrashloop%2Fcrashloop\` returned \`health_status: unhealthy\`
  - Alert fired on the next \`*/5\` evaluator tick: alert id 37, \`container_unhealthy\`, message \`"Container \"default/crashloop/crashloop\" on k3d-worker1-0 is unhealthy — Error"\`

## Edge cases covered

- \`Completed\` terminations (one-shot Jobs, init containers that finished) stay \`null\`, not \`'unhealthy'\` — they're not failures.
- A \`waiting\` state with no \`reason\` (malformed or missing) defaults to \`'unhealthy'\` since it can't be confirmed transient.
- Docker mode is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)