### PR TITLE
refactor(insights): extract capacity-floor thresholds to shared module

### DIFF
--- a/hub/src/insights/detector.ts
+++ b/hub/src/insights/detector.ts
@@ -2,6 +2,21 @@ import logger = require('../../../shared/utils/logger');
 import type Database from 'better-sqlite3';
 
 const { getTimePeriod, MIN_PERIOD_SAMPLES } = require('./baselines') as { getTimePeriod: (hour: number) => string; MIN_PERIOD_SAMPLES: number };
+import {
+  HOST_CPU_WARN_PCT,
+  HOST_CPU_CRIT_PCT,
+  HOST_MEMORY_WARN_PCT,
+  HOST_MEMORY_CRIT_PCT,
+  HOST_LOAD_WARN,
+  HOST_LOAD_CRIT,
+  HOST_CPU_PREDICTION_SATURATION_PCT,
+  HOST_LOAD_PREDICTION_SATURATION,
+  HOST_MEMORY_PREDICTION_SATURATION_FRACTION,
+  HOST_CPU_WOW_MIN_PCT,
+  HOST_MEMORY_WOW_MIN_PCT,
+  CONTAINER_CPU_WARN_PCT,
+  CONTAINER_MEMORY_OVER_P95_MB,
+} from './thresholds';
 
 interface HostIdRow {
   host_id: string;
@@ -121,37 +136,37 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
     ).all(host_id) as HostSnapshotRow[];
 
     if (recent.length >= 6) {
-      // CPU: only flag sustained >80%
+      // CPU: only flag sustained above warn threshold
       const cpuValues = recent.map(r => r.cpu_percent).filter((v): v is number => v != null);
-      if (cpuValues.length >= 6 && cpuValues.every(v => v > 80)) {
-        insert.run('host', host_id, 'performance', cpuValues[0] > 95 ? 'critical' : 'warning',
+      if (cpuValues.length >= 6 && cpuValues.every(v => v > HOST_CPU_WARN_PCT)) {
+        insert.run('host', host_id, 'performance', cpuValues[0] > HOST_CPU_CRIT_PCT ? 'critical' : 'warning',
           `CPU saturated on ${host_id}`,
-          `CPU has been above 80% for 30+ minutes. Current: ${round(cpuValues[0])}%`,
-          'cpu_percent', cpuValues[0], 80, null);
+          `CPU has been above ${HOST_CPU_WARN_PCT}% for 30+ minutes. Current: ${round(cpuValues[0])}%`,
+          'cpu_percent', cpuValues[0], HOST_CPU_WARN_PCT, null);
         count++;
       }
 
-      // Memory: only flag sustained >85% of total
+      // Memory: only flag sustained above warn percent of total
       const memPcts = recent.map(r => {
         const used = r.memory_used_mb;
         const total = r.memory_total_mb;
         return used != null && total ? (used / total) * 100 : null;
       }).filter((v): v is number => v != null);
-      if (memPcts.length >= 6 && memPcts.every(v => v > 85)) {
-        insert.run('host', host_id, 'performance', memPcts[0] > 95 ? 'critical' : 'warning',
+      if (memPcts.length >= 6 && memPcts.every(v => v > HOST_MEMORY_WARN_PCT)) {
+        insert.run('host', host_id, 'performance', memPcts[0] > HOST_MEMORY_CRIT_PCT ? 'critical' : 'warning',
           `Memory pressure on ${host_id}`,
-          `Memory has been above 85% for 30+ minutes. Current: ${round(memPcts[0])}%`,
-          'memory_used_mb', memPcts[0], 85, null);
+          `Memory has been above ${HOST_MEMORY_WARN_PCT}% for 30+ minutes. Current: ${round(memPcts[0])}%`,
+          'memory_used_mb', memPcts[0], HOST_MEMORY_WARN_PCT, null);
         count++;
       }
 
-      // Load: only flag sustained >8
+      // Load: only flag sustained above warn threshold
       const loadValues = recent.map(r => r.load_5).filter((v): v is number => v != null);
-      if (loadValues.length >= 6 && loadValues.every(v => v > 8)) {
-        insert.run('host', host_id, 'performance', loadValues[0] > 16 ? 'critical' : 'warning',
+      if (loadValues.length >= 6 && loadValues.every(v => v > HOST_LOAD_WARN)) {
+        insert.run('host', host_id, 'performance', loadValues[0] > HOST_LOAD_CRIT ? 'critical' : 'warning',
           `High load on ${host_id}`,
-          `Load average has been above 8 for 30+ minutes. Current: ${round(loadValues[0])}`,
-          'load_5', loadValues[0], 8, null);
+          `Load average has been above ${HOST_LOAD_WARN} for 30+ minutes. Current: ${round(loadValues[0])}`,
+          'load_5', loadValues[0], HOST_LOAD_WARN, null);
         count++;
       }
     }
@@ -168,10 +183,10 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
     `).get(host_id) as WeekAvgRow | undefined;
 
     if (thisWeekAvg && lastWeekAvg) {
-      // CPU trend: only flag if current week avg is already above 40% AND doubled
+      // CPU trend: only flag if current week avg is already concerning AND doubled
       if (lastWeekAvg.cpu != null && lastWeekAvg.cpu > 0 && thisWeekAvg.cpu != null
           && thisWeekAvg.cpu > lastWeekAvg.cpu * 2
-          && thisWeekAvg.cpu >= 40) {
+          && thisWeekAvg.cpu >= HOST_CPU_WOW_MIN_PCT) {
         const ratio = round(thisWeekAvg.cpu / lastWeekAvg.cpu);
         insert.run('host', host_id, 'trend', 'warning',
           `CPU usage growing on ${host_id}`,
@@ -179,12 +194,12 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
           'cpu_percent', thisWeekAvg.cpu, lastWeekAvg.cpu, null);
         count++;
       }
-      // Memory trend: only flag if we know total and usage is above 50% of capacity AND grew 1.5x
+      // Memory trend: only flag if we know total and usage is above min-pct of capacity AND grew 1.5x
       const memTotal = recent.length > 0 ? recent[0].memory_total_mb : null;
       const memPct = memTotal ? ((thisWeekAvg.mem ?? 0) / memTotal) * 100 : null;
       if (lastWeekAvg.mem != null && lastWeekAvg.mem > 0 && thisWeekAvg.mem != null
           && thisWeekAvg.mem > lastWeekAvg.mem * 1.5
-          && memPct != null && memPct >= 50) {
+          && memPct != null && memPct >= HOST_MEMORY_WOW_MIN_PCT) {
         const ratio = round(thisWeekAvg.mem / lastWeekAvg.mem);
         insert.run('host', host_id, 'trend', 'warning',
           `Memory usage growing on ${host_id}`,
@@ -213,7 +228,7 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
     const baselines = baselineCache?.get(`container:${entityId}`) as Record<string, BaselineRow> ?? getBaselines(db, 'container', entityId);
 
     // Sustained high usage — only flag when above capacity thresholds AND above baseline P95.
-    // Container CPU >50% sustained OR memory >500 MB above P95 for 30+ minutes.
+    // Container CPU above warn threshold sustained OR memory N MB above P95 for 30+ minutes.
     const recent = db.prepare(`
       SELECT cpu_percent, memory_mb FROM container_snapshots
       WHERE host_id = ? AND container_name = ? AND status = 'running'
@@ -221,25 +236,25 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
     `).all(host_id, container_name) as ContainerSnapshotRow[];
 
     if (recent.length >= 6) {
-      // CPU: only flag sustained >50% AND above P95
+      // CPU: only flag sustained above warn threshold AND above P95
       const cpuBl = baselines.cpu_percent;
       if (cpuBl && cpuBl.sample_count >= 288 && cpuBl.p95 != null) {
         const cpuValues = recent.map(r => r.cpu_percent).filter((v): v is number => v != null);
-        if (cpuValues.length >= 6 && cpuValues.every(v => v > 50 && v > (cpuBl.p95 ?? 0))) {
+        if (cpuValues.length >= 6 && cpuValues.every(v => v > CONTAINER_CPU_WARN_PCT && v > (cpuBl.p95 ?? 0))) {
           insert.run('container', entityId, 'performance', 'warning',
             `${container_name} CPU sustained high`,
-            `${container_name} CPU has been above 50% for 30+ minutes. Current: ${round(cpuValues[0])}%`,
+            `${container_name} CPU has been above ${CONTAINER_CPU_WARN_PCT}% for 30+ minutes. Current: ${round(cpuValues[0])}%`,
             'cpu_percent', cpuValues[0], cpuBl.p95, null);
           count++;
         }
       }
 
-      // Memory: only flag sustained above P95 AND >500 MB above P95
+      // Memory: only flag sustained above P95 AND well above P95
       const memBl = baselines.memory_mb;
       if (memBl && memBl.sample_count >= 288 && memBl.p95 != null) {
         const memValues = recent.map(r => r.memory_mb).filter((v): v is number => v != null);
         const p95 = memBl.p95 ?? 0;
-        if (memValues.length >= 6 && memValues.every(v => v > p95) && (memValues[0] - p95) >= 500) {
+        if (memValues.length >= 6 && memValues.every(v => v > p95) && (memValues[0] - p95) >= CONTAINER_MEMORY_OVER_P95_MB) {
           insert.run('container', entityId, 'performance', 'warning',
             `${container_name} memory unusually high`,
             `${container_name} memory at ${round(memValues[0])} MB, sustained above P95 (${round(p95)} MB) for 30+ minutes`,
@@ -401,14 +416,15 @@ function generatePredictions(db: Database.Database, insert: Database.Statement):
       if (!pred) continue;
       if (pred.dailyGrowth <= 0) continue;
 
-      // Determine the saturation ceiling for this metric:
-      //   cpu_percent: 80% (same as the host CPU detector threshold)
-      //   memory_used_mb: 80% of memory_total_mb (skip if we don't know total)
-      //   load_5: 4 (same as the host load detector threshold)
+      // Determine the saturation ceiling for this metric. Constants live in
+      // ./thresholds.ts; values may differ from the detector's alert thresholds
+      // because predictions warn earlier (lower ceiling).
       let saturation: number | null = null;
-      if (metric === 'cpu_percent') saturation = 80;
-      else if (metric === 'load_5') saturation = 4;
-      else if (metric === 'memory_used_mb' && memoryTotalMb) saturation = memoryTotalMb * 0.8;
+      if (metric === 'cpu_percent') saturation = HOST_CPU_PREDICTION_SATURATION_PCT;
+      else if (metric === 'load_5') saturation = HOST_LOAD_PREDICTION_SATURATION;
+      else if (metric === 'memory_used_mb' && memoryTotalMb) {
+        saturation = memoryTotalMb * HOST_MEMORY_PREDICTION_SATURATION_FRACTION;
+      }
       if (saturation == null) continue;
       if (pred.current >= saturation) continue; // already saturated — detector handles it
 

--- a/hub/src/insights/thresholds.ts
+++ b/hub/src/insights/thresholds.ts
@@ -1,0 +1,71 @@
+// Capacity-floor thresholds for the insights pipeline.
+//
+// Per the project's insights philosophy ("usage is healthy, saturation is the
+// problem"), detector alerts and trend predictions only fire when a metric
+// crosses an absolute capacity-based ceiling, not when it deviates from
+// baseline. These constants are the source of truth for those ceilings.
+//
+// They are imported by:
+//   - hub/src/insights/detector.ts — gates whether alerts fire
+//   - hub/src/web/handlers.ts (BaselinesViewer) — drives the
+//     "won't alert because below capacity floor" pill in the UI
+//
+// Keeping these in one place ensures the UI pill cannot drift from detector
+// behavior. If you change a threshold, both sides update at once.
+//
+// Detector alert vs. prediction saturation: the detector alerts when the
+// current sustained value crosses the alert threshold. Predictions warn
+// earlier — when the trend is *about to* reach saturation within 14 days —
+// so they use slightly more conservative ceilings (e.g. load 4 vs alert 8).
+// The BaselinesViewer pill uses the prediction (lower) ceilings so it can
+// honestly say "below this we won't alert at all" — both detector and
+// prediction need the value above their respective ceiling.
+
+// ── Host detector alert thresholds (sustained ≥30 min triggers warning) ─────
+
+/** Host CPU sustained above this percent → warning alert. */
+export const HOST_CPU_WARN_PCT = 80;
+/** Host CPU sustained above this percent → critical alert. */
+export const HOST_CPU_CRIT_PCT = 95;
+
+/** Host memory sustained above this percent of total → warning alert. */
+export const HOST_MEMORY_WARN_PCT = 85;
+/** Host memory sustained above this percent of total → critical alert. */
+export const HOST_MEMORY_CRIT_PCT = 95;
+
+/** Host 5-min load average sustained above this → warning alert. */
+export const HOST_LOAD_WARN = 8;
+/** Host 5-min load average sustained above this → critical alert. */
+export const HOST_LOAD_CRIT = 16;
+
+// ── Host prediction saturation ceilings ─────────────────────────────────────
+//
+// A prediction fires only when the trend will reach the saturation ceiling
+// within 14 days at the current growth rate. These are the lower of the two
+// thresholds (alert vs saturation), so the BaselinesViewer pill uses them.
+
+export const HOST_CPU_PREDICTION_SATURATION_PCT = 80;
+export const HOST_LOAD_PREDICTION_SATURATION = 4;
+/** Memory saturation as a fraction of memory_total_mb (0.8 = 80%). */
+export const HOST_MEMORY_PREDICTION_SATURATION_FRACTION = 0.8;
+
+// ── Host week-over-week trend gates ─────────────────────────────────────────
+
+/** WoW host memory growth alert only fires when current usage is at least
+ *  this percent of total — prevents "memory critical at 1.4%" from low-
+ *  baseline noise. */
+export const HOST_MEMORY_WOW_MIN_PCT = 50;
+
+/** WoW host CPU growth alert only fires when current weekly average CPU is
+ *  at least this percent — same low-baseline-noise rationale. */
+export const HOST_CPU_WOW_MIN_PCT = 40;
+
+// ── Container detector alert thresholds ─────────────────────────────────────
+
+/** Container CPU sustained above this percent (and above its P95) → warning. */
+export const CONTAINER_CPU_WARN_PCT = 50;
+
+/** Container memory sustained above P95 by at least this many MB → warning.
+ *  Absolute floor on top of the relative-to-P95 check, so a container whose
+ *  P95 is 50 MB doesn't alert for routine 60 MB blips. */
+export const CONTAINER_MEMORY_OVER_P95_MB = 500;

--- a/hub/src/web/handlers.ts
+++ b/hub/src/web/handlers.ts
@@ -786,13 +786,19 @@ function handleGetBaselines(req: HandlerReq, res: ServerResponse, db: Database.D
 // latest live value, the capacity floor an alert would need to clear, and
 // a server-computed robust z so the UI doesn't have to recreate the formula.
 //
-// TODO(thresholds): the capacity-floor numbers below duplicate the alert
-// thresholds in `hub/src/insights/detector.ts`. Extract both to
-// `hub/src/insights/thresholds.ts` next time anyone touches detector
-// thresholds. Ship-now / extract-later was an explicit user call.
+// Capacity-floor numbers come from `hub/src/insights/thresholds.ts`, which is
+// also imported by the detector — keeping the UI pill in lockstep with what
+// will actually fire an alert.
 
 const { getTimePeriod } = require('../insights/baselines');
 const { robustZ } = require('../insights/stats');
+import {
+  HOST_CPU_PREDICTION_SATURATION_PCT,
+  HOST_LOAD_PREDICTION_SATURATION,
+  HOST_MEMORY_PREDICTION_SATURATION_FRACTION,
+  CONTAINER_CPU_WARN_PCT,
+  CONTAINER_MEMORY_OVER_P95_MB,
+} from '../insights/thresholds';
 
 interface CapacityFloor {
   /** Threshold in the metric's native unit. Null when the metric drives no
@@ -807,18 +813,24 @@ interface CapacityFloor {
 }
 
 function hostCapacityFloor(metric: string, memoryTotalMb: number | null): CapacityFloor {
-  if (metric === 'cpu_percent') return { threshold: 80, kind: 'absolute' };
-  if (metric === 'load_5') return { threshold: 4, kind: 'absolute' };
+  if (metric === 'cpu_percent') return { threshold: HOST_CPU_PREDICTION_SATURATION_PCT, kind: 'absolute' };
+  if (metric === 'load_5') return { threshold: HOST_LOAD_PREDICTION_SATURATION, kind: 'absolute' };
   if (metric === 'memory_used_mb' && memoryTotalMb && memoryTotalMb > 0) {
-    return { threshold: Math.round(memoryTotalMb * 0.8 * 100) / 100, kind: 'capacity' };
+    return {
+      threshold: Math.round(memoryTotalMb * HOST_MEMORY_PREDICTION_SATURATION_FRACTION * 100) / 100,
+      kind: 'capacity',
+    };
   }
   return { threshold: null, kind: 'none' };
 }
 
 function containerCapacityFloor(metric: string, allBucketP95: number | null): CapacityFloor {
-  if (metric === 'cpu_percent') return { threshold: 50, kind: 'absolute' };
+  if (metric === 'cpu_percent') return { threshold: CONTAINER_CPU_WARN_PCT, kind: 'absolute' };
   if (metric === 'memory_mb' && allBucketP95 != null) {
-    return { threshold: Math.round((allBucketP95 + 500) * 100) / 100, kind: 'p95_plus' };
+    return {
+      threshold: Math.round((allBucketP95 + CONTAINER_MEMORY_OVER_P95_MB) * 100) / 100,
+      kind: 'p95_plus',
+    };
   }
   return { threshold: null, kind: 'none' };
 }


### PR DESCRIPTION
## Summary
- Moves capacity-floor numbers (host CPU 80, memory 85/80%, load 8/4, container CPU 50, memory P95+500, etc.) into `hub/src/insights/thresholds.ts`.
- `detector.ts` and `handlers.ts` (BaselinesViewer) now import from the shared module — UI "won't alert below this" pill can no longer drift from detector behavior.
- No behavior change: same numbers, same place they're applied. Removes the `TODO(thresholds)` from the BaselinesViewer comment block.

## Background
PR #203 (BaselinesViewer) duplicated the detector's capacity floors into the handler to keep that PR small. This is the follow-up extraction that was queued at the time.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — all 984 tests pass
- [ ] Spot-check on dev VM that BaselinesViewer pills still render the same numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)