### PR TITLE
feat(k8s): source host disk usage from kubelet /stats/summary

### DIFF
--- a/agent/src/runtime/kubernetes.ts
+++ b/agent/src/runtime/kubernetes.ts
@@ -4,7 +4,7 @@ import logger = require('../../../shared/utils/logger');
 import type {
   ContainerRuntime, ContainerInfo, ContainerWithResources,
   LogEntry, LogOptions, ContainerAction, ActionResult, ImageUpdate,
-  HostMetricsOverride,
+  HostMetricsOverride, DiskResult,
 } from './types';
 
 const { safeCollect } = require('../../../shared/utils/errors') as {
@@ -746,6 +746,41 @@ export class KubernetesRuntime implements ContainerRuntime {
   }
 
   /**
+   * Node-level disk usage sourced from kubelet `/stats/summary`. Replaces
+   * the /proc-based `collectDisk` in k8s mode, where the DaemonSet's rootfs
+   * bind mount doesn't propagate nested host mounts and the meaningful
+   * numbers are kubelet's own `nodefs` and `imagefs` anyway.
+   *
+   * - `nodefs` is where kubelet stores its data (pod logs, emptyDir, etc.)
+   * - `imagefs` is where the container runtime stores pulled images
+   *
+   * When the two point to the same underlying filesystem (shared-disk
+   * nodes — the common case for small clusters), we emit a single
+   * `nodefs` entry to avoid double-counting.
+   */
+  async getDiskMetrics(): Promise<DiskResult[] | null> {
+    try {
+      const stats = await this.fetchKubeletStats();
+      const nodeFs = stats?.node?.fs as FsStats | undefined;
+      const imageFs = stats?.node?.runtime?.imageFs as FsStats | undefined;
+
+      const results: DiskResult[] = [];
+      const nodeEntry = fsStatsToDiskResult('nodefs', nodeFs);
+      if (nodeEntry) results.push(nodeEntry);
+
+      if (imageFs && !sameFilesystem(nodeFs, imageFs)) {
+        const imageEntry = fsStatsToDiskResult('imagefs', imageFs);
+        if (imageEntry) results.push(imageEntry);
+      }
+
+      return results.length > 0 ? results : null;
+    } catch (err) {
+      logger.warn('k8s-disk', `Failed to fetch kubelet disk stats: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
    * Fetch the kubelet's `/stats/summary` JSON. This is the per-node view
    * the kubelet maintains for its own scheduling decisions — much more
    * accurate than scraping cAdvisor for node-level totals.
@@ -962,6 +997,47 @@ export function parseQuantity(q: string | undefined | null): number | null {
   };
   const mult = multipliers[suffix];
   return mult != null ? num * mult : null;
+}
+
+/**
+ * Shape of the `fs` / `runtime.imageFs` blocks in kubelet `/stats/summary`.
+ * All fields are optional — older kubelets or misconfigured runtimes may
+ * omit any of them.
+ */
+interface FsStats {
+  capacityBytes?: number;
+  usedBytes?: number;
+  availableBytes?: number;
+}
+
+function fsStatsToDiskResult(mountPoint: string, fs: FsStats | undefined): DiskResult | null {
+  if (!fs) return null;
+  const total = fs.capacityBytes;
+  if (!Number.isFinite(total) || (total ?? 0) <= 0) return null;
+
+  // Prefer explicit `usedBytes`; fall back to `capacity - available` when
+  // kubelet only reports free space (seen on some cAdvisor configurations).
+  let used = fs.usedBytes;
+  if (!Number.isFinite(used) && Number.isFinite(fs.availableBytes)) {
+    used = (total as number) - (fs.availableBytes as number);
+  }
+  if (!Number.isFinite(used) || (used ?? 0) < 0) return null;
+
+  const totalGb = Math.round(((total as number) / 1e9) * 100) / 100;
+  const usedGb = Math.round(((used as number) / 1e9) * 100) / 100;
+  const usedPercent = totalGb > 0 ? Math.round((usedGb / totalGb) * 100 * 10) / 10 : 0;
+  return { mountPoint, totalGb, usedGb, usedPercent };
+}
+
+/**
+ * When kubelet reports nodefs and imagefs with identical capacity and
+ * usage, they're the same underlying filesystem — a single disk on the
+ * node. In that case we avoid emitting both to prevent apparent
+ * double-counting in the Storage page and alerts.
+ */
+function sameFilesystem(a: FsStats | undefined, b: FsStats | undefined): boolean {
+  if (!a || !b) return false;
+  return a.capacityBytes === b.capacityBytes && a.usedBytes === b.usedBytes;
 }
 
 function splitKubeTimestamp(line: string): { timestamp: string | null; message: string } {

--- a/agent/src/runtime/kubernetes.ts
+++ b/agent/src/runtime/kubernetes.ts
@@ -1030,14 +1030,27 @@ function fsStatsToDiskResult(mountPoint: string, fs: FsStats | undefined): DiskR
 }
 
 /**
- * When kubelet reports nodefs and imagefs with identical capacity and
- * usage, they're the same underlying filesystem — a single disk on the
- * node. In that case we avoid emitting both to prevent apparent
- * double-counting in the Storage page and alerts.
+ * When kubelet reports nodefs and imagefs with identical capacity AND
+ * available-bytes, they're the same underlying filesystem — a single
+ * disk shared between kubelet data and the container runtime's images.
+ *
+ * usedBytes legitimately differs between the two even on a shared disk:
+ * each tracks a different subtree (kubelet's rootDir vs. the image
+ * store), so imagefs.usedBytes is a subset of nodefs.usedBytes. Using
+ * `availableBytes` for the dedupe signal instead catches the shared-disk
+ * case without losing the separate-disk case — two filesystems on
+ * different disks can't happen to have identical free space, whereas
+ * two subtrees on the same disk always do.
+ *
+ * Without this dedupe, the UI would show two rows users would mentally
+ * sum (nodefs 24 GB + imagefs 1 GB = "25 GB used"), when in reality the
+ * disk only has 24 GB used.
  */
 function sameFilesystem(a: FsStats | undefined, b: FsStats | undefined): boolean {
   if (!a || !b) return false;
-  return a.capacityBytes === b.capacityBytes && a.usedBytes === b.usedBytes;
+  if (a.capacityBytes !== b.capacityBytes) return false;
+  if (a.availableBytes === undefined || b.availableBytes === undefined) return false;
+  return a.availableBytes === b.availableBytes;
 }
 
 function splitKubeTimestamp(line: string): { timestamp: string | null; message: string } {

--- a/agent/src/runtime/types.ts
+++ b/agent/src/runtime/types.ts
@@ -95,6 +95,19 @@ export interface VolumeInfo {
  * `null` mean "this runtime can't observe this metric meaningfully — emit
  * NULL rather than the bogus /proc value".
  */
+/**
+ * A single disk/filesystem usage entry. Shared between the on-host
+ * `collectDisk` collector (Docker/standalone) and runtime-provided disk
+ * metrics (Kubernetes — sourced from kubelet `/stats/summary` rather than
+ * `/proc/mounts`, which is unreliable inside a containerized agent).
+ */
+export interface DiskResult {
+  mountPoint: string;
+  totalGb: number;
+  usedGb: number;
+  usedPercent: number;
+}
+
 export interface HostMetricsOverride {
   cpuPercent?: number | null;
   memoryUsedMb?: number | null;
@@ -174,4 +187,18 @@ export interface ContainerRuntime {
    * Returns null on failure (scheduler keeps the /proc values).
    */
   getHostMetrics?(): Promise<HostMetricsOverride | null>;
+
+  /**
+   * Optional: return per-filesystem disk usage for the host/node. When
+   * defined, the scheduler uses this *instead of* the generic /proc/mounts
+   * collector. Intended for containerized runtimes (Kubernetes) where
+   * /proc/mounts and statfs(/host/...) can't give accurate nested-mount
+   * data without `mountPropagation: HostToContainer`, and where operators
+   * care about kubelet-level concepts (nodefs, imagefs) anyway.
+   *
+   * Returns null on failure. The scheduler treats null as "no disk data"
+   * rather than falling back to the /proc collector (which would report
+   * misleading numbers in k8s mode).
+   */
+  getDiskMetrics?(): Promise<DiskResult[] | null>;
 }

--- a/agent/src/scheduler.ts
+++ b/agent/src/scheduler.ts
@@ -49,7 +49,15 @@ function startAgentScheduler(runtime: ContainerRuntime, config: SchedulerConfig)
       containers = await safeCollect('resources', () => runtime.collectResources(containers!));
     }
 
-    const disk = await safeCollect('disk', () => Promise.resolve(collectDisk(config))) || [];
+    // Runtime-provided disk metrics (Kubernetes uses kubelet /stats/summary
+    // — /proc/mounts inside the DaemonSet can't see nested host mounts
+    // without mountPropagation=HostToContainer, and nodefs/imagefs are the
+    // meaningful units on a k8s node anyway). When the runtime opts in, we
+    // use it exclusively; falling back to collectDisk would produce the
+    // same misleading rootfs-only numbers the override is meant to avoid.
+    const disk = runtime.getDiskMetrics
+      ? (await safeCollect('disk', () => runtime.getDiskMetrics!())) || []
+      : await safeCollect('disk', () => Promise.resolve(collectDisk(config))) || [];
     const host = await safeCollect('host', () => Promise.resolve(collectHost(config)));
 
     // For containerized runtimes (k8s), /proc/* and /sys/* reflect the

--- a/tests/unit/kubernetes-runtime.test.ts
+++ b/tests/unit/kubernetes-runtime.test.ts
@@ -296,6 +296,7 @@ describe('KubernetesRuntime.getDiskMetrics', () => {
       node: {
         fs: { capacityBytes: 100e9, usedBytes: 40e9, availableBytes: 60e9 },
         runtime: {
+          // Different capacity → clearly a different physical disk
           imageFs: { capacityBytes: 500e9, usedBytes: 50e9, availableBytes: 450e9 },
         },
       },
@@ -307,18 +308,32 @@ describe('KubernetesRuntime.getDiskMetrics', () => {
     ]);
   });
 
-  it('dedupes when nodefs and imagefs share the same underlying filesystem', async () => {
-    const shared = { capacityBytes: 200e9, usedBytes: 60e9, availableBytes: 140e9 };
+  it('treats same capacity but different availableBytes as separate filesystems', async () => {
+    // Edge case: equal-size disks, but different free space → genuinely
+    // distinct mounts, not one shared disk. Don't dedupe.
     const runtime = makeRuntime({
       node: {
-        fs: shared,
-        runtime: { imageFs: { ...shared } },
+        fs:      { capacityBytes: 100e9, usedBytes: 40e9, availableBytes: 60e9 },
+        runtime: { imageFs: { capacityBytes: 100e9, usedBytes: 10e9, availableBytes: 90e9 } },
+      },
+    });
+    const disks = await runtime.getDiskMetrics();
+    assert.equal(disks.length, 2);
+  });
+
+  it('dedupes when nodefs and imagefs share a disk (same capacity + availableBytes, different usedBytes)', async () => {
+    // Real-world shape from a k3d node: kubelet reports separate usedBytes
+    // for each subtree (kubelet rootDir vs. image store), but capacity and
+    // availableBytes are identical because it's the same physical disk.
+    const runtime = makeRuntime({
+      node: {
+        fs:      { capacityBytes: 200e9, usedBytes: 60e9, availableBytes: 140e9 },
+        runtime: { imageFs: { capacityBytes: 200e9, usedBytes: 5e9,  availableBytes: 140e9 } },
       },
     });
     const disks = await runtime.getDiskMetrics();
     assert.equal(disks.length, 1);
     assert.equal(disks[0].mountPoint, 'nodefs');
-    assert.equal(disks[0].totalGb, 200);
     assert.equal(disks[0].usedGb, 60);
   });
 

--- a/tests/unit/kubernetes-runtime.test.ts
+++ b/tests/unit/kubernetes-runtime.test.ts
@@ -284,6 +284,83 @@ describe('KubernetesRuntime.getHostMetrics', () => {
   });
 });
 
+describe('KubernetesRuntime.getDiskMetrics', () => {
+  function makeRuntime(stats: any): any {
+    const runtime = new KubernetesRuntime({ nodeName: 'k3d-test', nodeIp: '127.0.0.1' });
+    runtime.fetchKubeletStats = async () => stats;
+    return runtime;
+  }
+
+  it('maps node.fs and imageFs to nodefs + imagefs when they are separate filesystems', async () => {
+    const runtime = makeRuntime({
+      node: {
+        fs: { capacityBytes: 100e9, usedBytes: 40e9, availableBytes: 60e9 },
+        runtime: {
+          imageFs: { capacityBytes: 500e9, usedBytes: 50e9, availableBytes: 450e9 },
+        },
+      },
+    });
+    const disks = await runtime.getDiskMetrics();
+    assert.deepEqual(disks, [
+      { mountPoint: 'nodefs', totalGb: 100, usedGb: 40, usedPercent: 40 },
+      { mountPoint: 'imagefs', totalGb: 500, usedGb: 50, usedPercent: 10 },
+    ]);
+  });
+
+  it('dedupes when nodefs and imagefs share the same underlying filesystem', async () => {
+    const shared = { capacityBytes: 200e9, usedBytes: 60e9, availableBytes: 140e9 };
+    const runtime = makeRuntime({
+      node: {
+        fs: shared,
+        runtime: { imageFs: { ...shared } },
+      },
+    });
+    const disks = await runtime.getDiskMetrics();
+    assert.equal(disks.length, 1);
+    assert.equal(disks[0].mountPoint, 'nodefs');
+    assert.equal(disks[0].totalGb, 200);
+    assert.equal(disks[0].usedGb, 60);
+  });
+
+  it('falls back to capacity - available when usedBytes is missing', async () => {
+    const runtime = makeRuntime({
+      node: {
+        fs: { capacityBytes: 50e9, availableBytes: 30e9 },
+      },
+    });
+    const disks = await runtime.getDiskMetrics();
+    assert.equal(disks.length, 1);
+    assert.equal(disks[0].usedGb, 20);
+    assert.equal(disks[0].usedPercent, 40);
+  });
+
+  it('returns null when kubelet has no fs data at all', async () => {
+    const runtime = makeRuntime({ node: {} });
+    const disks = await runtime.getDiskMetrics();
+    assert.equal(disks, null);
+  });
+
+  it('returns null when fetchKubeletStats throws', async () => {
+    const runtime = new KubernetesRuntime({ nodeName: 'k3d-test', nodeIp: '127.0.0.1' });
+    (runtime as any).fetchKubeletStats = async () => { throw new Error('kubelet down'); };
+    const disks = await (runtime as any).getDiskMetrics();
+    assert.equal(disks, null);
+  });
+
+  it('skips fs entries with zero or missing capacity', async () => {
+    const runtime = makeRuntime({
+      node: {
+        fs: { capacityBytes: 0, usedBytes: 0 },
+        runtime: { imageFs: { capacityBytes: 10e9, usedBytes: 1e9 } },
+      },
+    });
+    const disks = await runtime.getDiskMetrics();
+    // nodefs dropped, imagefs kept and emitted (dedupe doesn't fire because nodefs was rejected)
+    assert.equal(disks.length, 1);
+    assert.equal(disks[0].mountPoint, 'imagefs');
+  });
+});
+
 describe('KubernetesRuntime constructor: kubeletUrl precedence', () => {
   it('uses explicit kubeletUrl when provided', () => {
     const runtime: any = new KubernetesRuntime({


### PR DESCRIPTION
## Summary

- In Kubernetes mode, replace the `/proc/mounts`-based disk collector with values pulled from kubelet `/stats/summary`, exposed as `nodefs` and `imagefs` entries (deduped when they share the same underlying filesystem).
- Docker and standalone paths are unchanged.

## Why

The Resources tab was showing wrong numbers for k8s hosts. The DaemonSet bind-mounts host `/` at `/host` without `mountPropagation: HostToContainer`, so nested host mounts (a separate `/var`, container-runtime disks, LVM/ZFS datasets, NFS) aren't propagated into the pod. `statfs` on `/host/<mount>` either errors out or silently returns the root filesystem's stats under whatever label `/proc/mounts` carried — both misleading.

`nodefs` (kubelet data) and `imagefs` (container images) are the meaningful disk concepts on a k8s node anyway — they're what the kubelet itself tracks for eviction.

## Changes

- `agent/src/runtime/types.ts` — add shared `DiskResult` type and optional `getDiskMetrics()` on `ContainerRuntime`.
- `agent/src/runtime/kubernetes.ts` — implement `getDiskMetrics()` against the already-fetched kubelet `/stats/summary`. Handles missing `usedBytes` (fallback to `capacity - available`), shared filesystems (dedupe), and kubelet errors (returns null, scheduler emits empty disk instead of falling back to the misleading `/proc` path).
- `agent/src/scheduler.ts` — prefer `runtime.getDiskMetrics` when defined.
- `tests/unit/kubernetes-runtime.test.ts` — 6 new cases covering separate/shared filesystems, usedBytes fallback, missing data, and kubelet failure.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 846/846 passing
- [ ] Deploy to a real k8s node and verify the Resources tab shows `nodefs` / `imagefs` with correct totals
- [ ] Verify Docker hosts still show real mount points unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)