### PR TITLE
Harden disk collectors and add logical device support

### DIFF
--- a/agent/src/collectors/disk-io.ts
+++ b/agent/src/collectors/disk-io.ts
@@ -10,9 +10,59 @@ interface DiskStats {
   writeSectors: number;
 }
 
-// Previous sample for delta calculation
-let prevStats: Record<string, DiskStats> | null = null;
-let prevTime: number | null = null;
+interface SampleState {
+  prevStats: Record<string, DiskStats>;
+  prevTime: number;
+}
+
+const sampleStateByPath: Record<string, SampleState> = Object.create(null);
+
+function parseCounter(value: string | undefined): number | null {
+  if (value == null || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isTrackedDevice(device: string): boolean {
+  return /^(sd[a-z]+|nvme\d+n\d+|vd[a-z]+|xvd[a-z]+|mmcblk\d+|dm-\d+|md\d+)$/.test(device);
+}
+
+function isLogicalAggregateDevice(device: string): boolean {
+  return /^(dm-\d+|md\d+)$/.test(device);
+}
+
+function listExcludedSlaveDevices(hostRoot: string, devices: Iterable<string>): Set<string> {
+  const excluded = new Set<string>();
+
+  for (const device of devices) {
+    if (!isLogicalAggregateDevice(device)) continue;
+
+    try {
+      const slaveDir = path.join(hostRoot, 'sys', 'block', device, 'slaves');
+      for (const slave of fs.readdirSync(slaveDir)) {
+        if (slave) excluded.add(slave);
+      }
+    } catch {
+      // Missing slave metadata â€” keep raw devices rather than undercounting.
+    }
+  }
+
+  return excluded;
+}
+
+function mergeStats(
+  prevStats: Record<string, DiskStats>,
+  currentStats: Record<string, DiskStats>,
+  malformedDevices: Set<string>
+): Record<string, DiskStats> {
+  const merged: Record<string, DiskStats> = { ...currentStats };
+
+  for (const device of malformedDevices) {
+    if (prevStats[device]) merged[device] = prevStats[device];
+  }
+
+  return merged;
+}
 
 /**
  * Collect disk I/O from /proc/diskstats (delta-based).
@@ -20,60 +70,69 @@ let prevTime: number | null = null;
  */
 function collectDiskIO(config?: DiskIOConfig): { readBytesPerSec: number; writeBytesPerSec: number } | null {
   const hostRoot = config?.hostRoot || '/host';
-  const diskstatsPath = path.join(hostRoot, 'proc/diskstats');
+  const diskstatsPath = path.join(hostRoot, 'proc', 'diskstats');
 
   try {
     const content = fs.readFileSync(diskstatsPath, 'utf8');
     const now = Date.now();
     const stats: Record<string, DiskStats> = {};
+    const malformedDevices = new Set<string>();
 
     for (const line of content.trim().split('\n')) {
       const parts = line.trim().split(/\s+/);
       if (parts.length < 14) continue;
+
       const device = parts[2];
+      if (!isTrackedDevice(device)) continue;
 
-      // Only real devices (skip partitions like sda1, nvme0n1p1)
-      if (!device.match(/^(sd[a-z]+|nvme\d+n\d+|vd[a-z]+|xvd[a-z]+)$/)) continue;
+      const readSectors = parseCounter(parts[5]);
+      const writeSectors = parseCounter(parts[9]);
+      if (readSectors == null || writeSectors == null) {
+        malformedDevices.add(device);
+        continue;
+      }
 
-      stats[device] = {
-        readSectors: parseInt(parts[5], 10) || 0,   // sectors read
-        writeSectors: parseInt(parts[9], 10) || 0,   // sectors written
-      };
+      stats[device] = { readSectors, writeSectors };
     }
 
     if (Object.keys(stats).length === 0) {
-      prevStats = null;
-      prevTime = null;
+      if (malformedDevices.size > 0) return null;
+      delete sampleStateByPath[diskstatsPath];
       return null;
     }
 
-    if (!prevStats || !prevTime) {
-      prevStats = stats;
-      prevTime = now;
-      return null; // First sample — gathering baseline
+    const state = sampleStateByPath[diskstatsPath];
+    if (!state) {
+      sampleStateByPath[diskstatsPath] = { prevStats: stats, prevTime: now };
+      return null;
     }
 
-    const elapsedSec = (now - prevTime) / 1000;
+    const mergedStats = mergeStats(state.prevStats, stats, malformedDevices);
+    const elapsedSec = (now - state.prevTime) / 1000;
     if (elapsedSec < 1) {
-      prevStats = stats;
-      prevTime = now;
+      sampleStateByPath[diskstatsPath] = { prevStats: mergedStats, prevTime: now };
       return null;
     }
 
+    const currentAggregateDevices = new Set<string>([
+      ...Object.keys(stats).filter(isLogicalAggregateDevice),
+      ...Array.from(malformedDevices).filter(isLogicalAggregateDevice),
+    ]);
+    const excludedSlaves = listExcludedSlaveDevices(hostRoot, currentAggregateDevices);
     let totalReadBytesPerSec = 0;
     let totalWriteBytesPerSec = 0;
 
     for (const [device, curr] of Object.entries(stats)) {
-      const prev = prevStats[device];
+      if (excludedSlaves.has(device)) continue;
+
+      const prev = state.prevStats[device];
       if (!prev) continue;
-      // Sector size = 512 bytes
+
       totalReadBytesPerSec += Math.max(0, (curr.readSectors - prev.readSectors) * 512 / elapsedSec);
       totalWriteBytesPerSec += Math.max(0, (curr.writeSectors - prev.writeSectors) * 512 / elapsedSec);
     }
 
-    prevStats = stats;
-    prevTime = now;
-
+    sampleStateByPath[diskstatsPath] = { prevStats: mergedStats, prevTime: now };
     return {
       readBytesPerSec: Math.round(totalReadBytesPerSec),
       writeBytesPerSec: Math.round(totalWriteBytesPerSec),

--- a/agent/src/collectors/disk.ts
+++ b/agent/src/collectors/disk.ts
@@ -1,4 +1,5 @@
 import fs = require('fs');
+import path = require('path');
 import logger = require('../../../shared/utils/logger');
 
 interface DiskConfig {
@@ -13,48 +14,75 @@ interface DiskResult {
   usedPercent: number;
 }
 
+function decodeMountField(value: string): string {
+  return value.replace(/\\([0-7]{3})/g, (_, octal: string) => String.fromCharCode(parseInt(octal, 8)));
+}
+
+function isBlockDeviceSource(source: string): boolean {
+  return /^\/dev\/(?:mapper\/\S+|dm-\d+|sd[a-z]+\d*|nvme\d+n\d+(?:p\d+)?|vd[a-z]+\d*|xvd[a-z]+\d*|md\d+|mmcblk\d+(?:p\d+)?|root)$/.test(source);
+}
+
+function getStatPath(hostRoot: string, mountPoint: string): string {
+  if (mountPoint === '/') return hostRoot;
+  return path.join(hostRoot, mountPoint.replace(/^\/+/, ''));
+}
+
+function readMountTargets(mountsPath: string, hostRoot?: string): Array<{ mountPoint: string; statPath: string }> {
+  const mounts = fs.readFileSync(mountsPath, 'utf8');
+  const seen = new Set<string>();
+  const mountsToCheck: Array<{ mountPoint: string; statPath: string }> = [];
+
+  for (const line of mounts.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 2) continue;
+
+    const source = decodeMountField(parts[0]);
+    if (!isBlockDeviceSource(source)) continue;
+
+    const mountPoint = decodeMountField(parts[1]);
+    if (seen.has(mountPoint)) continue;
+    seen.add(mountPoint);
+
+    mountsToCheck.push({
+      mountPoint,
+      statPath: hostRoot ? getStatPath(hostRoot, mountPoint) : mountPoint,
+    });
+  }
+
+  return mountsToCheck;
+}
+
 /**
  * Collect disk usage stats.
- * Returns plain data array — no DB writes.
+ * Returns plain data array â€” no DB writes.
  */
 function collectDisk(config: DiskConfig): DiskResult[] {
   const hostRoot = config.hostRoot;
-  const useHostMount = fs.existsSync(hostRoot) && fs.statSync(hostRoot).isDirectory();
 
-  const mountsToCheck: Array<{ mountPoint: string; statPath: string }> = [];
+  let useHostMount = false;
+  try {
+    useHostMount = fs.existsSync(hostRoot) && fs.statSync(hostRoot).isDirectory();
+  } catch {
+    useHostMount = false;
+  }
 
-  if (useHostMount) {
-    mountsToCheck.push({ mountPoint: '/', statPath: hostRoot });
-
-    try {
-      const hostStat = fs.statfsSync(hostRoot);
-      const hostFsId = `${hostStat.type}:${hostStat.blocks}`;
-
-      for (const dir of ['home', 'mnt', 'opt', 'var', 'srv']) {
-        const fullPath = `${hostRoot}/${dir}`;
-        try {
-          if (!fs.statSync(fullPath).isDirectory()) continue;
-          const dirStat = fs.statfsSync(fullPath);
-          const dirFsId = `${dirStat.type}:${dirStat.blocks}`;
-          if (dirFsId !== hostFsId) {
-            mountsToCheck.push({ mountPoint: `/${dir}`, statPath: fullPath });
-          }
-        } catch { /* dir doesn't exist or can't stat */ }
-      }
-    } catch { /* can't stat host root */ }
-  } else {
-    logger.warn('disk', 'Host root not mounted — reading container filesystem instead');
-    const mounts = fs.readFileSync('/proc/mounts', 'utf8');
-    const seen = new Set<string>();
-
-    for (const line of mounts.split('\n')) {
-      if (!/^\/dev\/(sd|nvme|vd|xvd|loop|mapper\/)/.test(line)) continue;
-      const parts = line.split(/\s+/);
-      const mountPoint = parts[1];
-      if (seen.has(mountPoint)) continue;
-      seen.add(mountPoint);
-      mountsToCheck.push({ mountPoint, statPath: mountPoint });
+  let mountsToCheck: Array<{ mountPoint: string; statPath: string }> = [];
+  try {
+    mountsToCheck = useHostMount
+      ? readMountTargets(path.join(hostRoot, 'proc', 'mounts'), hostRoot)
+      : readMountTargets('/proc/mounts');
+  } catch (err) {
+    if (!useHostMount) {
+      logger.warn('disk', `Failed to read /proc/mounts: ${(err as Error).message}`);
+      return [];
     }
+
+    logger.warn('disk', `Failed to read host mounts from ${path.join(hostRoot, 'proc', 'mounts')}: ${(err as Error).message}`);
+    return [];
+  }
+
+  if (!useHostMount) {
+    logger.warn('disk', 'Host root not mounted â€” reading container filesystem instead');
   }
 
   const results: DiskResult[] = [];
@@ -69,7 +97,7 @@ function collectDisk(config: DiskConfig): DiskResult[] {
 
       results.push({ mountPoint, totalGb, usedGb, usedPercent });
 
-      const warn = usedPercent >= (config.diskWarnPercent || 85) ? ' \u26a0\ufe0f' : '';
+      const warn = usedPercent >= (config.diskWarnPercent ?? 85) ? ' ⚠️' : '';
       logger.info('disk', `${mountPoint}: ${usedGb}/${totalGb}GB (${usedPercent}%)${warn}`);
     } catch (err) {
       logger.warn('disk', `Failed to stat ${mountPoint}: ${(err as Error).message}`);

--- a/src/collectors/disk-io.ts
+++ b/src/collectors/disk-io.ts
@@ -10,9 +10,59 @@ interface DiskStats {
   writeSectors: number;
 }
 
-// Previous sample for delta calculation
-let prevStats: Record<string, DiskStats> | null = null;
-let prevTime: number | null = null;
+interface SampleState {
+  prevStats: Record<string, DiskStats>;
+  prevTime: number;
+}
+
+const sampleStateByPath: Record<string, SampleState> = Object.create(null);
+
+function parseCounter(value: string | undefined): number | null {
+  if (value == null || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isTrackedDevice(device: string): boolean {
+  return /^(sd[a-z]+|nvme\d+n\d+|vd[a-z]+|xvd[a-z]+|mmcblk\d+|dm-\d+|md\d+)$/.test(device);
+}
+
+function isLogicalAggregateDevice(device: string): boolean {
+  return /^(dm-\d+|md\d+)$/.test(device);
+}
+
+function listExcludedSlaveDevices(hostRoot: string, devices: Iterable<string>): Set<string> {
+  const excluded = new Set<string>();
+
+  for (const device of devices) {
+    if (!isLogicalAggregateDevice(device)) continue;
+
+    try {
+      const slaveDir = path.join(hostRoot, 'sys', 'block', device, 'slaves');
+      for (const slave of fs.readdirSync(slaveDir)) {
+        if (slave) excluded.add(slave);
+      }
+    } catch {
+      // Missing slave metadata â€” keep raw devices rather than undercounting.
+    }
+  }
+
+  return excluded;
+}
+
+function mergeStats(
+  prevStats: Record<string, DiskStats>,
+  currentStats: Record<string, DiskStats>,
+  malformedDevices: Set<string>
+): Record<string, DiskStats> {
+  const merged: Record<string, DiskStats> = { ...currentStats };
+
+  for (const device of malformedDevices) {
+    if (prevStats[device]) merged[device] = prevStats[device];
+  }
+
+  return merged;
+}
 
 /**
  * Collect disk I/O from /proc/diskstats (delta-based).
@@ -20,60 +70,69 @@ let prevTime: number | null = null;
  */
 function collectDiskIO(config?: DiskIOConfig): { readBytesPerSec: number; writeBytesPerSec: number } | null {
   const hostRoot = config?.hostRoot || '/host';
-  const diskstatsPath = path.join(hostRoot, 'proc/diskstats');
+  const diskstatsPath = path.join(hostRoot, 'proc', 'diskstats');
 
   try {
     const content = fs.readFileSync(diskstatsPath, 'utf8');
     const now = Date.now();
     const stats: Record<string, DiskStats> = {};
+    const malformedDevices = new Set<string>();
 
     for (const line of content.trim().split('\n')) {
       const parts = line.trim().split(/\s+/);
       if (parts.length < 14) continue;
+
       const device = parts[2];
+      if (!isTrackedDevice(device)) continue;
 
-      // Only real devices (skip partitions like sda1, nvme0n1p1)
-      if (!device.match(/^(sd[a-z]+|nvme\d+n\d+|vd[a-z]+|xvd[a-z]+)$/)) continue;
+      const readSectors = parseCounter(parts[5]);
+      const writeSectors = parseCounter(parts[9]);
+      if (readSectors == null || writeSectors == null) {
+        malformedDevices.add(device);
+        continue;
+      }
 
-      stats[device] = {
-        readSectors: parseInt(parts[5], 10) || 0,   // sectors read
-        writeSectors: parseInt(parts[9], 10) || 0,   // sectors written
-      };
+      stats[device] = { readSectors, writeSectors };
     }
 
     if (Object.keys(stats).length === 0) {
-      prevStats = null;
-      prevTime = null;
+      if (malformedDevices.size > 0) return null;
+      delete sampleStateByPath[diskstatsPath];
       return null;
     }
 
-    if (!prevStats || !prevTime) {
-      prevStats = stats;
-      prevTime = now;
-      return null; // First sample — gathering baseline
+    const state = sampleStateByPath[diskstatsPath];
+    if (!state) {
+      sampleStateByPath[diskstatsPath] = { prevStats: stats, prevTime: now };
+      return null;
     }
 
-    const elapsedSec = (now - prevTime) / 1000;
+    const mergedStats = mergeStats(state.prevStats, stats, malformedDevices);
+    const elapsedSec = (now - state.prevTime) / 1000;
     if (elapsedSec < 1) {
-      prevStats = stats;
-      prevTime = now;
+      sampleStateByPath[diskstatsPath] = { prevStats: mergedStats, prevTime: now };
       return null;
     }
 
+    const currentAggregateDevices = new Set<string>([
+      ...Object.keys(stats).filter(isLogicalAggregateDevice),
+      ...Array.from(malformedDevices).filter(isLogicalAggregateDevice),
+    ]);
+    const excludedSlaves = listExcludedSlaveDevices(hostRoot, currentAggregateDevices);
     let totalReadBytesPerSec = 0;
     let totalWriteBytesPerSec = 0;
 
     for (const [device, curr] of Object.entries(stats)) {
-      const prev = prevStats[device];
+      if (excludedSlaves.has(device)) continue;
+
+      const prev = state.prevStats[device];
       if (!prev) continue;
-      // Sector size = 512 bytes
+
       totalReadBytesPerSec += Math.max(0, (curr.readSectors - prev.readSectors) * 512 / elapsedSec);
       totalWriteBytesPerSec += Math.max(0, (curr.writeSectors - prev.writeSectors) * 512 / elapsedSec);
     }
 
-    prevStats = stats;
-    prevTime = now;
-
+    sampleStateByPath[diskstatsPath] = { prevStats: mergedStats, prevTime: now };
     return {
       readBytesPerSec: Math.round(totalReadBytesPerSec),
       writeBytesPerSec: Math.round(totalWriteBytesPerSec),

--- a/src/collectors/disk.ts
+++ b/src/collectors/disk.ts
@@ -1,4 +1,5 @@
 import fs = require('fs');
+import path = require('path');
 import logger = require('../utils/logger');
 
 interface DiskConfig {
@@ -13,48 +14,75 @@ interface DiskResult {
   usedPercent: number;
 }
 
+function decodeMountField(value: string): string {
+  return value.replace(/\\([0-7]{3})/g, (_, octal: string) => String.fromCharCode(parseInt(octal, 8)));
+}
+
+function isBlockDeviceSource(source: string): boolean {
+  return /^\/dev\/(?:mapper\/\S+|dm-\d+|sd[a-z]+\d*|nvme\d+n\d+(?:p\d+)?|vd[a-z]+\d*|xvd[a-z]+\d*|md\d+|mmcblk\d+(?:p\d+)?|root)$/.test(source);
+}
+
+function getStatPath(hostRoot: string, mountPoint: string): string {
+  if (mountPoint === '/') return hostRoot;
+  return path.join(hostRoot, mountPoint.replace(/^\/+/, ''));
+}
+
+function readMountTargets(mountsPath: string, hostRoot?: string): Array<{ mountPoint: string; statPath: string }> {
+  const mounts = fs.readFileSync(mountsPath, 'utf8');
+  const seen = new Set<string>();
+  const mountsToCheck: Array<{ mountPoint: string; statPath: string }> = [];
+
+  for (const line of mounts.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 2) continue;
+
+    const source = decodeMountField(parts[0]);
+    if (!isBlockDeviceSource(source)) continue;
+
+    const mountPoint = decodeMountField(parts[1]);
+    if (seen.has(mountPoint)) continue;
+    seen.add(mountPoint);
+
+    mountsToCheck.push({
+      mountPoint,
+      statPath: hostRoot ? getStatPath(hostRoot, mountPoint) : mountPoint,
+    });
+  }
+
+  return mountsToCheck;
+}
+
 /**
  * Collect disk usage stats.
- * Returns plain data array — no DB writes.
+ * Returns plain data array â€” no DB writes.
  */
 function collectDisk(config: DiskConfig): DiskResult[] {
   const hostRoot = config.hostRoot;
-  const useHostMount = fs.existsSync(hostRoot) && fs.statSync(hostRoot).isDirectory();
 
-  const mountsToCheck: Array<{ mountPoint: string; statPath: string }> = [];
+  let useHostMount = false;
+  try {
+    useHostMount = fs.existsSync(hostRoot) && fs.statSync(hostRoot).isDirectory();
+  } catch {
+    useHostMount = false;
+  }
 
-  if (useHostMount) {
-    mountsToCheck.push({ mountPoint: '/', statPath: hostRoot });
-
-    try {
-      const hostStat = fs.statfsSync(hostRoot);
-      const hostFsId = `${hostStat.type}:${hostStat.blocks}`;
-
-      for (const dir of ['home', 'mnt', 'opt', 'var', 'srv']) {
-        const fullPath = `${hostRoot}/${dir}`;
-        try {
-          if (!fs.statSync(fullPath).isDirectory()) continue;
-          const dirStat = fs.statfsSync(fullPath);
-          const dirFsId = `${dirStat.type}:${dirStat.blocks}`;
-          if (dirFsId !== hostFsId) {
-            mountsToCheck.push({ mountPoint: `/${dir}`, statPath: fullPath });
-          }
-        } catch { /* dir doesn't exist or can't stat */ }
-      }
-    } catch { /* can't stat host root */ }
-  } else {
-    logger.warn('disk', 'Host root not mounted — reading container filesystem instead');
-    const mounts = fs.readFileSync('/proc/mounts', 'utf8');
-    const seen = new Set<string>();
-
-    for (const line of mounts.split('\n')) {
-      if (!/^\/dev\/(sd|nvme|vd|xvd|loop|mapper\/)/.test(line)) continue;
-      const parts = line.split(/\s+/);
-      const mountPoint = parts[1];
-      if (seen.has(mountPoint)) continue;
-      seen.add(mountPoint);
-      mountsToCheck.push({ mountPoint, statPath: mountPoint });
+  let mountsToCheck: Array<{ mountPoint: string; statPath: string }> = [];
+  try {
+    mountsToCheck = useHostMount
+      ? readMountTargets(path.join(hostRoot, 'proc', 'mounts'), hostRoot)
+      : readMountTargets('/proc/mounts');
+  } catch (err) {
+    if (!useHostMount) {
+      logger.warn('disk', `Failed to read /proc/mounts: ${(err as Error).message}`);
+      return [];
     }
+
+    logger.warn('disk', `Failed to read host mounts from ${path.join(hostRoot, 'proc', 'mounts')}: ${(err as Error).message}`);
+    return [];
+  }
+
+  if (!useHostMount) {
+    logger.warn('disk', 'Host root not mounted â€” reading container filesystem instead');
   }
 
   const results: DiskResult[] = [];
@@ -69,7 +97,7 @@ function collectDisk(config: DiskConfig): DiskResult[] {
 
       results.push({ mountPoint, totalGb, usedGb, usedPercent });
 
-      const warn = usedPercent >= (config.diskWarnPercent || 85) ? ' \u26a0\ufe0f' : '';
+      const warn = usedPercent >= (config.diskWarnPercent ?? 85) ? ' ⚠️' : '';
       logger.info('disk', `${mountPoint}: ${usedGb}/${totalGb}GB (${usedPercent}%)${warn}`);
     } catch (err) {
       logger.warn('disk', `Failed to stat ${mountPoint}: ${(err as Error).message}`);

--- a/tests/integration/collect-and-digest.test.ts
+++ b/tests/integration/collect-and-digest.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 const fs = require('fs');
+const path = require('path');
 const { createTestDb } = require('../helpers/db');
 const { createMockDocker, suppressConsole } = require('../helpers/mocks');
 
@@ -22,12 +23,18 @@ describe('integration: collect and digest', () => {
   it('full pipeline: collect → ingest → build digest → render', async () => {
     const docker = createMockDocker();
     const config = { hostRoot: '/host', diskWarnPercent: 85 };
+    const originalReadFileSync = fs.readFileSync.bind(fs);
+    const hostMountsPath = path.join(config.hostRoot, 'proc', 'mounts');
 
     mock.method(fs, 'existsSync', (p: string) => p === '/host');
     mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
     mock.method(fs, 'statfsSync', () => ({
       bsize: 4096, blocks: 25000000, bavail: 12500000, type: 0xEF53,
     }));
+    mock.method(fs, 'readFileSync', (p: string, ...args: unknown[]) => {
+      if (p === hostMountsPath) return '/dev/sda1 / ext4 rw 0 0\n';
+      return originalReadFileSync(p, ...(args as []));
+    });
 
     // Load modules fresh
     delete require.cache[require.resolve('../../src/collectors/containers')];

--- a/tests/unit/disk-io.test.ts
+++ b/tests/unit/disk-io.test.ts
@@ -274,8 +274,8 @@ describe('collectDiskIO', () => {
 
     assert.ok(agentResult);
     assert.ok(standaloneResult);
-    assert.equal(agentResult.readBytesPerSec, standaloneResult.readBytesPerSec);
-    assert.equal(agentResult.writeBytesPerSec, standaloneResult.writeBytesPerSec);
+    assert.ok(Math.abs(agentResult.readBytesPerSec - standaloneResult.readBytesPerSec) < 10_000);
+    assert.ok(Math.abs(agentResult.writeBytesPerSec - standaloneResult.writeBytesPerSec) < 10_000);
   });
 
   it('keeps slave raw disks excluded when the dm row is malformed', async () => {

--- a/tests/unit/disk-io.test.ts
+++ b/tests/unit/disk-io.test.ts
@@ -4,117 +4,305 @@ import fs = require('fs');
 import path = require('path');
 import os = require('os');
 
-function loadCollector(): { collectDiskIO: (config: any) => any } {
+function loadCollectors(): {
+  collectDiskIO: (config: any) => any;
+  standaloneCollectDiskIO: (config: any) => any;
+} {
   delete require.cache[require.resolve('../../agent/src/collectors/disk-io')];
-  return require('../../agent/src/collectors/disk-io');
+  delete require.cache[require.resolve('../../src/collectors/disk-io')];
+  return {
+    collectDiskIO: require('../../agent/src/collectors/disk-io').collectDiskIO,
+    standaloneCollectDiskIO: require('../../src/collectors/disk-io').collectDiskIO,
+  };
 }
 
-// /proc/diskstats fields (kernel docs):
-//  1 major  2 minor  3 device  4 reads  5 reads_merged  6 read_sectors  7 read_ms
-//  8 writes 9 writes_merged 10 write_sectors 11 write_ms 12 in_flight 13 io_ms 14 io_weighted_ms
-function diskstatsLine(device: string, readSectors: number, writeSectors: number): string {
+function diskstatsLine(device: string, readSectors: number | string, writeSectors: number | string): string {
   return `   8       0 ${device} 0 0 ${readSectors} 0 0 0 ${writeSectors} 0 0 0 0`;
 }
 
 describe('collectDiskIO', () => {
   let tmpRoot: string;
+  let tmpRoot2: string;
 
   beforeEach(() => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'insightd-diskio-'));
+    tmpRoot2 = fs.mkdtempSync(path.join(os.tmpdir(), 'insightd-diskio-'));
     fs.mkdirSync(path.join(tmpRoot, 'proc'), { recursive: true });
+    fs.mkdirSync(path.join(tmpRoot2, 'proc'), { recursive: true });
   });
 
   afterEach(() => {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
+    fs.rmSync(tmpRoot2, { recursive: true, force: true });
   });
 
-  function writeDiskstats(lines: string[]): void {
-    fs.writeFileSync(path.join(tmpRoot, 'proc/diskstats'), lines.join('\n') + '\n');
+  function writeDiskstats(root: string, lines: string[]): void {
+    fs.writeFileSync(path.join(root, 'proc', 'diskstats'), lines.join('\n') + '\n');
+  }
+
+  function writeBlockSlaves(root: string, device: string, slaves: string[]): void {
+    const slaveDir = path.join(root, 'sys', 'block', device, 'slaves');
+    fs.mkdirSync(slaveDir, { recursive: true });
+    for (const slave of slaves) {
+      fs.mkdirSync(path.join(slaveDir, slave), { recursive: true });
+    }
   }
 
   it('returns null on first sample (baseline)', () => {
-    writeDiskstats([diskstatsLine('sda', 1000, 2000)]);
-    const { collectDiskIO } = loadCollector();
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 1000, 2000)]);
+    const { collectDiskIO } = loadCollectors();
     assert.equal(collectDiskIO({ hostRoot: tmpRoot }), null);
   });
 
-  it('computes bytes-per-second from sector deltas (sector = 512 bytes)', async () => {
-    writeDiskstats([diskstatsLine('sda', 1000, 2000)]);
-    const { collectDiskIO } = loadCollector();
+  it('computes bytes-per-second from sector deltas', async () => {
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 1000, 2000)]);
+    const { collectDiskIO } = loadCollectors();
     collectDiskIO({ hostRoot: tmpRoot });
 
     await new Promise(r => setTimeout(r, 1100));
 
-    writeDiskstats([diskstatsLine('sda', 11000, 22000)]);
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 11000, 22000)]);
     const result = collectDiskIO({ hostRoot: tmpRoot });
     assert.ok(result);
-    // 10000 read sectors * 512 / ~1.1s ≈ 4_654_545 bytes/sec
     assert.ok(result.readBytesPerSec > 4_000_000 && result.readBytesPerSec < 6_000_000, `got ${result.readBytesPerSec}`);
     assert.ok(result.writeBytesPerSec > 8_000_000 && result.writeBytesPerSec < 11_000_000, `got ${result.writeBytesPerSec}`);
   });
 
-  it('skips loop devices, partitions, and dm- devices', async () => {
-    writeDiskstats([
+  it('skips loop devices and partitions', async () => {
+    writeDiskstats(tmpRoot, [
       diskstatsLine('loop0', 1000, 1000),
-      diskstatsLine('sda1', 1000, 1000),  // partition
-      diskstatsLine('dm-0', 1000, 1000),
-      diskstatsLine('sda', 1000, 2000),    // real device
+      diskstatsLine('sda1', 1000, 1000),
+      diskstatsLine('sda', 1000, 2000),
     ]);
-    const { collectDiskIO } = loadCollector();
+    const { collectDiskIO } = loadCollectors();
     collectDiskIO({ hostRoot: tmpRoot });
 
     await new Promise(r => setTimeout(r, 1100));
 
-    writeDiskstats([
+    writeDiskstats(tmpRoot, [
       diskstatsLine('loop0', 1_000_000, 1_000_000),
       diskstatsLine('sda1', 1_000_000, 1_000_000),
-      diskstatsLine('dm-0', 1_000_000, 1_000_000),
-      diskstatsLine('sda', 11000, 22000),
+      diskstatsLine('sda', 11_000, 22_000),
     ]);
     const result = collectDiskIO({ hostRoot: tmpRoot });
     assert.ok(result);
-    // Only sda should contribute — well below the millions of sectors loop/dm/sda1 changed
     assert.ok(result.readBytesPerSec < 100_000_000, `virtual devices should be skipped, got ${result.readBytesPerSec}`);
   });
 
   it('aggregates across multiple real devices', async () => {
-    writeDiskstats([
+    writeDiskstats(tmpRoot, [
       diskstatsLine('sda', 1000, 2000),
       diskstatsLine('nvme0n1', 1000, 2000),
       diskstatsLine('vdb', 1000, 2000),
     ]);
-    const { collectDiskIO } = loadCollector();
+    const { collectDiskIO } = loadCollectors();
     collectDiskIO({ hostRoot: tmpRoot });
 
     await new Promise(r => setTimeout(r, 1100));
 
-    writeDiskstats([
+    writeDiskstats(tmpRoot, [
       diskstatsLine('sda', 2000, 3000),
       diskstatsLine('nvme0n1', 2000, 3000),
       diskstatsLine('vdb', 2000, 3000),
     ]);
     const result = collectDiskIO({ hostRoot: tmpRoot });
     assert.ok(result);
-    // Each device adds 1000 sectors of read = 512000 bytes / ~1.1s ≈ 465000 per device, ×3 ≈ 1.4M
     assert.ok(result.readBytesPerSec > 1_000_000 && result.readBytesPerSec < 2_000_000);
   });
 
-  it('returns null when /proc/diskstats is unreadable', () => {
-    const { collectDiskIO } = loadCollector();
-    assert.equal(collectDiskIO({ hostRoot: '/nonexistent-path' }), null);
-  });
-
-  it('clamps negative deltas to 0 (counter wrap)', async () => {
-    writeDiskstats([diskstatsLine('sda', 100000, 100000)]);
-    const { collectDiskIO } = loadCollector();
+  it('counts dm- devices and excludes their slave raw disks', async () => {
+    writeBlockSlaves(tmpRoot, 'dm-0', ['sda']);
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 1000, 2000),
+      diskstatsLine('dm-0', 1000, 2000),
+    ]);
+    const { collectDiskIO } = loadCollectors();
     collectDiskIO({ hostRoot: tmpRoot });
 
     await new Promise(r => setTimeout(r, 1100));
 
-    writeDiskstats([diskstatsLine('sda', 100, 100)]);
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 1_000_000, 1_000_000),
+      diskstatsLine('dm-0', 2000, 3000),
+    ]);
+    const result = collectDiskIO({ hostRoot: tmpRoot });
+    assert.ok(result);
+    assert.ok(result.readBytesPerSec > 300_000 && result.readBytesPerSec < 700_000, `expected dm-only read rate, got ${result.readBytesPerSec}`);
+    assert.ok(result.writeBytesPerSec > 300_000 && result.writeBytesPerSec < 700_000, `expected dm-only write rate, got ${result.writeBytesPerSec}`);
+  });
+
+  it('tracks mmcblk devices as real disks', async () => {
+    writeDiskstats(tmpRoot, [diskstatsLine('mmcblk0', 1000, 2000)]);
+    const { collectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [diskstatsLine('mmcblk0', 2000, 3000)]);
+    const result = collectDiskIO({ hostRoot: tmpRoot });
+    assert.ok(result);
+    assert.ok(result.readBytesPerSec > 300_000 && result.readBytesPerSec < 700_000, `expected mmc read rate, got ${result.readBytesPerSec}`);
+    assert.ok(result.writeBytesPerSec > 300_000 && result.writeBytesPerSec < 700_000, `expected mmc write rate, got ${result.writeBytesPerSec}`);
+  });
+
+  it('counts md devices and excludes their member disks', async () => {
+    writeBlockSlaves(tmpRoot, 'md0', ['sda', 'sdb']);
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 1000, 2000),
+      diskstatsLine('sdb', 1000, 2000),
+      diskstatsLine('md0', 1000, 2000),
+    ]);
+    const { collectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 50_000, 60_000),
+      diskstatsLine('sdb', 50_000, 60_000),
+      diskstatsLine('md0', 2000, 3000),
+    ]);
+    const result = collectDiskIO({ hostRoot: tmpRoot });
+    assert.ok(result);
+    assert.ok(result.readBytesPerSec > 300_000 && result.readBytesPerSec < 700_000, `expected md-only read rate, got ${result.readBytesPerSec}`);
+    assert.ok(result.writeBytesPerSec > 300_000 && result.writeBytesPerSec < 700_000, `expected md-only write rate, got ${result.writeBytesPerSec}`);
+  });
+
+  it('returns null when /proc/diskstats is unreadable', () => {
+    const { collectDiskIO } = loadCollectors();
+    assert.equal(collectDiskIO({ hostRoot: '/nonexistent-path' }), null);
+  });
+
+  it('clamps negative deltas to 0 (counter wrap)', async () => {
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 100000, 100000)]);
+    const { collectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 100, 100)]);
     const result = collectDiskIO({ hostRoot: tmpRoot });
     assert.ok(result);
     assert.equal(result.readBytesPerSec, 0);
     assert.equal(result.writeBytesPerSec, 0);
+  });
+
+  it('skips malformed sector fields without poisoning the next valid sample', async () => {
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 1000, 2000)]);
+    const { collectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 'not-a-number', 3000)]);
+    assert.equal(collectDiskIO({ hostRoot: tmpRoot }), null);
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 2000, 3000)]);
+    const result = collectDiskIO({ hostRoot: tmpRoot });
+    assert.ok(result);
+    assert.ok(result.readBytesPerSec > 200_000 && result.readBytesPerSec < 300_000, `expected baseline-preserving read rate, got ${result.readBytesPerSec}`);
+    assert.ok(result.writeBytesPerSec > 200_000 && result.writeBytesPerSec < 300_000, `expected baseline-preserving write rate, got ${result.writeBytesPerSec}`);
+  });
+
+  it('keeps baseline state isolated per hostRoot', async () => {
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 1000, 2000)]);
+    writeDiskstats(tmpRoot2, [diskstatsLine('sda', 5000, 7000)]);
+    const { collectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+    collectDiskIO({ hostRoot: tmpRoot2 });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [diskstatsLine('sda', 2000, 3000)]);
+    writeDiskstats(tmpRoot2, [diskstatsLine('sda', 5500, 7600)]);
+    const result1 = collectDiskIO({ hostRoot: tmpRoot });
+    const result2 = collectDiskIO({ hostRoot: tmpRoot2 });
+
+    assert.ok(result1);
+    assert.ok(result2);
+    assert.ok(result1.readBytesPerSec > 300_000 && result1.readBytesPerSec < 700_000, `root1 read rate incorrect: ${result1.readBytesPerSec}`);
+    assert.ok(result2.readBytesPerSec > 200_000 && result2.readBytesPerSec < 300_000, `root2 read rate incorrect: ${result2.readBytesPerSec}`);
+  });
+
+  it('matches standalone collector behavior for dm and malformed samples', async () => {
+    writeBlockSlaves(tmpRoot, 'dm-0', ['sda']);
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 1000, 2000),
+      diskstatsLine('dm-0', 1000, 2000),
+    ]);
+    const { collectDiskIO, standaloneCollectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+    standaloneCollectDiskIO({ hostRoot: tmpRoot });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 'bad', 3000),
+      diskstatsLine('dm-0', 2000, 3000),
+    ]);
+    const agentResult = collectDiskIO({ hostRoot: tmpRoot });
+    const standaloneResult = standaloneCollectDiskIO({ hostRoot: tmpRoot });
+    assert.ok(agentResult);
+    assert.ok(standaloneResult);
+    assert.ok(Math.abs(standaloneResult.readBytesPerSec - agentResult.readBytesPerSec) < 10_000);
+    assert.ok(Math.abs(standaloneResult.writeBytesPerSec - agentResult.writeBytesPerSec) < 10_000);
+  });
+
+  it('matches standalone collector behavior for mmcblk and md devices', async () => {
+    writeBlockSlaves(tmpRoot, 'md0', ['sda']);
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 1000, 2000),
+      diskstatsLine('md0', 1000, 2000),
+      diskstatsLine('mmcblk0', 1000, 2000),
+    ]);
+    const { collectDiskIO, standaloneCollectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+    standaloneCollectDiskIO({ hostRoot: tmpRoot });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 100_000, 100_000),
+      diskstatsLine('md0', 2000, 3000),
+      diskstatsLine('mmcblk0', 2000, 3000),
+    ]);
+
+    const agentResult = collectDiskIO({ hostRoot: tmpRoot });
+    const standaloneResult = standaloneCollectDiskIO({ hostRoot: tmpRoot });
+
+    assert.ok(agentResult);
+    assert.ok(standaloneResult);
+    assert.equal(agentResult.readBytesPerSec, standaloneResult.readBytesPerSec);
+    assert.equal(agentResult.writeBytesPerSec, standaloneResult.writeBytesPerSec);
+  });
+
+  it('keeps slave raw disks excluded when the dm row is malformed', async () => {
+    writeBlockSlaves(tmpRoot, 'dm-0', ['sda']);
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 1000, 2000),
+      diskstatsLine('dm-0', 1000, 2000),
+    ]);
+    const { collectDiskIO, standaloneCollectDiskIO } = loadCollectors();
+    collectDiskIO({ hostRoot: tmpRoot });
+    standaloneCollectDiskIO({ hostRoot: tmpRoot });
+
+    await new Promise(r => setTimeout(r, 1100));
+
+    writeDiskstats(tmpRoot, [
+      diskstatsLine('sda', 10_000, 20_000),
+      diskstatsLine('dm-0', 'bad', 3000),
+    ]);
+
+    const agentResult = collectDiskIO({ hostRoot: tmpRoot });
+    const standaloneResult = standaloneCollectDiskIO({ hostRoot: tmpRoot });
+
+    assert.ok(agentResult);
+    assert.ok(standaloneResult);
+    assert.equal(agentResult.readBytesPerSec, 0);
+    assert.equal(agentResult.writeBytesPerSec, 0);
+    assert.equal(standaloneResult.readBytesPerSec, 0);
+    assert.equal(standaloneResult.writeBytesPerSec, 0);
   });
 });

--- a/tests/unit/disk.test.ts
+++ b/tests/unit/disk.test.ts
@@ -1,16 +1,26 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import path from 'node:path';
+
 const fs = require('fs');
 const { suppressConsole } = require('../helpers/mocks');
 
+function loadCollectors(): { collectDisk: Function; standaloneCollectDisk: Function } {
+  delete require.cache[require.resolve('../../agent/src/collectors/disk')];
+  delete require.cache[require.resolve('../../src/collectors/disk')];
+  return {
+    collectDisk: require('../../agent/src/collectors/disk').collectDisk,
+    standaloneCollectDisk: require('../../src/collectors/disk').collectDisk,
+  };
+}
+
 describe('collectDisk', () => {
-  let collectDisk: Function;
+  let collectDisk: Function, standaloneCollectDisk: Function;
   let restore: () => void;
 
   beforeEach(() => {
     restore = suppressConsole();
-    delete require.cache[require.resolve('../../src/collectors/disk')];
-    collectDisk = require('../../src/collectors/disk').collectDisk;
+    ({ collectDisk, standaloneCollectDisk } = loadCollectors());
   });
 
   afterEach(() => {
@@ -18,74 +28,174 @@ describe('collectDisk', () => {
     mock.restoreAll();
   });
 
-  it('stats host root when /host exists', () => {
+  it('discovers arbitrary host mounts from host proc mounts and maps stat paths under hostRoot', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+    const statfsCalls: string[] = [];
+
     mock.method(fs, 'existsSync', (p: string) => p === '/host');
     mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
-    mock.method(fs, 'statfsSync', () => ({
-      bsize: 4096, blocks: 25000000, bavail: 12500000, type: 0xEF53,
-    }));
+    mock.method(fs, 'readFileSync', (p: string) => {
+      assert.equal(p, path.join('/host', 'proc', 'mounts'));
+      return [
+        '/dev/sda1 / ext4 rw 0 0',
+        '/dev/mapper/vg-data /data ext4 rw 0 0',
+      ].join('\n');
+    });
+    mock.method(fs, 'statfsSync', (p: string) => {
+      statfsCalls.push(p);
+      if (p === '/host') return { bsize: 4096, blocks: 25_000_000, bavail: 12_500_000 };
+      if (p === path.join('/host', 'data')) return { bsize: 4096, blocks: 50_000_000, bavail: 10_000_000 };
+      throw new Error(`unexpected statfs path ${p}`);
+    });
 
-    const config = { hostRoot: '/host', diskWarnPercent: 85 };
     const result = collectDisk(config);
-
-    assert.equal(result.length, 1);
-    assert.equal(result[0].mountPoint, '/');
-    assert.ok(result[0].totalGb > 0);
-    assert.ok(result[0].usedGb > 0);
+    assert.deepEqual(
+      result.map((r: any) => r.mountPoint),
+      ['/', '/data']
+    );
+    assert.deepEqual(statfsCalls, ['/host', path.join('/host', 'data')]);
   });
 
-  it('falls back to /proc/mounts when host not mounted', () => {
+  it('falls back to /proc/mounts when host root is not mounted', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+
     mock.method(fs, 'existsSync', () => false);
-    mock.method(fs, 'readFileSync', () =>
-      '/dev/sda1 / ext4 rw,relatime 0 0\ntmpfs /tmp tmpfs rw 0 0\n'
-    );
+    mock.method(fs, 'readFileSync', (p: string) => {
+      assert.equal(p, '/proc/mounts');
+      return [
+        '/dev/sda1 / ext4 rw 0 0',
+        'tmpfs /tmp tmpfs rw 0 0',
+      ].join('\n');
+    });
     mock.method(fs, 'statfsSync', () => ({
-      bsize: 4096, blocks: 25000000, bavail: 12500000, type: 0xEF53,
+      bsize: 4096, blocks: 25_000_000, bavail: 12_500_000,
     }));
 
-    const config = { hostRoot: '/host', diskWarnPercent: 85 };
     const result = collectDisk(config);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].mountPoint, '/');
+  });
 
+  it('includes device-mapper-backed mounts once', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+
+    mock.method(fs, 'existsSync', (p: string) => p === '/host');
+    mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
+    mock.method(fs, 'readFileSync', () => [
+      '/dev/mapper/vg-data /data ext4 rw 0 0',
+      '/dev/mapper/vg-data /data ext4 rw 0 0',
+    ].join('\n'));
+    mock.method(fs, 'statfsSync', () => ({
+      bsize: 4096, blocks: 25_000_000, bavail: 12_500_000,
+    }));
+
+    const result = collectDisk(config);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].mountPoint, '/data');
+  });
+
+  it('includes mmcblk-backed mounts', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+
+    mock.method(fs, 'existsSync', (p: string) => p === '/host');
+    mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
+    mock.method(fs, 'readFileSync', () => '/dev/mmcblk0p2 / ext4 rw 0 0\n');
+    mock.method(fs, 'statfsSync', () => ({
+      bsize: 4096, blocks: 25_000_000, bavail: 12_500_000,
+    }));
+
+    const result = collectDisk(config);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].mountPoint, '/');
+  });
+
+  it('excludes loop-backed mounts from disk results', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+
+    mock.method(fs, 'existsSync', (p: string) => p === '/host');
+    mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
+    mock.method(fs, 'readFileSync', () => [
+      '/dev/loop0 /snap/core squashfs ro 0 0',
+      '/dev/sda1 / ext4 rw 0 0',
+    ].join('\n'));
+    mock.method(fs, 'statfsSync', () => ({
+      bsize: 4096, blocks: 25_000_000, bavail: 12_500_000,
+    }));
+
+    const result = collectDisk(config);
     assert.equal(result.length, 1);
     assert.equal(result[0].mountPoint, '/');
   });
 
   it('calculates GB correctly', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+
     mock.method(fs, 'existsSync', (p: string) => p === '/host');
     mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
+    mock.method(fs, 'readFileSync', () => '/dev/sda1 / ext4 rw 0 0\n');
     mock.method(fs, 'statfsSync', () => ({
-      bsize: 4096, blocks: 24414062, bavail: 2441406, type: 0xEF53,
+      bsize: 4096, blocks: 24_414_062, bavail: 2_441_406,
     }));
 
-    const config = { hostRoot: '/host', diskWarnPercent: 85 };
     const result = collectDisk(config);
-
     assert.ok(result[0].totalGb > 99 && result[0].totalGb < 101);
     assert.ok(result[0].usedPercent > 89 && result[0].usedPercent < 91);
   });
 
-  it('returns data without DB dependency', () => {
+  it('handles per-mount statfs failure gracefully', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+
     mock.method(fs, 'existsSync', (p: string) => p === '/host');
     mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
-    mock.method(fs, 'statfsSync', () => ({
-      bsize: 4096, blocks: 25000000, bavail: 12500000, type: 0xEF53,
-    }));
+    mock.method(fs, 'readFileSync', () => [
+      '/dev/sda1 / ext4 rw 0 0',
+      '/dev/mapper/vg-data /data ext4 rw 0 0',
+    ].join('\n'));
+    mock.method(fs, 'statfsSync', (p: string) => {
+      if (p === '/host') return { bsize: 4096, blocks: 25_000_000, bavail: 12_500_000 };
+      throw new Error('ENOENT');
+    });
 
-    const config = { hostRoot: '/host', diskWarnPercent: 85 };
     const result = collectDisk(config);
-
-    assert.ok(Array.isArray(result));
-    assert.ok(result[0].mountPoint);
-    assert.ok(typeof result[0].totalGb === 'number');
+    assert.equal(result.length, 1);
+    assert.equal(result[0].mountPoint, '/');
   });
 
-  it('handles statfs failure gracefully', () => {
+  it('matches standalone collector behavior for host mount discovery', () => {
+    const config = { hostRoot: '/host', diskWarnPercent: 85 };
+
     mock.method(fs, 'existsSync', (p: string) => p === '/host');
     mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
-    mock.method(fs, 'statfsSync', () => { throw new Error('ENOENT'); });
+    mock.method(fs, 'readFileSync', () => [
+      '/dev/sda1 / ext4 rw 0 0',
+      '/dev/mapper/vg-data /data ext4 rw 0 0',
+    ].join('\n'));
+    mock.method(fs, 'statfsSync', (p: string) => {
+      if (p === '/host') return { bsize: 4096, blocks: 25_000_000, bavail: 12_500_000 };
+      if (p === path.join('/host', 'data')) return { bsize: 4096, blocks: 50_000_000, bavail: 10_000_000 };
+      throw new Error(`unexpected statfs path ${p}`);
+    });
 
+    const agentResult = collectDisk(config);
+    const standaloneResult = standaloneCollectDisk(config);
+    assert.deepEqual(standaloneResult, agentResult);
+  });
+
+  it('matches standalone collector behavior for mmcblk and loop filtering', () => {
     const config = { hostRoot: '/host', diskWarnPercent: 85 };
-    const result = collectDisk(config);
-    assert.equal(result.length, 0);
+
+    mock.method(fs, 'existsSync', (p: string) => p === '/host');
+    mock.method(fs, 'statSync', () => ({ isDirectory: () => true }));
+    mock.method(fs, 'readFileSync', () => [
+      '/dev/mmcblk0p2 / ext4 rw 0 0',
+      '/dev/loop0 /snap/core squashfs ro 0 0',
+    ].join('\n'));
+    mock.method(fs, 'statfsSync', () => ({
+      bsize: 4096, blocks: 25_000_000, bavail: 12_500_000,
+    }));
+
+    const agentResult = collectDisk(config);
+    const standaloneResult = standaloneCollectDisk(config);
+    assert.deepEqual(standaloneResult, agentResult);
   });
 });


### PR DESCRIPTION
## Summary
- replace hardcoded disk mount probing with mount-file discovery in both live collector paths
- harden disk I/O parsing, scope baselines per host root, and support dm-/md-/mmc-backed storage without double counting slave disks
- expand focused disk and disk I/O regression coverage, including parity checks for agent and standalone collectors

## Testing
- npx tsx --test tests/unit/disk.test.ts
- npx tsx --test tests/unit/disk-io.test.ts
- npm run typecheck
