### PR TITLE
fix(dashboard): surface retrospective downtime as Insights only, with "recovered Xh ago" copy

### DIFF
--- a/hub/src/insights/detector.ts
+++ b/hub/src/insights/detector.ts
@@ -102,8 +102,8 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
   db.prepare('DELETE FROM insights').run();
 
   const insert = db.prepare(`
-    INSERT INTO insights (entity_type, entity_id, category, severity, title, message, metric, current_value, baseline_value)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO insights (entity_type, entity_id, category, severity, title, message, metric, current_value, baseline_value, evidence)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   let count = 0;
@@ -127,7 +127,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
         insert.run('host', host_id, 'performance', cpuValues[0] > 95 ? 'critical' : 'warning',
           `CPU saturated on ${host_id}`,
           `CPU has been above 80% for 30+ minutes. Current: ${round(cpuValues[0])}%`,
-          'cpu_percent', cpuValues[0], 80);
+          'cpu_percent', cpuValues[0], 80, null);
         count++;
       }
 
@@ -141,7 +141,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
         insert.run('host', host_id, 'performance', memPcts[0] > 95 ? 'critical' : 'warning',
           `Memory pressure on ${host_id}`,
           `Memory has been above 85% for 30+ minutes. Current: ${round(memPcts[0])}%`,
-          'memory_used_mb', memPcts[0], 85);
+          'memory_used_mb', memPcts[0], 85, null);
         count++;
       }
 
@@ -151,7 +151,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
         insert.run('host', host_id, 'performance', loadValues[0] > 16 ? 'critical' : 'warning',
           `High load on ${host_id}`,
           `Load average has been above 8 for 30+ minutes. Current: ${round(loadValues[0])}`,
-          'load_5', loadValues[0], 8);
+          'load_5', loadValues[0], 8, null);
         count++;
       }
     }
@@ -176,7 +176,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
         insert.run('host', host_id, 'trend', 'warning',
           `CPU usage growing on ${host_id}`,
           `Average CPU is ${ratio}x higher than last week (${round(thisWeekAvg.cpu)}% vs ${round(lastWeekAvg.cpu)}%)`,
-          'cpu_percent', thisWeekAvg.cpu, lastWeekAvg.cpu);
+          'cpu_percent', thisWeekAvg.cpu, lastWeekAvg.cpu, null);
         count++;
       }
       // Memory trend: only flag if we know total and usage is above 50% of capacity AND grew 1.5x
@@ -189,7 +189,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
         insert.run('host', host_id, 'trend', 'warning',
           `Memory usage growing on ${host_id}`,
           `Average memory is ${ratio}x higher than last week (${round(memPct)}% of total)`,
-          'memory_used_mb', thisWeekAvg.mem, lastWeekAvg.mem);
+          'memory_used_mb', thisWeekAvg.mem, lastWeekAvg.mem, null);
         count++;
       }
     }
@@ -229,7 +229,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
           insert.run('container', entityId, 'performance', 'warning',
             `${container_name} CPU sustained high`,
             `${container_name} CPU has been above 50% for 30+ minutes. Current: ${round(cpuValues[0])}%`,
-            'cpu_percent', cpuValues[0], cpuBl.p95);
+            'cpu_percent', cpuValues[0], cpuBl.p95, null);
           count++;
         }
       }
@@ -243,7 +243,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
           insert.run('container', entityId, 'performance', 'warning',
             `${container_name} memory unusually high`,
             `${container_name} memory at ${round(memValues[0])} MB, sustained above P95 (${round(p95)} MB) for 30+ minutes`,
-            'memory_mb', memValues[0], memBl.p95);
+            'memory_mb', memValues[0], memBl.p95, null);
           count++;
         }
       }
@@ -271,10 +271,22 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
         const uptimePct = (uptimeData.running / uptimeData.total) * 100;
         if (uptimePct < 99 && uptimePct > 0) {
           const downMinutes = Math.round((uptimeData.total - uptimeData.running) * 5);
+          // Most recent non-running snapshot inside the 24h window — lets the
+          // frontend render "Brief dip 3h ago" via timeAgo() instead of the
+          // vague "in the last 24 hours" the old copy used.
+          const lastDown = db.prepare(`
+            SELECT collected_at FROM container_snapshots
+            WHERE host_id = ? AND container_name = ? AND status != 'running'
+              AND collected_at >= datetime('now', '-1 day')
+            ORDER BY collected_at DESC LIMIT 1
+          `).get(host_id, container_name) as { collected_at: string } | undefined;
+          const evidence = lastDown
+            ? JSON.stringify({ lastDownAt: lastDown.collected_at, downMinutes, uptimePct: round(uptimePct) })
+            : null;
           insert.run('container', entityId, 'availability', uptimePct < 90 ? 'critical' : 'warning',
-            `${container_name} had downtime`,
-            `${container_name} was down for ~${downMinutes} minutes in the last 24 hours but has recovered (${round(uptimePct)}% uptime)`,
-            null, uptimePct, 99);
+            `${container_name} recovered from a brief dip`,
+            `Down for ~${downMinutes}m in the last 24h — now running again (${round(uptimePct)}% uptime).`,
+            null, uptimePct, 99, evidence);
           count++;
         }
       }
@@ -290,7 +302,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
       insert.run('container', entityId, 'availability', 'warning',
         `${container_name} restarting frequently`,
         `${container_name} has restarted ${restarts} times in the last 24 hours`,
-        null, restarts, 0);
+        null, restarts, 0, null);
       count++;
     }
 
@@ -312,7 +324,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
       insert.run('container', entityId, 'trend', 'warning',
         `${container_name} memory growing`,
         `${container_name} is using ${ratio}x more memory than last week (${round(thisWeek.mem)} MB vs ${round(lastWeek.mem)} MB)`,
-        'memory_mb', thisWeek.mem, lastWeek.mem);
+        'memory_mb', thisWeek.mem, lastWeek.mem, null);
       count++;
     }
   }
@@ -419,7 +431,7 @@ function generatePredictions(db: Database.Database, insert: Database.Statement):
       insert.run('host', host_id, 'prediction', severity,
         `${label} trending up on ${host_id}`,
         `${label} at ${round(pred.current)}${unit}, growing ${round(pred.dailyGrowth)}${unit}/day — will reach ${round(saturation)}${unit} (saturation) in ~${daysUntil} ${dayWord}`,
-        metric, pred.current, saturation);
+        metric, pred.current, saturation, null);
       count++;
     }
   }
@@ -453,7 +465,7 @@ function generatePredictions(db: Database.Database, insert: Database.Statement):
       insert.run('container', entityId, 'prediction', severity,
         `${container_name} ${label.toLowerCase()} trending up`,
         `${container_name} ${label.toLowerCase()} at ${round(pred.current)}${unit}, growing ${round(pred.dailyGrowth)}${unit}/day — will exceed P90 (${round(bl.p90)}${unit}) in ~${daysUntil} ${dayWord}`,
-        metric, pred.current, bl.p90);
+        metric, pred.current, bl.p90, null);
       count++;
     }
   }

--- a/hub/src/web/frontend/src/hooks/useFeedItems.ts
+++ b/hub/src/web/frontend/src/hooks/useFeedItems.ts
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import type { DashboardData, Alert, DashboardInsight } from '@/types/api';
 import type { FeedSeverity } from '@/components/FeedRow';
-import { fmtDurationMs, formatAlertType } from '@/lib/formatters';
+import { formatAlertType, timeAgo } from '@/lib/formatters';
 import { splitContainerEntityId } from '@/lib/containers';
 
 export interface FeedItem {
   id: string;
-  kind: 'alert' | 'downtime' | 'insight';
+  kind: 'alert' | 'insight';
   severity: FeedSeverity;
   icon: string;
   title: string;
@@ -64,7 +64,22 @@ function normalizeInsightSeverity(sev: string): FeedSeverity | null {
 }
 
 const SEVERITY_ORDER: Record<FeedSeverity, number> = { critical: 0, warning: 1, info: 2 };
-const KIND_ORDER: Record<FeedItem['kind'], number> = { alert: 0, downtime: 1, insight: 2 };
+const KIND_ORDER: Record<FeedItem['kind'], number> = { alert: 0, insight: 1 };
+
+interface AvailabilityEvidence {
+  lastDownAt?: string;
+  downMinutes?: number;
+  uptimePct?: number;
+}
+
+function parseAvailabilityEvidence(raw: string | null | undefined): AvailabilityEvidence | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as AvailabilityEvidence;
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    return parsed;
+  } catch { return null; }
+}
 
 export function useFeedItems(data: DashboardData | undefined): FeedItem[] {
   return useMemo(() => {
@@ -86,26 +101,27 @@ export function useFeedItems(data: DashboardData | undefined): FeedItem[] {
       });
     }
 
-    for (const c of data.availability.downContainers) {
-      const hasAlert = data.activeAlertsList.some(a => a.host_id === c.hostId && a.target === c.name);
-      if (hasAlert) continue;
-      items.push({
-        id: `downtime-${c.hostId}-${c.name}`,
-        kind: 'downtime',
-        severity: c.uptimePercent < 95 ? 'critical' : 'warning',
-        icon: '\u23f8\ufe0f',
-        title: `${c.name} down ~${fmtDurationMs(c.downMinutes * 60000)}`,
-        pillLabel: 'Downtime',
-        detail: `${c.uptimePercent}% uptime`,
-        meta: c.hostId,
-        to: `/hosts/${encodeURIComponent(c.hostId)}/containers/${encodeURIComponent(c.name)}`,
-      });
-    }
+    // Retrospective "had downtime" events used to produce a separate acute
+    // "Downtime" row here, duplicating the `availability` insight from
+    // topInsights. That made recovered dips look like active problems.
+    // They now live only in the Insights feed below, with a timeAgo-rich
+    // detail so the user can tell "3h ago" from "23h ago" at a glance.
 
     for (const insight of data.topInsights ?? []) {
       const severity = normalizeInsightSeverity(insight.severity);
       if (!severity) continue;
       const config = INSIGHT_CONFIG[insight.category] ?? INSIGHT_CONFIG.performance!;
+
+      let detail = insight.message;
+      if (insight.category === 'availability') {
+        const ev = parseAvailabilityEvidence(insight.evidence);
+        if (ev?.lastDownAt) {
+          const pct = typeof ev.uptimePct === 'number' ? `${ev.uptimePct}% uptime` : null;
+          const ago = timeAgo(ev.lastDownAt);
+          detail = pct ? `Brief dip ${ago} — ${pct}` : `Brief dip ${ago}`;
+        }
+      }
+
       items.push({
         id: `insight-${insight.entity_type}-${insight.entity_id}-${insight.category}`,
         kind: 'insight',
@@ -113,7 +129,7 @@ export function useFeedItems(data: DashboardData | undefined): FeedItem[] {
         icon: config.icon,
         title: insight.title,
         pillLabel: config.label,
-        detail: insight.message,
+        detail,
         meta: insightEntityName(insight),
         to: insightLink(insight),
         insight,

--- a/hub/src/web/frontend/src/types/api.ts
+++ b/hub/src/web/frontend/src/types/api.ts
@@ -16,6 +16,7 @@ export interface DashboardInsight {
   severity: string;
   title: string;
   message: string;
+  evidence?: string | null;
 }
 
 export interface DashboardData {
@@ -40,7 +41,7 @@ export interface DashboardData {
     computedAt: string;
   } | null;
   topInsights: DashboardInsight[];
-  availability: { overallPercent: number | null; downContainers: { hostId: string; name: string; uptimePercent: number; downMinutes: number }[] };
+  availability: { overallPercent: number | null };
 }
 
 export interface RankingItem {

--- a/hub/src/web/queries.ts
+++ b/hub/src/web/queries.ts
@@ -100,6 +100,7 @@ interface InsightRow {
   severity: string;
   title: string;
   message: string;
+  evidence: string | null;
 }
 
 interface HostMetricsRow {
@@ -511,18 +512,17 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
     if (!c.labels) return true;
     try { return JSON.parse(c.labels)['insightd.internal'] !== 'true'; } catch { return true; }
   });
+  // Per-container retrospective downtime used to surface here as an acute
+  // "Downtime" row in the dashboard feed. That duplicated the `availability`
+  // insight (same event, same container) in two columns, making recovered
+  // dips look like active problems. The fleet-wide `overallPercent` still
+  // needs the totals, but individual entries now live only in the Insights
+  // feed via getTopInsights + the `had downtime` insight row.
   let totalSnapshots = 0, totalRunning = 0;
-  const downContainers: Array<{ hostId: string; name: string; uptimePercent: number; downMinutes: number }> = [];
   for (const r of availFiltered) {
     totalSnapshots += r.total;
     totalRunning += r.running;
-    const pct = Math.round((r.running / r.total) * 1000) / 10;
-    if (pct < 100) {
-      const downMinutes = Math.round((r.total - r.running) * 5);
-      downContainers.push({ hostId: r.host_id, name: r.container_name, uptimePercent: pct, downMinutes });
-    }
   }
-  downContainers.sort((a, b) => a.uptimePercent - b.uptimePercent);
   const overallAvailability = totalSnapshots > 0 ? Math.round((totalRunning / totalSnapshots) * 1000) / 10 : null;
 
   const result = {
@@ -542,7 +542,7 @@ function getDashboard(db: Database.Database, onlineThresholdMinutes: number, sho
     groups,
     systemHealthScore: getSystemHealthScore(db),
     topInsights: getTopInsights(db),
-    availability: { overallPercent: overallAvailability, downContainers },
+    availability: { overallPercent: overallAvailability },
   };
 
   _dashboardCache.data = result;
@@ -629,7 +629,7 @@ function getSystemHealthScore(db: Database.Database): { score: number; factors: 
 function getTopInsights(db: Database.Database): InsightRow[] {
   try {
     return db.prepare(`
-      SELECT entity_type, entity_id, category, severity, title, message FROM insights
+      SELECT entity_type, entity_id, category, severity, title, message, evidence FROM insights
       ORDER BY CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END
       LIMIT 5
     `).all() as InsightRow[];

--- a/tests/unit/detector.test.ts
+++ b/tests/unit/detector.test.ts
@@ -140,23 +140,35 @@ describe('detector', () => {
   });
 
   describe('downtime insight filter', () => {
-    it('flags a container that was briefly down but has recovered', () => {
+    it('flags a container that was briefly down but has recovered, with evidence JSON', () => {
       const recent = ts(new Date(NOW - 2 * 60 * 1000));
       seedHost(db, 'h1', recent);
 
-      // 6 hours down, then currently running.
+      // 6 hours down, then currently running. The most recent non-running
+      // snapshot should end up in the evidence JSON as lastDownAt.
       for (let h = 23; h > 6; h--) {
         seedContainerSnapshots(db, [{ hostId: 'h1', name: 'svc', status: 'running', cpu: 5, mem: 50, at: ts(new Date(NOW - h * 3600_000)) }]);
       }
+      const lastDownAt = ts(new Date(NOW - 2 * 3600_000));
       for (let h = 6; h > 1; h--) {
         seedContainerSnapshots(db, [{ hostId: 'h1', name: 'svc', status: 'exited', cpu: 0, mem: 0, at: ts(new Date(NOW - h * 3600_000)) }]);
       }
+      seedContainerSnapshots(db, [{ hostId: 'h1', name: 'svc', status: 'exited', cpu: 0, mem: 0, at: lastDownAt }]);
       seedContainerSnapshots(db, [{ hostId: 'h1', name: 'svc', status: 'running', cpu: 5, mem: 50, at: recent }]);
 
       generateInsights(db);
-      const rows = db.prepare("SELECT * FROM insights WHERE entity_id = 'h1/svc' AND category = 'availability'").all();
+      const rows = db.prepare("SELECT * FROM insights WHERE entity_id = 'h1/svc' AND category = 'availability'").all() as Array<{
+        title: string; message: string; evidence: string | null;
+      }>;
       assert.equal(rows.length, 1);
-      assert.match(rows[0].message, /recovered/);
+      assert.match(rows[0].title, /recovered from a brief dip/);
+      assert.match(rows[0].message, /running again/);
+
+      assert.ok(rows[0].evidence, 'evidence JSON must be populated');
+      const ev = JSON.parse(rows[0].evidence!);
+      assert.equal(ev.lastDownAt, lastDownAt, 'lastDownAt should equal the most recent non-running snapshot');
+      assert.ok(typeof ev.downMinutes === 'number' && ev.downMinutes > 0);
+      assert.ok(typeof ev.uptimePct === 'number' && ev.uptimePct < 100);
     });
 
     it('does NOT flag a long-stopped container as "had downtime"', () => {

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -274,33 +274,34 @@ describe('queries', () => {
       assert.equal(hs.score, 97);
     });
 
-    it('excludes intentionally-stopped containers from downContainers', () => {
+    it('overallPercent excludes intentionally-stopped containers', () => {
       // Simulates proxmox-01 with nginx sitting 'exited' for days — the agent
-      // still reports it every 5 min (docker ps -a), and the 24h availability
-      // query would show 0% uptime, but we don't want it in the feed.
+      // still reports it every 5 min (docker ps -a). getDashboard previously
+      // exposed a per-container `downContainers` list that the frontend
+      // routed into the acute "Needs Attention" feed, which duplicated the
+      // retrospective `had downtime` insight. That list is gone; what
+      // remains is the fleet-wide `overallPercent`, which should still
+      // ignore intentionally-stopped containers by design (the upstream
+      // filter in getDashboard skips any container whose latest snapshot
+      // is not 'running').
       seedHost(db, 'h1', recent);
-      // Seed 20 snapshots of an exited container, all within the last 24h and
-      // the most recent one inside the 15-minute active-pair window.
       const snapshots: any[] = [];
       for (let i = 0; i < 20; i++) {
         const minutesAgo = 5 + i * 5;
         snapshots.push({ hostId: 'h1', name: 'nginx', status: 'exited', at: ts(new Date(NOW - minutesAgo * 60 * 1000)) });
       }
-      // Also seed a currently-running container with some historical dips
-      // (10 running + 2 exited = 83.3% uptime) — this SHOULD appear.
-      for (let i = 0; i < 10; i++) {
+      // A currently-running container with 100% uptime — the fleet % should
+      // be 100 and nginx should not drag it down.
+      for (let i = 0; i < 12; i++) {
         snapshots.push({ hostId: 'h1', name: 'webapp', status: 'running', at: ts(new Date(NOW - (5 + i * 5) * 60 * 1000)) });
       }
-      snapshots.push({ hostId: 'h1', name: 'webapp', status: 'exited', at: ts(new Date(NOW - 60 * 60 * 1000)) });
-      snapshots.push({ hostId: 'h1', name: 'webapp', status: 'exited', at: ts(new Date(NOW - 65 * 60 * 1000)) });
       seedContainerSnapshots(db, snapshots);
 
       const dash = getDashboard(db, 10);
-      const downNames = dash.availability.downContainers.map((c: any) => c.name);
-      assert.ok(!downNames.includes('nginx'),
-        'intentionally-stopped nginx should not be in downContainers');
-      assert.ok(downNames.includes('webapp'),
-        'currently-running webapp with historical downtime should be in downContainers');
+      assert.equal(dash.availability.overallPercent, 100,
+        'exited nginx must not drag overallPercent below 100');
+      assert.equal(dash.availability.downContainers, undefined,
+        'downContainers field removed — retrospective dips live in topInsights now');
     });
 
     it('leaves alerts factor alone when live count matches stored value', () => {
@@ -326,6 +327,28 @@ describe('queries', () => {
       // Score stays at stored value since nothing was patched
       assert.equal(h1.score, 80);
       assert.equal(dash.systemHealthScore.score, 80);
+    });
+
+    it('getTopInsights returns the evidence column so the frontend can render timeAgo', () => {
+      seedHost(db, 'h1', recent);
+      seedContainerSnapshots(db, [{ hostId: 'h1', name: 'nginx', status: 'running', at: recent }]);
+      db.prepare(`
+        INSERT INTO insights (entity_type, entity_id, category, severity, title, message, metric, current_value, baseline_value, evidence)
+        VALUES ('container', 'h1/nginx', 'availability', 'warning',
+                'nginx recovered from a brief dip',
+                'Down for ~5m in the last 24h — now running again (98.9% uptime).',
+                null, 98.9, 99,
+                '{"lastDownAt":"2026-04-15 16:32:07","downMinutes":5,"uptimePct":98.9}')
+      `).run();
+
+      const dash = getDashboard(db, 10);
+      const insight = dash.topInsights.find((i: any) => i.title.includes('recovered'));
+      assert.ok(insight, 'expected the availability insight to surface in topInsights');
+      assert.ok(insight.evidence, 'evidence field must be returned');
+      const ev = JSON.parse(insight.evidence);
+      assert.equal(ev.lastDownAt, '2026-04-15 16:32:07');
+      assert.equal(ev.downMinutes, 5);
+      assert.equal(ev.uptimePct, 98.9);
     });
   });
 


### PR DESCRIPTION
## Summary

A "had downtime" row for a currently-running container was appearing **twice** on the dashboard — once as an acute "Downtime" row in **Needs Attention** and once as a retrospective row in **Insights**. The acute placement made recovered dips look like active problems; the detail copy (*"in the last 24 hours"*) gave no hint whether the dip was a minute ago or 23 hours ago.

This PR closes the duplicate and adds a "Brief dip 3h ago" timestamp so the retrospective intent is self-explanatory.

## Motivation

From a recent user interaction on the live VM: `insightd/insightd-agent/agent` on `k3d-worker1-0` (an insightd agent DaemonSet pod) surfaced in Needs Attention as a warning. The pod had been running fine for hours — a single `created/starting` collection snapshot during a routine pod restart had dragged 24h uptime to 98.86%, which dropped it below the 99% threshold in `detector.ts`. The user asked whether something was currently wrong; it was not. The signal is genuinely useful ("FYI, this container had a blip in the last 24h"), but the feed placement + copy made it indistinguishable from an active incident.

Root cause: `getDashboard` built `availability.downContainers`, which `useFeedItems.ts:89` turned into `kind: 'downtime'` feed rows landing in Needs Attention. The same event was ALSO living in the `insights` table via the `availability` detector branch, producing a `kind: 'insight'` row in Insights. By construction `downContainers` only contained containers whose latest snapshot was running (upstream filter from PR #125), so every entry was already "recovered" — never acute in the first place.

## What changed

**Backend:**
- `hub/src/web/queries.ts::getDashboard` — stops building `downContainers`. `totalSnapshots`/`totalRunning` sums still drive `overallPercent` for the fleet uptime hero; the per-container list is gone.
- `hub/src/web/queries.ts::getTopInsights` — now SELECTs the existing `evidence` column so retrospective payload reaches the frontend.
- `hub/src/insights/detector.ts` "had downtime" branch:
  - Queries the most recent non-running snapshot's `collected_at`.
  - Packs `{ lastDownAt, downMinutes, uptimePct }` into `evidence` JSON.
  - Title: `"X had downtime"` → `"X recovered from a brief dip"` (past-tense, recovery explicit).
  - Message: `"Down for ~Nm in the last 24h — now running again (X% uptime)."`
- `insert` prepared statement in `generateInsights` gains an `evidence` column. All 12 other `insert.run(...)` call sites in `detector.ts` pass a trailing `null`. **No schema migration** — the `evidence` column has existed since v20 for diagnosis findings.

**Frontend:**
- `DashboardInsight` gains `evidence?: string | null`.
- `DashboardData.availability.downContainers` removed from the type.
- `useFeedItems.ts` drops the `kind: 'downtime'` branch entirely. Parses availability evidence for insight rows and renders `"Brief dip ${timeAgo(lastDownAt)} — ${uptimePct}% uptime"` via the existing `timeAgo` helper in `lib/formatters.ts`.
- `FeedItem['kind']` union narrows from `'alert' | 'downtime' | 'insight'` to `'alert' | 'insight'`.
- `fmtDurationMs` import dropped (only used by the removed downtime branch).

## Test plan

- [x] `npm run typecheck` (backend + frontend) — clean
- [x] `npm test` — **779/779 pass** (one new test: `getTopInsights returns the evidence column so the frontend can render timeAgo`)
- [x] `tests/unit/detector.test.ts` — "flags a container that was briefly down but has recovered" now asserts the new title and parses `evidence` JSON for `lastDownAt`/`downMinutes`/`uptimePct`.
- [x] `tests/unit/queries.test.ts` — rewrote the old `downContainers`-exclusion test into an `overallPercent`-exclusion test (the behavior it was actually gating on).
- [x] Live VM verification: manually triggered `generateInsights` in the running hub container; the existing problematic row for `k3d-worker1-0/insightd/insightd-agent/agent` regenerated as:
  ```json
  {
    "title": "insightd/insightd-agent/agent recovered from a brief dip",
    "message": "Down for ~5m in the last 24h — now running again (98.9% uptime).",
    "evidence": "{\"lastDownAt\":\"2026-04-15 16:32:07\",\"downMinutes\":5,\"uptimePct\":98.9}"
  }
  ```
- [x] `GET /api/dashboard?showInternal=true` — confirmed `availability` has keys `['overallPercent']` only (no `downContainers`), `overallPercent = 100`, and `topInsights[0].evidence` is the JSON above.
- [ ] Visual smoke test in browser after merge — the row should appear in the Insights column with detail text like `"Brief dip 4h ago — 98.9% uptime"` and be absent from Needs Attention.

## Follow-up (out of scope)

When the user clicks through from a "brief dip" insight to the container detail page, the `UptimeTimeline` still shows the dip as a tiny red pixel inside its hourly bucket with no special highlight. Adding a marker at the exact snapshot containing `lastDownAt` would make the click-through story complete. Noted as the natural next step — not in this PR to keep the scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)