### PR TITLE
fix(ingest): drop removed-container ghosts via containers registry (schema v27)

### DIFF
--- a/hub/src/alerts/evaluator.ts
+++ b/hub/src/alerts/evaluator.ts
@@ -376,11 +376,11 @@ const CONTAINER_ALERT_TYPES = new Set<string>([
   'container_unhealthy',
 ]);
 
-// Generous window for "agent stopped reporting this container". The default
-// collect interval is 5 minutes and the host detail page's live container
-// list uses the same 15-minute filter, so this stays consistent with what
-// the user already sees in the UI.
-const STALE_CONTAINER_MINUTES = 15;
+// Generous window for "is the agent itself still reporting?" — used as a
+// safety guard before auto-resolving container alerts on vanished targets.
+// If the whole agent went dark every container looks removed, and we want
+// the host-offline situation to stay visible instead.
+const HOST_REPORTING_MINUTES = 15;
 
 function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): AlertItem[] {
   const resolved: AlertItem[] = [];
@@ -388,8 +388,8 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
     'SELECT id, host_id, alert_type, target, triggered_at FROM alert_state WHERE resolved_at IS NULL'
   ).all() as { id: number; host_id: string; alert_type: string; target: string; triggered_at: string }[];
 
-  const recentSnapshotStmt = db.prepare(
-    "SELECT 1 FROM container_snapshots WHERE host_id = ? AND container_name = ? AND collected_at >= datetime('now', ?) LIMIT 1"
+  const containerRemovedStmt = db.prepare(
+    'SELECT removed_at FROM containers WHERE host_id = ? AND container_name = ?'
   );
   const hostReportingStmt = db.prepare(
     "SELECT 1 FROM hosts WHERE host_id = ? AND last_seen >= datetime('now', ?) LIMIT 1"
@@ -401,7 +401,7 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
   const isHostReporting = (hostId: string): boolean => {
     const cached = hostReporting.get(hostId);
     if (cached !== undefined) return cached;
-    const row = hostReportingStmt.get(hostId, `-${STALE_CONTAINER_MINUTES} minutes`);
+    const row = hostReportingStmt.get(hostId, `-${HOST_REPORTING_MINUTES} minutes`);
     const reporting = !!row;
     hostReporting.set(hostId, reporting);
     return reporting;
@@ -409,26 +409,24 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
 
   for (const alert of activeAlerts) {
     // Before running the type-specific resolver, auto-resolve any
-    // container-scoped alert whose target hasn't been reported in the
-    // recency window. Closes the leak where a deleted container (Docker
-    // rm, k8s pod delete) leaves its last "bad" snapshot frozen forever.
+    // container-scoped alert whose target has been removed (Docker rm,
+    // k8s pod delete, completed Job pod). The `containers` registry is
+    // the source of truth: `removed_at IS NOT NULL`, or no row at all,
+    // means the container is no longer present.
     //
-    // CRITICAL: only apply the "stale auto-resolve" path when the host
-    // itself is still reporting. If the whole agent went dark, every
-    // container on that host looks "stale" — auto-resolving their alerts
-    // would silently clear real failures and mislead the operator into
-    // thinking the problem was fixed. In that case we leave alerts in
-    // their current state so the host-offline situation stays visible.
+    // CRITICAL: only apply the stale auto-resolve path when the host
+    // itself is still reporting. If the whole agent went dark, we leave
+    // container alerts in their current state so the host-offline
+    // situation stays visible instead of being masked by mass resolutions.
     if (CONTAINER_ALERT_TYPES.has(alert.alert_type) && isHostReporting(alert.host_id)) {
-      const recent = recentSnapshotStmt.get(
-        alert.host_id, alert.target, `-${STALE_CONTAINER_MINUTES} minutes`
-      );
-      if (!recent) {
+      const row = containerRemovedStmt.get(alert.host_id, alert.target) as
+        { removed_at: string | null } | undefined;
+      if (!row || row.removed_at !== null) {
         resolved.push({
           type: alert.alert_type,
           hostId: alert.host_id,
           target: alert.target,
-          message: `Container "${alert.target}" on ${alert.host_id} is no longer reported by the agent (auto-resolved after ${STALE_CONTAINER_MINUTES}m)`,
+          message: `Container "${alert.target}" on ${alert.host_id} is no longer reported by the agent (auto-resolved)`,
           triggeredAt: alert.triggered_at,
           isResolution: true,
         });

--- a/hub/src/db/schema.ts
+++ b/hub/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import logger = require('../../../shared/utils/logger');
 
-const SCHEMA_VERSION = 26;
+const SCHEMA_VERSION = 27;
 
 function bootstrap(db: Database.Database): void {
   db.exec(`
@@ -41,6 +41,18 @@ function bootstrap(db: Database.Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_snapshots_host_name_time
       ON container_snapshots (host_id, container_name, collected_at);
+
+    CREATE TABLE IF NOT EXISTS containers (
+      host_id        TEXT NOT NULL,
+      container_name TEXT NOT NULL,
+      first_seen     TEXT NOT NULL DEFAULT (datetime('now')),
+      last_seen      TEXT NOT NULL DEFAULT (datetime('now')),
+      removed_at     TEXT,
+      PRIMARY KEY (host_id, container_name)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_containers_host_active
+      ON containers (host_id, removed_at);
 
     CREATE TABLE IF NOT EXISTS host_snapshots (
       id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -584,6 +596,23 @@ function migrate(db: Database.Database, fromVersion: number): void {
     try { db.exec('ALTER TABLE insight_feedback ADD COLUMN finding_hash TEXT'); } catch { /* already exists */ }
     // confidence_calibration table created via CREATE TABLE IF NOT EXISTS in bootstrap
   }
+  if (fromVersion < 27) {
+    // containers registry — one row per (host, container_name) with
+    // first_seen / last_seen / removed_at. Replaces the 15-minute staleness
+    // window that previously hid deleted containers in the UI.
+    //
+    // Backfill from container_snapshots: anything whose most recent snapshot
+    // is older than 15 minutes stays marked "removed" so the migration is a
+    // no-op for the live UI on first boot.
+    db.exec(`
+      INSERT INTO containers (host_id, container_name, first_seen, last_seen, removed_at)
+      SELECT host_id, container_name, MIN(collected_at), MAX(collected_at),
+             CASE WHEN MAX(collected_at) < datetime('now', '-15 minutes')
+                  THEN MAX(collected_at) ELSE NULL END
+      FROM container_snapshots
+      GROUP BY host_id, container_name
+    `);
+  }
 }
 
 /**
@@ -610,6 +639,7 @@ function pruneOldData(db: Database.Database, rawDays: number = 30, rollupDays: n
   const r5 = db.prepare(`DELETE FROM host_snapshots WHERE collected_at < ${rawCutoff}`).run();
   const r7 = db.prepare(`DELETE FROM http_checks WHERE checked_at < ${rawCutoff}`).run();
   const r8 = db.prepare(`DELETE FROM insight_feedback WHERE created_at < ${rawCutoff}`).run();
+  const rC = db.prepare(`DELETE FROM containers WHERE removed_at IS NOT NULL AND removed_at < ${rawCutoff}`).run();
   const r6 = db.prepare(`DELETE FROM hosts WHERE host_id NOT IN (
     SELECT DISTINCT host_id FROM container_snapshots WHERE collected_at >= ${rawCutoff}
     UNION SELECT DISTINCT host_id FROM host_snapshots WHERE collected_at >= ${rawCutoff}
@@ -623,7 +653,7 @@ function pruneOldData(db: Database.Database, rawDays: number = 30, rollupDays: n
   const r12 = db.prepare(`DELETE FROM http_rollups WHERE bucket < ${rollupCutoff}`).run();
 
   const total = r1.changes + r2.changes + r3.changes + r4.changes + r5.changes
-    + r6.changes + r7.changes + r8.changes + r9.changes + r10.changes + r11.changes + r12.changes;
+    + r6.changes + r7.changes + r8.changes + rC.changes + r9.changes + r10.changes + r11.changes + r12.changes;
 
   if (total > 0) {
     logger.info('schema', `Pruned ${total} rows (raw >${rawDays}d, rollups >${rollupDays}d)`);

--- a/hub/src/ingest.ts
+++ b/hub/src/ingest.ts
@@ -60,22 +60,45 @@ interface HostData {
 
 /**
  * Ingest collected container data into the database.
+ *
+ * Each published batch IS the authoritative "currently present" set for the
+ * host (agent/src/scheduler.ts only publishes on successful collection), so
+ * we diff against the `containers` registry: present containers are upserted
+ * with `removed_at = NULL`, and any previously-active row whose `last_seen`
+ * falls behind this batch is stamped with `removed_at`. That's how deleted
+ * containers stop appearing in the UI within one cycle instead of waiting
+ * out a 15-minute staleness window.
  */
 function ingestContainers(db: Database.Database, hostId: string, containers: ContainerSnapshot[]): void {
   const insert = db.prepare(`
     INSERT INTO container_snapshots (host_id, container_name, container_id, status, cpu_percent, memory_mb, restart_count, network_rx_bytes, network_tx_bytes, blkio_read_bytes, blkio_write_bytes, health_status, health_check_output, labels, collected_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const upsertRegistry = db.prepare(`
+    INSERT INTO containers (host_id, container_name, first_seen, last_seen, removed_at)
+    VALUES (?, ?, ?, ?, NULL)
+    ON CONFLICT(host_id, container_name) DO UPDATE SET
+      last_seen = excluded.last_seen,
+      removed_at = NULL
+  `);
+  const markRemoved = db.prepare(`
+    UPDATE containers
+       SET removed_at = ?
+     WHERE host_id = ? AND removed_at IS NULL AND last_seen < ?
   `);
 
-  const insertMany = db.transaction((items: ContainerSnapshot[]) => {
+  const ingestBatch = db.transaction((items: ContainerSnapshot[]) => {
+    const batchAt = (db.prepare("SELECT datetime('now') AS t").get() as { t: string }).t;
     for (const c of items) {
       const labels = typeof c.labels === 'object' ? JSON.stringify(c.labels) : (c.labels || null);
       insert.run(hostId, c.name, c.id, c.status, c.cpuPercent ?? null, c.memoryMb ?? null, c.restartCount,
-        c.networkRxBytes ?? null, c.networkTxBytes ?? null, c.blkioReadBytes ?? null, c.blkioWriteBytes ?? null, c.healthStatus ?? null, c.healthCheckOutput ?? null, labels);
+        c.networkRxBytes ?? null, c.networkTxBytes ?? null, c.blkioReadBytes ?? null, c.blkioWriteBytes ?? null, c.healthStatus ?? null, c.healthCheckOutput ?? null, labels, batchAt);
+      upsertRegistry.run(hostId, c.name, batchAt, batchAt);
     }
+    markRemoved.run(batchAt, hostId, batchAt);
   });
 
-  insertMany(containers);
+  ingestBatch(containers);
   logger.info('ingest', `Stored ${containers.length} container snapshots for ${hostId}`);
 }
 

--- a/hub/src/insights/detector.ts
+++ b/hub/src/insights/detector.ts
@@ -196,15 +196,13 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
   }
 
   // --- Container insights ---
-  // Only consider containers actively being reported. A 15-minute recency
-  // window matches the host-detail page's live container filter and the
-  // alert-evaluator's staleness cutoff (hub/src/alerts/evaluator.ts), so
-  // a removed container stops generating insights on the next tick instead
-  // of indefinitely regenerating "restarting frequently" and "is
-  // crash-looping" rows from historical snapshots.
+  // Only consider containers still present in the registry. A removed
+  // container's registry row has `removed_at` stamped on the next ingest
+  // cycle (hub/src/ingest.ts), so stale "restart loop" / "crash looping"
+  // insights stop regenerating one cycle after the container disappears.
   const containers = db.prepare(`
-    SELECT DISTINCT host_id, container_name FROM container_snapshots
-    WHERE collected_at >= datetime('now', '-15 minutes')
+    SELECT host_id, container_name FROM containers
+    WHERE removed_at IS NULL
   `).all() as ContainerIdRow[];
 
   for (const { host_id, container_name } of containers) {
@@ -320,13 +318,15 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
   }
 
   // --- Health check diagnoses (correlation-based) ---
-  // Only run diagnosis for containers whose latest snapshot is recent.
-  // Without this filter, a deleted container (Docker rm, k8s pod delete)
-  // whose last snapshot happened to be unhealthy keeps regenerating
-  // "is crash-looping" style insights on every */15 tick forever.
+  // Only run diagnosis for containers still present in the registry. A
+  // removed container's registry row is flagged `removed_at` on the next
+  // ingest (hub/src/ingest.ts), so its frozen "unhealthy" snapshot stops
+  // regenerating diagnoses one cycle after deletion.
   const unhealthyContainers = db.prepare(`
     SELECT cs.host_id, cs.container_name
     FROM container_snapshots cs
+    INNER JOIN containers c
+      ON c.host_id = cs.host_id AND c.container_name = cs.container_name
     INNER JOIN (
       SELECT host_id, container_name, MAX(collected_at) as max_at
       FROM container_snapshots GROUP BY host_id, container_name
@@ -334,7 +334,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
       AND cs.container_name = latest.container_name
       AND cs.collected_at = latest.max_at
     WHERE cs.health_status = 'unhealthy'
-      AND cs.collected_at >= datetime('now', '-15 minutes')
+      AND c.removed_at IS NULL
   `).all() as { host_id: string; container_name: string }[];
 
   const { runDiagnosis } = require('./diagnosis/run') as {

--- a/hub/src/web/queries.ts
+++ b/hub/src/web/queries.ts
@@ -301,17 +301,19 @@ function getHostDetail(db: Database.Database, hostId: string, onlineThresholdMin
 }
 
 function getLatestContainers(db: Database.Database, hostId: string, showInternal: boolean = false): ContainerRow[] {
-  // Only return containers seen in the last 15 minutes — drops "ghost" entries
-  // for containers that were once reported but have since been deleted or
-  // filtered out (e.g. completed K8s Job pods, removed Docker containers).
-  // Historical snapshots stay in the DB for the timeline view; this only
-  // affects the current host detail view.
+  // Return the latest snapshot for every container currently present on the
+  // host, per the `containers` registry. Containers whose latest batch no
+  // longer lists them (Docker rm, k8s pod delete, completed Job pods) have
+  // `removed_at` set by `ingestContainers` and are excluded here. Historical
+  // snapshots stay in the DB for the timeline view.
   const rows = db.prepare(`
     SELECT cs.container_name, cs.container_id, cs.status,
            cs.cpu_percent, cs.memory_mb, cs.restart_count,
            cs.network_rx_bytes, cs.network_tx_bytes, cs.blkio_read_bytes, cs.blkio_write_bytes,
            cs.health_status, cs.health_check_output, cs.labels, cs.collected_at
     FROM container_snapshots cs
+    INNER JOIN containers c
+      ON c.host_id = cs.host_id AND c.container_name = cs.container_name
     INNER JOIN (
       SELECT host_id, container_name, MAX(collected_at) as max_at
       FROM container_snapshots WHERE host_id = ?
@@ -319,9 +321,9 @@ function getLatestContainers(db: Database.Database, hostId: string, showInternal
     ) latest ON cs.host_id = latest.host_id
       AND cs.container_name = latest.container_name
       AND cs.collected_at = latest.max_at
-    WHERE cs.collected_at > datetime('now', '-15 minutes')
+    WHERE c.host_id = ? AND c.removed_at IS NULL
     ORDER BY cs.container_name
-  `).all(hostId) as ContainerRow[];
+  `).all(hostId, hostId) as ContainerRow[];
   if (showInternal) return rows;
   return rows.filter(r => {
     if (!r.labels) return true;
@@ -389,6 +391,8 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
   const allContainers = db.prepare(`
     SELECT cs.status, cs.labels
     FROM container_snapshots cs
+    INNER JOIN containers c
+      ON c.host_id = cs.host_id AND c.container_name = cs.container_name
     INNER JOIN (
       SELECT host_id as h, container_name as cn, MAX(collected_at) as max_at
       FROM container_snapshots
@@ -396,7 +400,7 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
     ) latest ON cs.host_id = latest.h
       AND cs.container_name = latest.cn
       AND cs.collected_at = latest.max_at
-    WHERE cs.collected_at > datetime('now', '-15 minutes')
+    WHERE c.removed_at IS NULL
   `).all() as ContainerStatusRow[];
   const filtered = showInternal ? allContainers : allContainers.filter(c => {
     if (!c.labels) return true;
@@ -449,15 +453,14 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
     groups = groupQueries.getGroups(db, showInternal);
   } catch { /* group queries not available */ }
 
-  // 24h availability per container — only for containers still being reported.
-  // Two-pass to avoid a correlated EXISTS over the snapshot table: first get
-  // the set of (host,name) pairs active in the last 15 min, then aggregate
-  // 24h stats filtered to that set. Joining via a temp table is much cheaper
-  // than re-evaluating EXISTS for every matching row.
+  // 24h availability per container — only for containers still present in
+  // the registry. Two-pass to avoid a correlated EXISTS over the snapshot
+  // table: first get the set of active (host,name) pairs, then aggregate
+  // 24h stats filtered to that set.
   const activePairs = db.prepare(`
-    SELECT DISTINCT host_id, container_name
-    FROM container_snapshots
-    WHERE collected_at > datetime('now', '-15 minutes')
+    SELECT host_id, container_name
+    FROM containers
+    WHERE removed_at IS NULL
   `).all() as Array<{ host_id: string; container_name: string }>;
   const availRows: AvailabilityRow[] = [];
   if (activePairs.length > 0) {

--- a/src/alerts/evaluator.ts
+++ b/src/alerts/evaluator.ts
@@ -289,11 +289,11 @@ const CONTAINER_ALERT_TYPES = new Set<string>([
   'container_unhealthy',
 ]);
 
-// Generous window for "agent stopped reporting this container". The default
-// collect interval is 5 minutes and the host detail page's live container
-// list uses the same 15-minute filter, so this stays consistent with what
-// the user already sees in the UI.
-const STALE_CONTAINER_MINUTES = 15;
+// Generous window for "is the agent itself still reporting?" — used as a
+// safety guard before auto-resolving container alerts on vanished targets.
+// If the whole agent went dark every container looks removed, and we want
+// the host-offline situation to stay visible instead.
+const HOST_REPORTING_MINUTES = 15;
 
 function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): AlertItem[] {
   const resolved: AlertItem[] = [];
@@ -301,8 +301,8 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
     'SELECT id, host_id, alert_type, target, triggered_at FROM alert_state WHERE resolved_at IS NULL'
   ).all() as { id: number; host_id: string; alert_type: string; target: string; triggered_at: string }[];
 
-  const recentSnapshotStmt = db.prepare(
-    "SELECT 1 FROM container_snapshots WHERE host_id = ? AND container_name = ? AND collected_at >= datetime('now', ?) LIMIT 1"
+  const containerRemovedStmt = db.prepare(
+    'SELECT removed_at FROM containers WHERE host_id = ? AND container_name = ?'
   );
   const hostReportingStmt = db.prepare(
     "SELECT 1 FROM hosts WHERE host_id = ? AND last_seen >= datetime('now', ?) LIMIT 1"
@@ -314,7 +314,7 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
   const isHostReporting = (hostId: string): boolean => {
     const cached = hostReporting.get(hostId);
     if (cached !== undefined) return cached;
-    const row = hostReportingStmt.get(hostId, `-${STALE_CONTAINER_MINUTES} minutes`);
+    const row = hostReportingStmt.get(hostId, `-${HOST_REPORTING_MINUTES} minutes`);
     const reporting = !!row;
     hostReporting.set(hostId, reporting);
     return reporting;
@@ -322,26 +322,24 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
 
   for (const alert of activeAlerts) {
     // Before running the type-specific resolver, auto-resolve any
-    // container-scoped alert whose target hasn't been reported in the
-    // recency window. Closes the leak where a deleted container (Docker
-    // rm, k8s pod delete) leaves its last "bad" snapshot frozen forever.
+    // container-scoped alert whose target has been removed (Docker rm,
+    // k8s pod delete, completed Job pod). The `containers` registry is
+    // the source of truth: `removed_at IS NOT NULL`, or no row at all,
+    // means the container is no longer present.
     //
-    // CRITICAL: only apply the "stale auto-resolve" path when the host
-    // itself is still reporting. If the whole agent went dark, every
-    // container on that host looks "stale" — auto-resolving their alerts
-    // would silently clear real failures and mislead the operator into
-    // thinking the problem was fixed. In that case we leave alerts in
-    // their current state so the host-offline situation stays visible.
+    // CRITICAL: only apply the stale auto-resolve path when the host
+    // itself is still reporting. If the whole agent went dark, we leave
+    // container alerts in their current state so the host-offline
+    // situation stays visible instead of being masked by mass resolutions.
     if (CONTAINER_ALERT_TYPES.has(alert.alert_type) && isHostReporting(alert.host_id)) {
-      const recent = recentSnapshotStmt.get(
-        alert.host_id, alert.target, `-${STALE_CONTAINER_MINUTES} minutes`
-      );
-      if (!recent) {
+      const row = containerRemovedStmt.get(alert.host_id, alert.target) as
+        { removed_at: string | null } | undefined;
+      if (!row || row.removed_at !== null) {
         resolved.push({
           type: alert.alert_type,
           hostId: alert.host_id,
           target: alert.target,
-          message: `Container "${alert.target}" on ${alert.host_id} is no longer reported by the agent (auto-resolved after ${STALE_CONTAINER_MINUTES}m)`,
+          message: `Container "${alert.target}" on ${alert.host_id} is no longer reported by the agent (auto-resolved)`,
           triggeredAt: alert.triggered_at,
           isResolution: true,
         });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import logger = require('../utils/logger');
 
-const SCHEMA_VERSION = 26;
+const SCHEMA_VERSION = 27;
 
 function bootstrap(db: Database.Database): void {
   db.exec(`
@@ -41,6 +41,18 @@ function bootstrap(db: Database.Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_snapshots_host_name_time
       ON container_snapshots (host_id, container_name, collected_at);
+
+    CREATE TABLE IF NOT EXISTS containers (
+      host_id        TEXT NOT NULL,
+      container_name TEXT NOT NULL,
+      first_seen     TEXT NOT NULL DEFAULT (datetime('now')),
+      last_seen      TEXT NOT NULL DEFAULT (datetime('now')),
+      removed_at     TEXT,
+      PRIMARY KEY (host_id, container_name)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_containers_host_active
+      ON containers (host_id, removed_at);
 
     CREATE TABLE IF NOT EXISTS host_snapshots (
       id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -584,6 +596,23 @@ function migrate(db: Database.Database, fromVersion: number): void {
     try { db.exec('ALTER TABLE insight_feedback ADD COLUMN finding_hash TEXT'); } catch { /* already exists */ }
     // confidence_calibration table created via CREATE TABLE IF NOT EXISTS in bootstrap
   }
+  if (fromVersion < 27) {
+    // containers registry — one row per (host, container_name) with
+    // first_seen / last_seen / removed_at. Replaces the 15-minute staleness
+    // window that previously hid deleted containers in the UI.
+    //
+    // Backfill from container_snapshots: anything whose most recent snapshot
+    // is older than 15 minutes stays marked "removed" so the migration is a
+    // no-op for the live UI on first boot.
+    db.exec(`
+      INSERT INTO containers (host_id, container_name, first_seen, last_seen, removed_at)
+      SELECT host_id, container_name, MIN(collected_at), MAX(collected_at),
+             CASE WHEN MAX(collected_at) < datetime('now', '-15 minutes')
+                  THEN MAX(collected_at) ELSE NULL END
+      FROM container_snapshots
+      GROUP BY host_id, container_name
+    `);
+  }
 }
 
 /**
@@ -610,6 +639,7 @@ function pruneOldData(db: Database.Database, rawDays: number = 30, rollupDays: n
   const r5 = db.prepare(`DELETE FROM host_snapshots WHERE collected_at < ${rawCutoff}`).run();
   const r7 = db.prepare(`DELETE FROM http_checks WHERE checked_at < ${rawCutoff}`).run();
   const r8 = db.prepare(`DELETE FROM insight_feedback WHERE created_at < ${rawCutoff}`).run();
+  const rC = db.prepare(`DELETE FROM containers WHERE removed_at IS NOT NULL AND removed_at < ${rawCutoff}`).run();
   const r6 = db.prepare(`DELETE FROM hosts WHERE host_id NOT IN (
     SELECT DISTINCT host_id FROM container_snapshots WHERE collected_at >= ${rawCutoff}
     UNION SELECT DISTINCT host_id FROM host_snapshots WHERE collected_at >= ${rawCutoff}
@@ -623,7 +653,7 @@ function pruneOldData(db: Database.Database, rawDays: number = 30, rollupDays: n
   const r12 = db.prepare(`DELETE FROM http_rollups WHERE bucket < ${rollupCutoff}`).run();
 
   const total = r1.changes + r2.changes + r3.changes + r4.changes + r5.changes
-    + r6.changes + r7.changes + r8.changes + r9.changes + r10.changes + r11.changes + r12.changes;
+    + r6.changes + r7.changes + r8.changes + rC.changes + r9.changes + r10.changes + r11.changes + r12.changes;
 
   if (total > 0) {
     logger.info('schema', `Pruned ${total} rows (raw >${rawDays}d, rollups >${rollupDays}d)`);

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -28,21 +28,43 @@ interface UpdateResult {
 
 /**
  * Ingest collected container data into the database.
+ *
+ * Each published batch IS the authoritative "currently present" set for the
+ * host, so we diff against the `containers` registry: present containers are
+ * upserted with `removed_at = NULL`, and any previously-active row whose
+ * `last_seen` falls behind this batch is stamped with `removed_at`. That's
+ * how deleted containers stop appearing in the UI within one cycle instead
+ * of waiting out a 15-minute staleness window.
  */
 function ingestContainers(db: Database.Database, hostId: string, containers: ContainerSnapshot[]): void {
   const insert = db.prepare(`
     INSERT INTO container_snapshots (host_id, container_name, container_id, status, cpu_percent, memory_mb, restart_count, labels, collected_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const upsertRegistry = db.prepare(`
+    INSERT INTO containers (host_id, container_name, first_seen, last_seen, removed_at)
+    VALUES (?, ?, ?, ?, NULL)
+    ON CONFLICT(host_id, container_name) DO UPDATE SET
+      last_seen = excluded.last_seen,
+      removed_at = NULL
+  `);
+  const markRemoved = db.prepare(`
+    UPDATE containers
+       SET removed_at = ?
+     WHERE host_id = ? AND removed_at IS NULL AND last_seen < ?
   `);
 
-  const insertMany = db.transaction((items: ContainerSnapshot[]) => {
+  const ingestBatch = db.transaction((items: ContainerSnapshot[]) => {
+    const batchAt = (db.prepare("SELECT datetime('now') AS t").get() as { t: string }).t;
     for (const c of items) {
       const labels = typeof c.labels === 'object' ? JSON.stringify(c.labels) : (c.labels || null);
-      insert.run(hostId, c.name, c.id, c.status, c.cpuPercent ?? null, c.memoryMb ?? null, c.restartCount, labels);
+      insert.run(hostId, c.name, c.id, c.status, c.cpuPercent ?? null, c.memoryMb ?? null, c.restartCount, labels, batchAt);
+      upsertRegistry.run(hostId, c.name, batchAt, batchAt);
     }
+    markRemoved.run(batchAt, hostId, batchAt);
   });
 
-  insertMany(containers);
+  ingestBatch(containers);
   logger.info('ingest', `Stored ${containers.length} container snapshots for ${hostId}`);
 }
 

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -8,6 +8,15 @@ interface ContainerSnapshotSeed {
   netRx?: number | null; netTx?: number | null;
   blkRead?: number | null; blkWrite?: number | null;
   health?: string | null; at: string;
+  // When true, skip upserting into the `containers` registry — use this to
+  // simulate a container that has been removed (Docker rm, k8s pod delete)
+  // but whose historical snapshots are still in the DB.
+  removed?: boolean;
+}
+
+interface ContainerRegistrySeed {
+  hostId?: string; name: string;
+  firstSeen?: string; lastSeen?: string; removedAt?: string | null;
 }
 
 interface HostSnapshotSeed {
@@ -79,10 +88,48 @@ function seedContainerSnapshots(db: Database.Database, rows: ContainerSnapshotSe
     (host_id, container_name, container_id, status, cpu_percent, memory_mb, restart_count, network_rx_bytes, network_tx_bytes, blkio_read_bytes, blkio_write_bytes, health_status, collected_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
+  // Production ingest always pairs snapshot inserts with a registry upsert.
+  // Mirror that here so tests that call seedContainerSnapshots get a live
+  // `containers` row for free — otherwise every query that joins the
+  // registry returns empty. Pass `removed: true` on a seed row to simulate
+  // a container whose last snapshot is frozen but whose registry row is
+  // either absent or marked removed_at.
+  const upsert = db.prepare(`
+    INSERT INTO containers (host_id, container_name, first_seen, last_seen, removed_at)
+    VALUES (?, ?, ?, ?, NULL)
+    ON CONFLICT(host_id, container_name) DO UPDATE SET
+      last_seen = MAX(containers.last_seen, excluded.last_seen),
+      first_seen = MIN(containers.first_seen, excluded.first_seen),
+      removed_at = NULL
+  `);
   for (const r of rows) {
-    insert.run(r.hostId || 'local', r.name, r.id || 'abc123', r.status || 'running', r.cpu ?? null, r.mem ?? null, r.restarts ?? 0,
+    const hostId = r.hostId || 'local';
+    insert.run(hostId, r.name, r.id || 'abc123', r.status || 'running', r.cpu ?? null, r.mem ?? null, r.restarts ?? 0,
       r.netRx ?? null, r.netTx ?? null, r.blkRead ?? null, r.blkWrite ?? null, r.health ?? null, r.at);
+    if (!r.removed) {
+      upsert.run(hostId, r.name, r.at, r.at);
+    }
   }
+}
+
+function seedContainers(db: Database.Database, rows: ContainerRegistrySeed[]): void {
+  const insert = db.prepare(`
+    INSERT INTO containers (host_id, container_name, first_seen, last_seen, removed_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(host_id, container_name) DO UPDATE SET
+      first_seen = excluded.first_seen,
+      last_seen = excluded.last_seen,
+      removed_at = excluded.removed_at
+  `);
+  for (const r of rows) {
+    const at = r.lastSeen || r.firstSeen || "datetime('now')";
+    insert.run(r.hostId || 'local', r.name, r.firstSeen || at, r.lastSeen || at, r.removedAt ?? null);
+  }
+}
+
+function markContainerRemoved(db: Database.Database, hostId: string, name: string, removedAt?: string): void {
+  db.prepare("UPDATE containers SET removed_at = ? WHERE host_id = ? AND container_name = ?")
+    .run(removedAt || new Date().toISOString().slice(0, 19).replace('T', ' '), hostId, name);
 }
 
 function seedHostSnapshots(db: Database.Database, rows: HostSnapshotSeed[]): void {
@@ -204,4 +251,4 @@ function seedHealthScores(db: Database.Database, rows: HealthScoreSeed[]): void 
   }
 }
 
-module.exports = { createTestDb, seedContainerSnapshots, seedDiskSnapshots, seedUpdateChecks, seedAlertState, seedHostSnapshots, seedHttpEndpoints, seedHttpChecks, seedWebhooks, seedServiceGroups, seedGroupMembers, seedBaselines, seedHealthScores };
+module.exports = { createTestDb, seedContainerSnapshots, seedContainers, markContainerRemoved, seedDiskSnapshots, seedUpdateChecks, seedAlertState, seedHostSnapshots, seedHttpEndpoints, seedHttpChecks, seedWebhooks, seedServiceGroups, seedGroupMembers, seedBaselines, seedHealthScores };

--- a/tests/integration/web-api.test.ts
+++ b/tests/integration/web-api.test.ts
@@ -78,7 +78,7 @@ describe('Web API integration', () => {
     assert.equal(res.status, 200);
     const data = res.json();
     assert.equal(data.status, 'ok');
-    assert.equal(data.schemaVersion, 26);
+    assert.equal(data.schemaVersion, 27);
   });
 
   it('GET /api/hosts returns host list', async () => {

--- a/tests/unit/containers-registry.test.ts
+++ b/tests/unit/containers-registry.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+const { createTestDb } = require('../helpers/db');
+
+const { ingestContainers } = require('../../hub/src/ingest') as {
+  ingestContainers: (db: any, hostId: string, containers: any[]) => void;
+};
+
+interface ContainerSeed {
+  name: string;
+  id?: string;
+  status?: string;
+  restartCount?: number;
+}
+
+function batch(names: string[]): ContainerSeed[] {
+  return names.map(n => ({ name: n, id: `id-${n}`, status: 'running', restartCount: 0 }));
+}
+
+function registryRow(db: any, hostId: string, name: string): { first_seen: string; last_seen: string; removed_at: string | null } | undefined {
+  return db.prepare(
+    'SELECT first_seen, last_seen, removed_at FROM containers WHERE host_id = ? AND container_name = ?'
+  ).get(hostId, name);
+}
+
+describe('containers registry', () => {
+  let db: any;
+
+  beforeEach(() => { db = createTestDb(); });
+  afterEach(() => { db.close(); });
+
+  it('creates a registry row for every container in the first batch', () => {
+    ingestContainers(db, 'h1', batch(['a', 'b', 'c']));
+
+    const rows = db.prepare("SELECT container_name, removed_at FROM containers WHERE host_id = 'h1' ORDER BY container_name").all();
+    assert.deepEqual(rows.map((r: any) => r.container_name), ['a', 'b', 'c']);
+    for (const r of rows) assert.equal(r.removed_at, null);
+  });
+
+  it('marks containers removed when they vanish from the next batch', () => {
+    ingestContainers(db, 'h1', batch(['a', 'b', 'c']));
+    // Force a noticeable gap so last_seen < new batchAt even with coarse second-granularity clocks
+    db.prepare("UPDATE containers SET last_seen = datetime('now', '-10 seconds') WHERE host_id = 'h1'").run();
+
+    ingestContainers(db, 'h1', batch(['a', 'c']));
+
+    assert.equal(registryRow(db, 'h1', 'a')?.removed_at, null);
+    assert.notEqual(registryRow(db, 'h1', 'b')?.removed_at, null);
+    assert.equal(registryRow(db, 'h1', 'c')?.removed_at, null);
+  });
+
+  it('clears removed_at when a previously-removed container reappears', () => {
+    ingestContainers(db, 'h1', batch(['a', 'b']));
+    db.prepare("UPDATE containers SET last_seen = datetime('now', '-10 seconds') WHERE host_id = 'h1'").run();
+    ingestContainers(db, 'h1', batch(['a']));
+    assert.notEqual(registryRow(db, 'h1', 'b')?.removed_at, null);
+
+    db.prepare("UPDATE containers SET last_seen = datetime('now', '-5 seconds') WHERE host_id = 'h1' AND container_name = 'a'").run();
+    ingestContainers(db, 'h1', batch(['a', 'b']));
+
+    assert.equal(registryRow(db, 'h1', 'a')?.removed_at, null);
+    assert.equal(registryRow(db, 'h1', 'b')?.removed_at, null);
+  });
+
+  it('marks all containers removed when an empty batch arrives', () => {
+    ingestContainers(db, 'h1', batch(['a', 'b', 'c']));
+    db.prepare("UPDATE containers SET last_seen = datetime('now', '-10 seconds') WHERE host_id = 'h1'").run();
+
+    ingestContainers(db, 'h1', []);
+
+    for (const name of ['a', 'b', 'c']) {
+      assert.notEqual(registryRow(db, 'h1', name)?.removed_at, null, `${name} should be removed`);
+    }
+  });
+
+  it('only diffs within a single host — other hosts are untouched', () => {
+    ingestContainers(db, 'h1', batch(['a', 'b']));
+    ingestContainers(db, 'h2', batch(['x', 'y']));
+    db.prepare("UPDATE containers SET last_seen = datetime('now', '-10 seconds')").run();
+
+    ingestContainers(db, 'h1', batch(['a']));
+
+    assert.equal(registryRow(db, 'h1', 'a')?.removed_at, null);
+    assert.notEqual(registryRow(db, 'h1', 'b')?.removed_at, null);
+    assert.equal(registryRow(db, 'h2', 'x')?.removed_at, null, 'h2 containers must not be affected');
+    assert.equal(registryRow(db, 'h2', 'y')?.removed_at, null, 'h2 containers must not be affected');
+  });
+
+  it('preserves first_seen across re-sightings', () => {
+    ingestContainers(db, 'h1', batch(['a']));
+    const firstSeenA = registryRow(db, 'h1', 'a')?.first_seen;
+    assert.ok(firstSeenA);
+
+    // Simulate time passing, remove and re-add
+    db.prepare("UPDATE containers SET last_seen = datetime('now', '-10 seconds') WHERE host_id = 'h1'").run();
+    ingestContainers(db, 'h1', []);
+    assert.notEqual(registryRow(db, 'h1', 'a')?.removed_at, null);
+
+    ingestContainers(db, 'h1', batch(['a']));
+    const row = registryRow(db, 'h1', 'a');
+    assert.equal(row?.removed_at, null);
+    assert.equal(row?.first_seen, firstSeenA, 'first_seen must be preserved across re-add');
+  });
+
+  it('ingest is transactional — a failure inside the batch rolls back registry changes', () => {
+    ingestContainers(db, 'h1', batch(['a', 'b']));
+    db.prepare("UPDATE containers SET last_seen = datetime('now', '-10 seconds') WHERE host_id = 'h1'").run();
+
+    // Force a constraint violation on the snapshot insert by passing an
+    // invalid status type (not a string). Any thrown error inside the
+    // transaction should roll back both the insert and the markRemoved.
+    assert.throws(() => {
+      ingestContainers(db, 'h1', [
+        { name: 'a', id: 'id-a', status: 'running', restartCount: 0 },
+        { name: 'b', id: 'id-b', status: { invalid: true } as unknown as string, restartCount: 0 },
+      ]);
+    });
+
+    // 'a' should still have its original last_seen (not bumped) and both
+    // should still be present (not marked removed), because the whole batch
+    // rolled back.
+    const a = registryRow(db, 'h1', 'a');
+    const b = registryRow(db, 'h1', 'b');
+    assert.equal(a?.removed_at, null);
+    assert.equal(b?.removed_at, null);
+  });
+});
+
+describe('containers registry — v27 backfill', () => {
+  it('backfills existing container_snapshots on migration from v26', () => {
+    const Database = require('better-sqlite3');
+    const db = new Database(':memory:');
+    db.pragma('journal_mode = WAL');
+
+    // Hand-built v26 schema subset — just enough to exercise the backfill.
+    db.exec(`
+      CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      CREATE TABLE hosts (host_id TEXT PRIMARY KEY, first_seen TEXT, last_seen TEXT, agent_version TEXT, runtime_type TEXT DEFAULT 'docker', host_group TEXT, host_group_override TEXT);
+      CREATE TABLE container_snapshots (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        host_id TEXT NOT NULL DEFAULT 'local',
+        container_name TEXT NOT NULL,
+        container_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        cpu_percent REAL, memory_mb REAL, restart_count INTEGER DEFAULT 0,
+        network_rx_bytes INTEGER, network_tx_bytes INTEGER,
+        blkio_read_bytes INTEGER, blkio_write_bytes INTEGER,
+        health_status TEXT, health_check_output TEXT, labels TEXT,
+        collected_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO meta (key, value) VALUES ('schema_version', '26');
+    `);
+
+    // One fresh (< 15 min ago), one stale (> 15 min ago).
+    db.prepare("INSERT INTO container_snapshots (host_id, container_name, container_id, status, collected_at) VALUES (?, ?, ?, ?, datetime('now', '-2 minutes'))")
+      .run('h1', 'fresh', 'id-fresh', 'running');
+    db.prepare("INSERT INTO container_snapshots (host_id, container_name, container_id, status, collected_at) VALUES (?, ?, ?, ?, datetime('now', '-2 hours'))")
+      .run('h1', 'stale', 'id-stale', 'exited');
+
+    const { bootstrap } = require('../../hub/src/db/schema');
+    bootstrap(db);
+
+    const rows = db.prepare("SELECT container_name, removed_at FROM containers WHERE host_id = 'h1' ORDER BY container_name").all();
+    assert.equal(rows.length, 2);
+    const fresh = rows.find((r: any) => r.container_name === 'fresh');
+    const stale = rows.find((r: any) => r.container_name === 'stale');
+    assert.equal(fresh.removed_at, null, 'fresh container should be active after backfill');
+    assert.notEqual(stale.removed_at, null, 'stale container should be marked removed after backfill');
+
+    db.close();
+  });
+});

--- a/tests/unit/detector.test.ts
+++ b/tests/unit/detector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-const { createTestDb, seedHostSnapshots, seedContainerSnapshots, seedAlertState, markContainerRemoved } = require('../helpers/db');
+const { createTestDb, seedHostSnapshots, seedContainerSnapshots, markContainerRemoved } = require('../helpers/db');
 const { ts, NOW } = require('../helpers/fixtures');
 const { suppressConsole } = require('../helpers/mocks');
 const { computeBaselines } = require('../../hub/src/insights/baselines');

--- a/tests/unit/detector.test.ts
+++ b/tests/unit/detector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-const { createTestDb, seedHostSnapshots, seedContainerSnapshots, seedAlertState } = require('../helpers/db');
+const { createTestDb, seedHostSnapshots, seedContainerSnapshots, seedAlertState, markContainerRemoved } = require('../helpers/db');
 const { ts, NOW } = require('../helpers/fixtures');
 const { suppressConsole } = require('../helpers/mocks');
 const { computeBaselines } = require('../../hub/src/insights/baselines');
@@ -177,20 +177,21 @@ describe('detector', () => {
     });
 
     it('skips containers that have stopped being reported (removed pods/containers)', () => {
-      // Same class of leak the alert evaluator had: a container whose last
-      // snapshot is older than the 15-minute recency window should not
-      // regenerate insights from its historical data.
+      // Same class of leak the alert evaluator had: a container whose
+      // registry row is marked `removed_at` should not regenerate insights
+      // from its historical snapshots.
       const recent = ts(new Date(NOW - 2 * 60 * 1000));
       seedHost(db, 'h1', recent);
 
       // Seed a container with a clear restart-loop history (>=3 restarts
-      // over the last 24h) but whose latest snapshot is 30 minutes old —
-      // the container has been deleted since, and the detector should
-      // skip it entirely.
+      // over the last 24h). Its registry row is then flagged as removed,
+      // so the detector should skip it entirely even though the snapshots
+      // are still in the DB.
       seedContainerSnapshots(db, [
         { hostId: 'h1', name: 'ghost', status: 'running', cpu: 5, mem: 50, restarts: 2, at: ts(new Date(NOW - 60 * 60 * 1000)) },
         { hostId: 'h1', name: 'ghost', status: 'running', cpu: 5, mem: 50, restarts: 8, at: ts(new Date(NOW - 30 * 60 * 1000)) },
       ]);
+      markContainerRemoved(db, 'h1', 'ghost');
 
       generateInsights(db);
       const rows = db.prepare("SELECT * FROM insights WHERE entity_id = 'h1/ghost'").all();

--- a/tests/unit/evaluator.test.ts
+++ b/tests/unit/evaluator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
-const { createTestDb, seedContainerSnapshots, seedDiskSnapshots, seedAlertState, seedHttpEndpoints, seedHttpChecks } = require('../helpers/db');
+const { createTestDb, seedContainerSnapshots, seedDiskSnapshots, seedAlertState, seedHttpEndpoints, seedHttpChecks, markContainerRemoved } = require('../helpers/db');
 const { ts, NOW } = require('../helpers/fixtures');
 const { suppressConsole } = require('../helpers/mocks');
 
@@ -354,15 +354,15 @@ describe('evaluateAlerts', () => {
         ).run(hostId);
       };
 
-      // An unhealthy container whose latest snapshot is older than the
-      // 15-minute recency window counts as "gone" — pod was deleted,
-      // agent stopped reporting, etc.
+      // An unhealthy container whose registry row is marked `removed_at`
+      // counts as "gone" — pod was deleted, Docker rm, etc.
       it('resolves container_unhealthy when the container stops being reported', () => {
         markHostAlive();
         const longAgo = ts(new Date(NOW - 30 * 60 * 1000)); // 30 min ago
         seedContainerSnapshots(db, [
           { name: 'crashloop', status: 'created', health: 'unhealthy', at: longAgo },
         ]);
+        markContainerRemoved(db, 'local', 'crashloop', longAgo);
         seedAlertState(db, [
           { type: 'container_unhealthy', target: 'crashloop', triggeredAt: longAgo, lastNotified: longAgo },
         ]);
@@ -379,6 +379,7 @@ describe('evaluateAlerts', () => {
         seedContainerSnapshots(db, [
           { name: 'zombie', status: 'exited', at: longAgo },
         ]);
+        markContainerRemoved(db, 'local', 'zombie', longAgo);
         seedAlertState(db, [
           { type: 'restart_loop', target: 'zombie', triggeredAt: longAgo, lastNotified: longAgo },
         ]);
@@ -390,9 +391,9 @@ describe('evaluateAlerts', () => {
 
       it('does NOT auto-resolve when the container is still being reported', () => {
         markHostAlive();
-        // Snapshot from 5 min ago — well within the 15-min window, so the
-        // container is still live. The existing container_unhealthy resolver
-        // should still fire (or not) based on the actual health_status.
+        // Container is still present in the registry (seedContainerSnapshots
+        // auto-upserts). The existing container_unhealthy resolver should
+        // fire (or not) based on the actual health_status.
         const fresh = ts(new Date(NOW - 5 * 60 * 1000));
         seedContainerSnapshots(db, [
           { name: 'alive', status: 'running', health: 'unhealthy', at: fresh },

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -22,7 +22,7 @@ describe('queries', () => {
     it('returns status ok with schema version', () => {
       const health = getHealth(db);
       assert.equal(health.status, 'ok');
-      assert.equal(health.schemaVersion, 26);
+      assert.equal(health.schemaVersion, 27);
       assert.equal(typeof health.uptime, 'number');
     });
   });


### PR DESCRIPTION
## Summary

- Adds a per-host `containers` registry (schema v27) that tracks `first_seen` / `last_seen` / `removed_at`. Each ingest batch diffs against it, so deleted containers stop appearing in the UI on the very next collect cycle instead of waiting out a 15-minute staleness window.
- Rewires the four sites that previously filtered snapshots on `collected_at > -15 minutes` (`getLatestContainers`, two dashboard queries, two detector iterations) to join the registry on `removed_at IS NULL`.
- Alert evaluator's `checkResolutions` now auto-resolves container alerts when the registry row is marked removed, not after the 15-min snapshot window.

## Motivation

First-time users iterating on container setup — spinning up a few containers, deleting them, retrying — were seeing a wall of red in the hub UI for containers that no longer existed. The hub had no concept of "removed", just "stale snapshot", and the 15-minute staleness window was a workaround that made the tool feel broken during the first 15 minutes of every setup session.

Root cause: `agent/src/scheduler.ts:78` only publishes a `containers` array when collection succeeds, so every published batch IS the authoritative current set for the host — the hub just wasn't comparing batches. This PR makes it compare.

## What changed

**Schema v27** (hub + standalone): new `containers` table with `(host_id, container_name)` primary key and a partial index on `(host_id, removed_at)`. Migration backfills from existing `container_snapshots`: anything with `MAX(collected_at) < '-15 minutes'` is marked removed, so the UI view stays identical on first boot. `pruneOldData` drops registry rows whose `removed_at` falls outside raw retention.

**Ingest diff** (`hub/src/ingest.ts` + `src/ingest.ts`): inside the existing transaction, pin `batchAt = datetime('now')` once, upsert each container in the batch with `removed_at = NULL`, then `UPDATE containers SET removed_at = batchAt WHERE host_id = ? AND removed_at IS NULL AND last_seen < batchAt`. Empty batches mark all previously-active rows removed — an empty publish is still a meaningful signal because the agent never publishes on collection failure.

**Query rewires**:
- `getLatestContainers` — INNER JOIN `containers` ON `removed_at IS NULL`
- `getDashboard.allContainers` — same
- `getDashboard.activePairs` (24h availability) — reads directly from `containers`
- `detector.ts` container iteration — reads directly from `containers`
- `detector.ts` unhealthy-container diagnosis query — joins `containers`

**Alert evaluator** (hub + standalone): `checkResolutions` reads `containers.removed_at` via a dedicated statement. The host-offline safety guard (don't mass-resolve when the agent is dark) is preserved — `STALE_CONTAINER_MINUTES` renamed to `HOST_REPORTING_MINUTES` to reflect its narrower semantic.

**Test helper**: `seedContainerSnapshots` now auto-upserts the registry row, mirroring production. New `seedContainers` + `markContainerRemoved` helpers for tests that need to simulate a removed state explicitly.

**Frontend**: no changes. The API surface is identical — removed containers just stop appearing in responses.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 778/778 pass (8 new registry tests, 5 existing tests updated to use the registry helpers)
- [x] VM migration: live DB with 59 containers / 117k snapshots migrated cleanly to v27. Backfill: 45 active + 14 stale-removed. Hub API returned `schemaVersion: 27` after restart.
- [x] Ghost container end-to-end:
  - `docker run --name ghost-test -d nginx:alpine` → force agent publish → registry row `removed_at = NULL`, appears on host detail page (8 containers total).
  - `docker rm -f ghost-test` → force agent publish → registry `removed_at` stamped, host detail drops to 7 containers **immediately** (no 15-min wait), `downContainers` does not include ghost-test.
  - `docker run --name ghost-test -d nginx:alpine` again → force publish → `removed_at` cleared, `first_seen` preserved from the original sighting, container reappears in the UI.
- [ ] Negative path (agent goes dark — host-offline guard) — not yet exercised on the VM; unit-tested in `evaluator.test.ts`.

Pre-migration DB backup at `/home/andreas/insightd-pre-v27-backup.db` (149 MB) for rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)