### PR TITLE
fix(update): hub self-update finds agent by the container it reports

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -78,6 +78,10 @@ services:
     volumes:
       - hub-data:/data
     environment:
+      # Keep the hub's own host id in sync with the sibling agent so
+      # internal features that need to match them (e.g. self-update) work
+      # without extra configuration.
+      INSIGHTD_HOST_ID: ${INSIGHTD_HOST_ID:-hub-server}
       INSIGHTD_MQTT_URL: mqtt://mosquitto:1883
       INSIGHTD_MQTT_USER: ${INSIGHTD_MQTT_USER:-insightd}
       INSIGHTD_MQTT_PASS: ${INSIGHTD_MQTT_PASS:-}

--- a/hub/src/web/handlers.ts
+++ b/hub/src/web/handlers.ts
@@ -950,17 +950,30 @@ async function handleUpdateHub(req: HandlerReq, res: ServerResponse, db: Databas
   if (!ctx.requestUpdate) { res.statusCode = 501; return { error: 'Update not available in standalone mode' }; }
   const { snoozeAlerts } = require('../alert-snooze');
   snoozeAlerts(10);
-  // Find the agent on the same host as the hub
-  const hubHostId = config.hostId || 'local';
-  const hosts = queries.getHosts(db, offlineThresholdMinutes());
-  const localAgent = hosts.find((h: any) => h.host_id === hubHostId && h.is_online);
-  if (!localAgent) { res.statusCode = 400; return { error: `No online agent found on hub host (${hubHostId}). Ensure an agent is running on the same host.` }; }
+  // The agent we need is whichever one can see the hub's own container on
+  // the same Docker daemon. Trying to match `config.hostId` here is fragile:
+  // the hub compose service doesn't set INSIGHTD_HOST_ID (fallback = 'local'),
+  // while the sibling agent's compose entry does (default 'hub-server'), so
+  // a literal id match fails on default installs. Looking up who reports
+  // `insightd-hub` as a running container answers the question directly.
+  const threshold = offlineThresholdMinutes();
+  const row = db.prepare(`
+    SELECT c.host_id
+    FROM containers c
+    INNER JOIN hosts h ON h.host_id = c.host_id
+    WHERE c.container_name = 'insightd-hub'
+      AND c.removed_at IS NULL
+      AND datetime(h.last_seen, '+' || ? || ' minutes') > datetime('now')
+    ORDER BY c.last_seen DESC
+    LIMIT 1
+  `).get(threshold) as { host_id: string } | undefined;
+  if (!row) { res.statusCode = 400; return { error: 'No online agent is reporting the hub container (insightd-hub). Ensure an agent is running on the same host and has reported at least once.' }; }
   const { getVersionInfo } = require('../version-check');
   const vi = getVersionInfo();
   const tag = vi.latestHubVersion || vi.currentVersion;
   const image = `andreas404/insightd-hub:${tag}`;
   try {
-    const result = await ctx.requestUpdate(localAgent.host_id, 'hub', image);
+    const result = await ctx.requestUpdate(row.host_id, 'hub', image);
     return result;
   } catch (err) {
     res.statusCode = 504;

--- a/tests/integration/web-api.test.ts
+++ b/tests/integration/web-api.test.ts
@@ -688,6 +688,75 @@ describe('Web API integration', () => {
   });
 });
 
+describe('POST /api/update/hub — picks the agent reporting insightd-hub', () => {
+  let db: any;
+  let server: any;
+  let port: number;
+  let updateCalls: Array<{ hostId: string; target: string; image: string }>;
+
+  async function start() {
+    const { startWebServer } = require('../../hub/src/web/server');
+    const config = {
+      collectIntervalMinutes: 5,
+      web: { enabled: true, port: 0, host: '127.0.0.1' },
+    };
+    const ctx = {
+      requestUpdate: async (hostId: string, target: string, image: string) => {
+        updateCalls.push({ hostId, target, image });
+        return { status: 'success' };
+      },
+    };
+    return new Promise<{ server: any; port: number }>((resolve) => {
+      const s = startWebServer(db, config, ctx);
+      s.on('listening', () => resolve({ server: s, port: s.address().port }));
+    });
+  }
+
+  beforeEach(async () => {
+    db = createTestDb();
+    updateCalls = [];
+    const r = await start();
+    server = r.server;
+    port = r.port;
+  });
+
+  afterEach(() => {
+    server.close();
+    db.close();
+  });
+
+  it('routes to whichever host reports a running insightd-hub container', async () => {
+    // The local agent registers as "hub-server" (INSIGHTD_HOST_ID default),
+    // but the hub container itself has config.hostId = 'local' — the id
+    // match that used to live in handleUpdateHub failed on every default
+    // install. The fix: find the agent by the container it reports.
+    seedHost(db, 'hub-server', recent);
+    seedHost(db, 'unrelated-host', recent);
+    seedContainerSnapshots(db, [
+      { hostId: 'hub-server', name: 'insightd-hub', status: 'running', at: recent },
+      { hostId: 'unrelated-host', name: 'nginx', status: 'running', at: recent },
+    ]);
+
+    const res = await fetchMethod(port, 'POST', '/api/update/hub');
+    assert.equal(res.status, 200);
+    assert.equal(updateCalls.length, 1);
+    assert.equal(updateCalls[0].hostId, 'hub-server');
+    assert.equal(updateCalls[0].target, 'hub');
+  });
+
+  it('returns 400 when no online agent is reporting insightd-hub', async () => {
+    seedHost(db, 'some-host', recent);
+    seedContainerSnapshots(db, [
+      { hostId: 'some-host', name: 'nginx', status: 'running', at: recent },
+    ]);
+
+    const res = await fetchMethod(port, 'POST', '/api/update/hub');
+    assert.equal(res.status, 400);
+    assert.match(res.json().error, /insightd-hub/);
+    assert.equal(updateCalls.length, 0);
+  });
+});
+
 describe('AI diagnose API', () => {
   let db: any;
   let server: any;


### PR DESCRIPTION
## Summary

Clicking "Update Hub" on a default install returned `No online agent found on hub host (local)`. The hub compose service doesn't read `INSIGHTD_HOST_ID`, so its \`config.hostId\` falls back to \`'local'\`, while the sibling agent registers as \`hub-server\` (install.sh default). The id match in \`handleUpdateHub\` never lined them up.

**Fix**: find the agent by the container it reports. The only agent that can restart the hub container is whichever one publishes a running \`insightd-hub\` snapshot on the same Docker daemon. No env coordination needed.

Also adds \`INSIGHTD_HOST_ID\` to the hub compose service (same default as the agent) so both ids agree by construction for anyone building new id-coupled features.

## Test plan

- [x] \`npm test\` — 786/786 pass (+2 new: routes to correct host, 400 when no hub container reported)
- [x] \`npm run typecheck\`
- [ ] Deploy to live hub and verify Update Hub button works on a default install

🤖 Generated with [Claude Code](https://claude.com/claude-code)