### PR TITLE
fix(setup): wizard goes blank after saving the admin password

### DIFF
--- a/hub/src/web/frontend/src/App.tsx
+++ b/hub/src/web/frontend/src/App.tsx
@@ -95,11 +95,13 @@ export function App() {
 
   if (!setupComplete) {
     return (
-      <ThemeProvider>
-        <Suspense fallback={<PageLoading />}>
-          <SetupWizardPage mode={mode} onComplete={() => setSetupComplete(true)} />
-        </Suspense>
-      </ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider>
+          <Suspense fallback={<PageLoading />}>
+            <SetupWizardPage mode={mode} onComplete={() => setSetupComplete(true)} />
+          </Suspense>
+        </ThemeProvider>
+      </AuthProvider>
     );
   }
 

--- a/hub/src/web/frontend/src/pages/SetupWizardPage.tsx
+++ b/hub/src/web/frontend/src/pages/SetupWizardPage.tsx
@@ -55,6 +55,7 @@ function WelcomeStep({ onNext }: { onNext: () => void }) {
 }
 
 function PasswordStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) {
+  const { login } = useAuth();
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [error, setError] = useState('');
@@ -64,7 +65,20 @@ function PasswordStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => vo
     if (password.length < 4) { setError('Password must be at least 4 characters'); return; }
     if (password !== confirm) { setError('Passwords do not match'); return; }
     try {
-      await fetch('/api/setup/password', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ password }) });
+      const res = await fetch('/api/setup/password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      if (!res.ok) {
+        const msg = await res.text().catch(() => '');
+        setError(msg || `Failed to save (${res.status})`);
+        return;
+      }
+      // Log in with the password we just set so subsequent steps (EmailStep's
+      // PUT /api/settings) can authenticate. Without this the token is null
+      // and the email-save silently 401s.
+      try { await login(password); } catch { /* wizard still advances; email save will error and user can skip */ }
       setSaved(true);
       setTimeout(onNext, 1000);
     } catch { setError('Failed to save'); }


### PR DESCRIPTION
## Summary

Clicking **Set Password** on step 1 of the setup wizard advances to step 2 (`EmailStep`), which calls `useAuth()` for the token used by `PUT /api/settings`. The wizard is rendered outside `<AuthProvider>` in `App.tsx` — so `useAuth()` throws `useAuth must be used within AuthProvider`, killing the React tree → **blank screen, no way to continue**.

## Fix

Two parts:

1. **`App.tsx`** — wrap the wizard in `<AuthProvider>`. The provider reads the token from `sessionStorage`, so the token we set mid-wizard carries cleanly into the main app once setup completes.

2. **`SetupWizardPage.tsx` PasswordStep** — after `POST /api/setup/password` succeeds, call `login(password)` from the new provider so `EmailStep` has a real token. Without this, even with the provider in place, `PUT /api/settings` would 401 (`requireAuth` guards it). `POST /api/auth` isn't gated by `setup-complete` so it works mid-wizard.

Also: the password-save path previously swallowed non-2xx responses and advanced anyway (\`setSaved(true); setTimeout(onNext, 1000)\` inside the try block with no status check). Now it surfaces the error and stops.

## Test plan

- [x] `tsc --noEmit` — clean (both backend and frontend projects)
- [x] `npm test` — 779/779 pass
- [ ] On the VM: wipe hub data and re-run the wizard: \`docker compose down && docker volume rm insightd_hub-data && docker compose up -d\`
  - Set a password → click Set Password → confirm we advance to the Email step (no blank screen)
  - Fill email fields → click Save Email Settings → confirm the PUT succeeds (no 401)
  - Continue through Agent → Waiting → Done; open dashboard; confirm we're still logged in (sessionStorage token persists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)