### PR TITLE
fix(bootstrap): chown mosquitto config so the broker can read passwd

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -34,6 +34,14 @@ services:
           mosquitto_passwd -b -c /mosquitto/config/passwd \
             "$$INSIGHTD_MQTT_USER" "$$INSIGHTD_MQTT_PASS"
         fi
+        # Fix ownership + perms every boot. The bootstrap runs as root, so
+        # mosquitto.conf is root-owned and mosquitto_passwd creates its file
+        # with mode 0700 — the broker runs as the 'mosquitto' user and bails
+        # with "Unable to open pwfile" without this. Applying every boot also
+        # repairs installs created before this fix.
+        chown -R mosquitto:mosquitto /mosquitto/config
+        chmod 0644 /mosquitto/config/mosquitto.conf
+        chmod 0600 /mosquitto/config/passwd
     environment:
       INSIGHTD_MQTT_USER: ${INSIGHTD_MQTT_USER:-insightd}
       INSIGHTD_MQTT_PASS: ${INSIGHTD_MQTT_PASS:-}


### PR DESCRIPTION
## Summary

First-boot installs via \`curl -sSL https://insightd.org/install.sh | bash\` are crash-looping:

\`\`\`
insightd-mqtt  | password-file: Error: Unable to open pwfile "/mosquitto/config/passwd".
insightd-mqtt  | mosquitto version 2.1.2 terminating
\`\`\`

The bootstrap service runs with a custom \`sh -c\` entrypoint, which means it runs as root. \`mosquitto_passwd\` creates its output file with **mode 0700** for security, owned by root. The broker container runs as the \`mosquitto\` user (UID 1883) and can't read it — so mosquitto restart-loops, hub can never connect, installer times out.

## Fix

At the end of every bootstrap run — not just first-boot — chown the config dir to \`mosquitto:mosquitto\` and restore sane modes (\`0644\` for the conf, \`0600\` for the passwd). Applied every boot so existing broken installs auto-heal on the next \`docker compose up -d\` (no manual remediation needed; \`install.sh\` re-runs cleanly).

## Reproducer

Fresh VM, no prior install:

\`\`\`
root@Insightd:~# curl -sSL https://insightd.org/install.sh | bash
  insightd installer → /root/insightd
  fetching docker-compose.hub.yml
  generating .env with a new MQTT password
  pulling images
  starting containers
  waiting for hub to come up
  error: hub didn't respond within 60s
\`\`\`

Mosquitto logs show the \`Unable to open pwfile\` error repeating on the restart loop.

## Test plan

- [x] Rebuild the VM or wipe the stack: \`docker compose -f ~/insightd/docker-compose.hub.yml down -v && rm -rf ~/insightd\`
- [ ] Re-run \`curl -sSL https://insightd.org/install.sh | bash\` and confirm it prints \`✓ insightd is running\`
- [ ] For an existing broken install, \`docker compose -f ~/insightd/docker-compose.hub.yml up -d\` with this fix should repair itself on the next bootstrap pass (the chown runs unconditionally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)