### PR TITLE
fix(alerts): preserve container alerts when the host itself goes offline

### DIFF
--- a/hub/src/alerts/evaluator.ts
+++ b/hub/src/alerts/evaluator.ts
@@ -359,15 +359,35 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
   const recentSnapshotStmt = db.prepare(
     "SELECT 1 FROM container_snapshots WHERE host_id = ? AND container_name = ? AND collected_at >= datetime('now', ?) LIMIT 1"
   );
+  const hostReportingStmt = db.prepare(
+    "SELECT 1 FROM hosts WHERE host_id = ? AND last_seen >= datetime('now', ?) LIMIT 1"
+  );
+
+  // Per-cycle cache of "is this host still reporting?" — one row lookup per
+  // unique host rather than per alert.
+  const hostReporting = new Map<string, boolean>();
+  const isHostReporting = (hostId: string): boolean => {
+    const cached = hostReporting.get(hostId);
+    if (cached !== undefined) return cached;
+    const row = hostReportingStmt.get(hostId, `-${STALE_CONTAINER_MINUTES} minutes`);
+    const reporting = !!row;
+    hostReporting.set(hostId, reporting);
+    return reporting;
+  };
 
   for (const alert of activeAlerts) {
     // Before running the type-specific resolver, auto-resolve any
     // container-scoped alert whose target hasn't been reported in the
-    // recency window. This closes the long-standing leak where a deleted
-    // container (Docker rm, k8s pod delete) would leave its last "bad"
-    // snapshot frozen in place forever, because the existing resolvers all
-    // look at that frozen snapshot and conclude "still bad".
-    if (CONTAINER_ALERT_TYPES.has(alert.alert_type)) {
+    // recency window. Closes the leak where a deleted container (Docker
+    // rm, k8s pod delete) leaves its last "bad" snapshot frozen forever.
+    //
+    // CRITICAL: only apply the "stale auto-resolve" path when the host
+    // itself is still reporting. If the whole agent went dark, every
+    // container on that host looks "stale" — auto-resolving their alerts
+    // would silently clear real failures and mislead the operator into
+    // thinking the problem was fixed. In that case we leave alerts in
+    // their current state so the host-offline situation stays visible.
+    if (CONTAINER_ALERT_TYPES.has(alert.alert_type) && isHostReporting(alert.host_id)) {
       const recent = recentSnapshotStmt.get(
         alert.host_id, alert.target, `-${STALE_CONTAINER_MINUTES} minutes`
       );

--- a/src/alerts/evaluator.ts
+++ b/src/alerts/evaluator.ts
@@ -273,15 +273,35 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
   const recentSnapshotStmt = db.prepare(
     "SELECT 1 FROM container_snapshots WHERE host_id = ? AND container_name = ? AND collected_at >= datetime('now', ?) LIMIT 1"
   );
+  const hostReportingStmt = db.prepare(
+    "SELECT 1 FROM hosts WHERE host_id = ? AND last_seen >= datetime('now', ?) LIMIT 1"
+  );
+
+  // Per-cycle cache of "is this host still reporting?" — one row lookup per
+  // unique host rather than per alert.
+  const hostReporting = new Map<string, boolean>();
+  const isHostReporting = (hostId: string): boolean => {
+    const cached = hostReporting.get(hostId);
+    if (cached !== undefined) return cached;
+    const row = hostReportingStmt.get(hostId, `-${STALE_CONTAINER_MINUTES} minutes`);
+    const reporting = !!row;
+    hostReporting.set(hostId, reporting);
+    return reporting;
+  };
 
   for (const alert of activeAlerts) {
     // Before running the type-specific resolver, auto-resolve any
     // container-scoped alert whose target hasn't been reported in the
-    // recency window. This closes the long-standing leak where a deleted
-    // container (Docker rm, k8s pod delete) would leave its last "bad"
-    // snapshot frozen in place forever, because the existing resolvers all
-    // look at that frozen snapshot and conclude "still bad".
-    if (CONTAINER_ALERT_TYPES.has(alert.alert_type)) {
+    // recency window. Closes the leak where a deleted container (Docker
+    // rm, k8s pod delete) leaves its last "bad" snapshot frozen forever.
+    //
+    // CRITICAL: only apply the "stale auto-resolve" path when the host
+    // itself is still reporting. If the whole agent went dark, every
+    // container on that host looks "stale" — auto-resolving their alerts
+    // would silently clear real failures and mislead the operator into
+    // thinking the problem was fixed. In that case we leave alerts in
+    // their current state so the host-offline situation stays visible.
+    if (CONTAINER_ALERT_TYPES.has(alert.alert_type) && isHostReporting(alert.host_id)) {
       const recent = recentSnapshotStmt.get(
         alert.host_id, alert.target, `-${STALE_CONTAINER_MINUTES} minutes`
       );

--- a/tests/unit/evaluator.test.ts
+++ b/tests/unit/evaluator.test.ts
@@ -255,10 +255,22 @@ describe('evaluateAlerts', () => {
     });
 
     describe('stale container auto-resolve', () => {
+      // Mark a host as "still reporting" by setting last_seen to now.
+      // Required for the auto-resolve path after the host-offline guard —
+      // a stale container alert only resolves when the HOST itself is
+      // currently reporting. Otherwise every alert on a dark agent would
+      // silently disappear.
+      const markHostAlive = (hostId: string = 'local') => {
+        db.prepare(
+          "INSERT OR REPLACE INTO hosts (host_id, first_seen, last_seen) VALUES (?, datetime('now', '-1 day'), datetime('now'))"
+        ).run(hostId);
+      };
+
       // An unhealthy container whose latest snapshot is older than the
       // 15-minute recency window counts as "gone" — pod was deleted,
       // agent stopped reporting, etc.
       it('resolves container_unhealthy when the container stops being reported', () => {
+        markHostAlive();
         const longAgo = ts(new Date(NOW - 30 * 60 * 1000)); // 30 min ago
         seedContainerSnapshots(db, [
           { name: 'crashloop', status: 'created', health: 'unhealthy', at: longAgo },
@@ -274,6 +286,7 @@ describe('evaluateAlerts', () => {
       });
 
       it('resolves restart_loop when the container stops being reported', () => {
+        markHostAlive();
         const longAgo = ts(new Date(NOW - 30 * 60 * 1000));
         seedContainerSnapshots(db, [
           { name: 'zombie', status: 'exited', at: longAgo },
@@ -288,6 +301,7 @@ describe('evaluateAlerts', () => {
       });
 
       it('does NOT auto-resolve when the container is still being reported', () => {
+        markHostAlive();
         // Snapshot from 5 min ago — well within the 15-min window, so the
         // container is still live. The existing container_unhealthy resolver
         // should still fire (or not) based on the actual health_status.
@@ -303,6 +317,28 @@ describe('evaluateAlerts', () => {
         const match = resolved.filter((a: any) => a.type === 'container_unhealthy');
         // Still unhealthy and still being reported → alert stays open.
         assert.equal(match.length, 0);
+      });
+
+      it('does NOT auto-resolve when the HOST is offline (agent went dark)', () => {
+        // The whole host stopped reporting 30 min ago — mark hosts.last_seen
+        // stale. A container alert on that host must NOT auto-resolve: the
+        // container is still in its last-known "bad" state, and silently
+        // clearing the alert would hide a real failure mode from the user.
+        const longAgo = ts(new Date(NOW - 30 * 60 * 1000));
+        db.prepare(
+          "INSERT OR REPLACE INTO hosts (host_id, first_seen, last_seen) VALUES (?, datetime('now', '-1 day'), ?)"
+        ).run('local', longAgo);
+
+        seedContainerSnapshots(db, [
+          { name: 'offline-container', status: 'running', health: 'unhealthy', at: longAgo },
+        ]);
+        seedAlertState(db, [
+          { type: 'container_unhealthy', target: 'offline-container', triggeredAt: longAgo, lastNotified: longAgo },
+        ]);
+
+        const { resolved } = evaluateAlerts(db, { alerts: alertsConfig });
+        const match = resolved.filter((a: any) => a.type === 'container_unhealthy');
+        assert.equal(match.length, 0, `alert must stay active when the host is offline, got: ${JSON.stringify(match)}`);
       });
 
       it('does NOT auto-resolve host-scoped alerts', () => {


### PR DESCRIPTION
## Summary

Correctness regression introduced by #146. Caught by the user with a very pointed question: *"if the agent is down in the k3d, then nothing will update right"* — which is exactly the failure mode.

**The bug #146 introduced.** \`checkResolutions\` auto-resolves container alerts when their target's latest snapshot is older than 15 minutes. That's correct for a single deleted container on an otherwise-healthy host. But when the whole agent goes dark (OOM, network partition, crash, reboot), **every** container on that host looks stale, and #146 would silently resolve every alert for them. The user-visible effect is the worst possible: a cascade of *"Container X is no longer reported (auto-resolved)"* resolution messages at precisely the moment the hub has the least visibility into what's actually happening.

**Fix.** Before taking the stale auto-resolve path, consult \`hosts.last_seen\` for the alert's host. If the host itself hasn't been seen in the same 15-minute window, skip the auto-resolve and let the type-specific resolver handle it — which will find the frozen "bad" snapshot and keep the alert active. Results cached in a per-cycle Map so each unique host costs one row lookup per evaluator tick, not one per alert.

Mirrored in both \`hub/src/alerts/evaluator.ts\` and \`src/alerts/evaluator.ts\` per the project convention.

## Test plan

- [x] \`npm test\` — 763/763 passing. The three existing #146 tests were updated to seed a fresh \`hosts\` row (they were implicitly relying on the bug). One new regression test confirms the specific host-offline path: container snapshot is 30 min stale AND host.last_seen is 30 min stale → alert **stays active**.
- [x] \`npm run typecheck\` clean
- [ ] Would normally verify end-to-end on k3d by stopping the DaemonSet and confirming alerts stay put, but that requires a 15+ min observation window — skipping to avoid blocking the review.

## Follow-up worth considering (not in this PR)

There's still no loud positive signal when a host goes dark. A dedicated \`host_offline\` alert type that fires when \`hosts.last_seen\` crosses a threshold would give the operator something to see instead of relying on the absence of noise. That's a new alert type with config, resolver logic, and UI — a separate PR if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)