### PR TITLE
feat(k8s): pod_pending alerts + cluster pending-pods publisher (schema v41)

### DIFF
--- a/agent/src/collectors/k8s-cluster.ts
+++ b/agent/src/collectors/k8s-cluster.ts
@@ -1,5 +1,5 @@
 import { parseQuantity } from '../runtime/kubernetes';
-import type { K8sClient, K8sPv, K8sPvc, K8sEvent, K8sIngress } from '../runtime/kubernetes';
+import type { K8sClient, K8sPv, K8sPvc, K8sEvent, K8sIngress, K8sPod } from '../runtime/kubernetes';
 
 export interface PvInfo {
   name: string;
@@ -213,4 +213,107 @@ export function mapIngress(ing: K8sIngress): IngressInfo | null {
 export async function collectIngresses(client: K8sClient): Promise<IngressInfo[]> {
   const list = await client.listIngresses();
   return (list.items || []).map(mapIngress).filter((x): x is IngressInfo => x !== null);
+}
+
+// ---- Pending pods ----
+
+export interface PendingPodInfo {
+  namespace: string;
+  podName: string;
+  reason: string | null;
+  message: string | null;
+  podPhase: string;
+  podCreatedAt: string | null;
+  workloadKind: string | null;
+  workloadName: string | null;
+}
+
+/**
+ * Reduce a Pending pod's status to the most actionable {reason, message}.
+ *
+ * Priority (highest first):
+ *   1. PodScheduled=False — scheduler refused to place the pod (Unschedulable
+ *      with "0/N nodes available: ..." message). Most actionable.
+ *   2. ContainersReady=False with a waiting reason on a containerStatus —
+ *      ImagePullBackOff / ErrImagePull / CreateContainerConfigError /
+ *      CreateContainerError. Pulled from the first non-transient waiting
+ *      container so the user sees *why* the pod can't run.
+ *   3. Initialized=False — typically waiting on initContainers or PVC bind.
+ *   4. Fall through to phase reason ("ContainerCreating" pre-image-pull).
+ */
+export function summarizePendingPod(pod: K8sPod): { reason: string | null; message: string | null } {
+  const conditions = pod.status?.conditions ?? [];
+
+  const scheduled = conditions.find(c => c.type === 'PodScheduled');
+  if (scheduled && scheduled.status === 'False') {
+    return {
+      reason: scheduled.reason ?? 'Unschedulable',
+      message: scheduled.message ?? null,
+    };
+  }
+
+  const containerStatuses = pod.status?.containerStatuses ?? [];
+  for (const cs of containerStatuses) {
+    const waiting = cs.state?.waiting;
+    if (waiting?.reason && waiting.reason !== 'ContainerCreating' && waiting.reason !== 'PodInitializing') {
+      return { reason: waiting.reason, message: waiting.message ?? null };
+    }
+  }
+
+  const initialized = conditions.find(c => c.type === 'Initialized');
+  if (initialized && initialized.status === 'False') {
+    return {
+      reason: initialized.reason ?? 'NotInitialized',
+      message: initialized.message ?? null,
+    };
+  }
+
+  // Pod is genuinely still coming up — surface the first waiting reason if any.
+  for (const cs of containerStatuses) {
+    const waiting = cs.state?.waiting;
+    if (waiting?.reason) {
+      return { reason: waiting.reason, message: waiting.message ?? null };
+    }
+  }
+
+  return { reason: null, message: null };
+}
+
+/**
+ * Resolve the workload (kind, name) that owns a pod. Walks one level via
+ * ownerReferences. ReplicaSet is left as-is — the leader collector has no
+ * RS→Deployment lookup cache here, and "ReplicaSet/foo-7d9f8" is a clear
+ * enough pointer for the user to find the parent Deployment.
+ */
+export function podWorkload(pod: K8sPod): { kind: string | null; name: string | null } {
+  const owner = pod.metadata?.ownerReferences?.[0];
+  if (!owner) return { kind: null, name: null };
+  return { kind: owner.kind, name: owner.name };
+}
+
+export function mapPendingPod(pod: K8sPod): PendingPodInfo | null {
+  if (pod.status?.phase !== 'Pending') return null;
+  const namespace = pod.metadata?.namespace;
+  const podName = pod.metadata?.name;
+  if (!namespace || !podName) return null;
+
+  const { reason, message } = summarizePendingPod(pod);
+  const { kind, name } = podWorkload(pod);
+  return {
+    namespace,
+    podName,
+    reason,
+    message,
+    podPhase: 'Pending',
+    podCreatedAt: pod.metadata?.creationTimestamp ?? null,
+    workloadKind: kind,
+    workloadName: name,
+  };
+}
+
+export async function collectPendingPods(client: K8sClient): Promise<PendingPodInfo[]> {
+  // Cluster-wide list (no fieldSelector) so unscheduled pods (no nodeName) are
+  // included — those are the ones the per-node collectors miss entirely.
+  const list = await client.listPods();
+  return (list.items || []).map(mapPendingPod).filter((x): x is PendingPodInfo => x !== null);
 }

--- a/agent/src/mqtt.ts
+++ b/agent/src/mqtt.ts
@@ -587,6 +587,50 @@ function publishIngresses(clusterId: string, publisherHostId: string, ingresses:
   });
 }
 
+interface PendingPodPayloadItem {
+  namespace: string;
+  podName: string;
+  reason: string | null;
+  message: string | null;
+  podPhase: string;
+  podCreatedAt: string | null;
+  workloadKind: string | null;
+  workloadName: string | null;
+}
+
+function publishPendingPods(clusterId: string, publisherHostId: string, pods: PendingPodPayloadItem[]): Promise<void> {
+  const topic = `insightd/_cluster_${clusterId}/pending-pods`;
+  const { VERSION } = require('./config') as { VERSION: string };
+  const payload = JSON.stringify({
+    version: 1,
+    cluster_id: clusterId,
+    publisher_host_id: publisherHostId,
+    agent_version: VERSION,
+    collected_at: new Date().toISOString(),
+    items: pods.map(p => ({
+      namespace: p.namespace,
+      pod_name: p.podName,
+      reason: p.reason,
+      message: p.message,
+      pod_phase: p.podPhase,
+      pod_created_at: p.podCreatedAt,
+      workload_kind: p.workloadKind,
+      workload_name: p.workloadName,
+    })),
+  });
+  return new Promise((resolve, reject) => {
+    client!.publish(topic, payload, { qos: 1 }, (err) => {
+      if (err) {
+        logger.error('mqtt', `Failed to publish ${topic}: ${err.message}`);
+        reject(err);
+      } else {
+        logger.info('mqtt', `Published ${pods.length} pending pods for cluster ${clusterId} (${payload.length} bytes)`);
+        resolve();
+      }
+    });
+  });
+}
+
 function publishUpdates(hostId: string, updates: UpdateData[]): Promise<void> {
   const topic = `insightd/${hostId}/updates`;
   const payload = JSON.stringify({
@@ -620,4 +664,4 @@ function disconnect(): void {
   }
 }
 
-module.exports = { connect, publishCollection, publishUpdates, publishPvs, publishPvcs, publishEvents, publishIngresses, disconnect, containerInfoToPayload };
+module.exports = { connect, publishCollection, publishUpdates, publishPvs, publishPvcs, publishEvents, publishIngresses, publishPendingPods, disconnect, containerInfoToPayload };

--- a/agent/src/runtime/kubernetes.ts
+++ b/agent/src/runtime/kubernetes.ts
@@ -45,12 +45,20 @@ interface K8sPodContainer {
   };
 }
 
-interface K8sPod {
+export interface K8sPodCondition {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+}
+
+export interface K8sPod {
   metadata?: K8sMeta;
   spec?: { nodeName?: string; containers?: K8sPodContainer[] };
   status?: {
     phase?: string;
     containerStatuses?: K8sContainerStatus[];
+    conditions?: K8sPodCondition[];
   };
 }
 

--- a/agent/src/scheduler.ts
+++ b/agent/src/scheduler.ts
@@ -4,13 +4,14 @@ import logger = require('../../shared/utils/logger');
 import type { ContainerRuntime } from './runtime/types';
 
 const { safeCollect } = require('../../shared/utils/errors') as { safeCollect: <T>(label: string, fn: () => Promise<T>) => Promise<T | null> };
-const { publishCollection, publishUpdates, publishPvs, publishPvcs, publishEvents, publishIngresses } = require('./mqtt') as {
+const { publishCollection, publishUpdates, publishPvs, publishPvcs, publishEvents, publishIngresses, publishPendingPods } = require('./mqtt') as {
   publishCollection: (hostId: string, data: any) => Promise<void>;
   publishUpdates: (hostId: string, updates: any[]) => Promise<void>;
   publishPvs: (clusterId: string, publisherHostId: string, pvs: any[]) => Promise<void>;
   publishPvcs: (clusterId: string, publisherHostId: string, pvcs: any[]) => Promise<void>;
   publishEvents: (clusterId: string, publisherHostId: string, events: any[]) => Promise<void>;
   publishIngresses: (clusterId: string, publisherHostId: string, ingresses: any[]) => Promise<void>;
+  publishPendingPods: (clusterId: string, publisherHostId: string, pods: any[]) => Promise<void>;
 };
 
 interface SchedulerConfig {
@@ -106,28 +107,32 @@ function startAgentScheduler(runtime: ContainerRuntime, config: SchedulerConfig)
       ? (await safeCollect('volumes', () => runtime.listVolumes!())) ?? []
       : [];
 
-    // K8s cluster-scoped inventory (PVs, PVCs, Events) — only the elected
-    // leader publishes so we don't duplicate streams from every node-agent.
+    // K8s cluster-scoped inventory (PVs, PVCs, Events, Ingresses, Pending pods)
+    // — only the elected leader publishes so we don't duplicate streams from
+    // every node-agent.
     if (clusterPublisher && clusterPublisher.leader.isLeader()) {
-      const { collectPvs, collectPvcs, collectEvents, collectIngresses } = require('./collectors/k8s-cluster') as {
+      const { collectPvs, collectPvcs, collectEvents, collectIngresses, collectPendingPods } = require('./collectors/k8s-cluster') as {
         collectPvs: (c: any) => Promise<any[]>;
         collectPvcs: (c: any) => Promise<any[]>;
         collectEvents: (c: any) => Promise<any[]>;
         collectIngresses: (c: any) => Promise<any[]>;
+        collectPendingPods: (c: any) => Promise<any[]>;
       };
       const pvs = await safeCollect('pvs', () => collectPvs(clusterPublisher!.client));
       const pvcs = await safeCollect('pvcs', () => collectPvcs(clusterPublisher!.client));
       const events = await safeCollect('events', () => collectEvents(clusterPublisher!.client));
       const ingresses = await safeCollect('ingresses', () => collectIngresses(clusterPublisher!.client));
+      const pendingPods = await safeCollect('pending-pods', () => collectPendingPods(clusterPublisher!.client));
       if (pvs) await safeCollect('mqtt-pvs', () => publishPvs(clusterPublisher!.clusterId, config.hostId, pvs));
       if (pvcs) await safeCollect('mqtt-pvcs', () => publishPvcs(clusterPublisher!.clusterId, config.hostId, pvcs));
       if (events && events.length > 0) {
         await safeCollect('mqtt-events', () => publishEvents(clusterPublisher!.clusterId, config.hostId, events));
       }
-      // Publish ingresses on every leader cycle (including empty arrays) so
-      // the hub can stamp removed_at on rows that disappeared since last
-      // batch — same registry pattern as `containers`.
+      // Publish ingresses + pending pods on every leader cycle (including
+      // empty arrays) so the hub can prune rows that disappeared since the
+      // last batch — same registry pattern as `containers`.
       if (ingresses) await safeCollect('mqtt-ingresses', () => publishIngresses(clusterPublisher!.clusterId, config.hostId, ingresses));
+      if (pendingPods) await safeCollect('mqtt-pending-pods', () => publishPendingPods(clusterPublisher!.clusterId, config.hostId, pendingPods));
     }
 
     logger.info('scheduler', 'Collection cycle complete');

--- a/hub/src/alerts/evaluator.ts
+++ b/hub/src/alerts/evaluator.ts
@@ -35,6 +35,8 @@ interface AlertsConfig {
   containerCpuLimitPercent: number;
   certExpiry?: boolean;
   certExpiryWarnDays?: number;
+  podPending?: boolean;
+  podPendingMinutes?: number;
   cooldownMinutes: number;
   reminderBackoff?: boolean;
   reminderMaxMinutes?: number;
@@ -154,6 +156,11 @@ function evaluateAlerts(db: Database.Database, config: EvaluatorConfig): Evaluat
   // endpoint name so cooldown/resolution flow through alert_state.
   if (alerts.certExpiry !== false) {
     triggered.push(...checkCertAlerts(db, alerts.certExpiryWarnDays || 14));
+  }
+
+  // Pods stuck Pending past threshold — cluster-scoped (leader-published).
+  if (alerts.podPending !== false) {
+    triggered.push(...checkPodPending(db, alerts.podPendingMinutes ?? 5));
   }
 
   // Check for resolutions of active alerts
@@ -549,6 +556,45 @@ function checkCertAlerts(db: Database.Database, warnDays: number): AlertItem[] {
   return out;
 }
 
+interface PendingPodRow {
+  cluster_id: string;
+  namespace: string;
+  pod_name: string;
+  reason: string | null;
+  message: string | null;
+  workload_kind: string | null;
+  workload_name: string | null;
+  age_minutes: number;
+}
+
+function checkPodPending(db: Database.Database, thresholdMinutes: number): AlertItem[] {
+  const rows = db.prepare(
+    "SELECT cluster_id, namespace, pod_name, reason, message, workload_kind, workload_name, " +
+    " CAST((strftime('%s','now') - strftime('%s', first_seen_at)) / 60 AS INTEGER) AS age_minutes " +
+    " FROM pending_pods " +
+    "WHERE first_seen_at < datetime('now', ?)"
+  ).all(`-${thresholdMinutes} minutes`) as PendingPodRow[];
+
+  return rows.map(r => {
+    // target uniquely identifies the pod within a cluster — alert_state
+    // dedupes on (host_id, alert_type, target), so cluster_id goes into
+    // host_id and ns/pod into target.
+    const owner = r.workload_kind && r.workload_name
+      ? ` (${r.workload_kind}/${r.workload_name})`
+      : '';
+    const reasonPart = r.reason ? r.reason : 'Pending';
+    const detail = r.message ? ` — ${r.message.slice(0, 200)}` : '';
+    return {
+      type: 'pod_pending',
+      hostId: r.cluster_id,
+      target: `${r.namespace}/${r.pod_name}`,
+      message: `Pod "${r.namespace}/${r.pod_name}"${owner} stuck ${reasonPart} for ${r.age_minutes}m${detail}`,
+      value: r.reason ?? 'Pending',
+      threshold: thresholdMinutes,
+    };
+  });
+}
+
 function checkEndpointDown(db: Database.Database, failureThreshold: number): AlertItem[] {
   const { getEndpoints, getLastNChecks } = require('../http-monitor/queries');
   const endpoints = (getEndpoints(db) as Array<{ id: number; name: string; url: string; enabled: number }>).filter(ep => ep.enabled);
@@ -750,6 +796,19 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
         `SELECT 1 FROM node_conditions WHERE host_id = ? AND type = 'Ready' AND status != 'True'`
       ).get(alert.host_id);
       isResolved = !row;
+    } else if (alert.alert_type === 'pod_pending') {
+      // Resolved when the pod is no longer in `pending_pods` (left Pending
+      // or no longer exists). target is "namespace/pod_name", host_id is
+      // the cluster_id — see checkPodPending.
+      const slash = alert.target.indexOf('/');
+      if (slash > 0) {
+        const ns = alert.target.slice(0, slash);
+        const pod = alert.target.slice(slash + 1);
+        const row = db.prepare(
+          'SELECT 1 FROM pending_pods WHERE cluster_id = ? AND namespace = ? AND pod_name = ?'
+        ).get(alert.host_id, ns, pod);
+        isResolved = !row;
+      }
     }
 
     if (isResolved) {
@@ -787,6 +846,7 @@ function getResolutionMessage(type: string, target: string, hostId: string): str
     case 'cert_expired': return `Certificate for "${target}" is no longer expired`;
     case 'cert_expiring_soon': return `Certificate for "${target}" is no longer expiring soon`;
     case 'cert_invalid': return `Certificate for "${target}" is valid again`;
+    case 'pod_pending': return `Pod "${target}" is no longer Pending`;
     default: return `Alert resolved for ${target}${on}`;
   }
 }

--- a/hub/src/config.ts
+++ b/hub/src/config.ts
@@ -85,6 +85,8 @@ const config = Object.freeze({
     certExpiry: process.env.INSIGHTD_ALERT_CERT_EXPIRY !== 'false',
     certExpiryWarnDays: parseInt(process.env.INSIGHTD_ALERT_CERT_WARN_DAYS || '14', 10),
     certCheckIntervalHours: parseInt(process.env.INSIGHTD_CERT_CHECK_INTERVAL_HOURS || '6', 10),
+    podPending: process.env.INSIGHTD_ALERT_POD_PENDING !== 'false',
+    podPendingMinutes: parseInt(process.env.INSIGHTD_ALERT_POD_PENDING_MINUTES || '5', 10),
   }),
 
   // AI diagnosis (Gemini)

--- a/hub/src/db/schema.ts
+++ b/hub/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import logger = require('../../../shared/utils/logger');
 
-const SCHEMA_VERSION = 40;
+const SCHEMA_VERSION = 41;
 
 function bootstrap(db: Database.Database): void {
   db.exec(`
@@ -233,6 +233,28 @@ function bootstrap(db: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_k8s_ingresses_cluster
       ON k8s_ingresses (cluster_id, observed_at DESC);
+
+    -- Pods stuck in Pending phase (cluster-scoped, leader-published).
+    -- Current-state UPSERT model — same row keyed by (cluster_id, namespace,
+    -- pod_name) is refreshed each leader cycle. first_seen_at is preserved
+    -- across cycles so the alert evaluator can age out by duration.
+    -- Rows are deleted when the pod leaves Pending or disappears.
+    CREATE TABLE IF NOT EXISTS pending_pods (
+      cluster_id      TEXT NOT NULL,
+      namespace       TEXT NOT NULL,
+      pod_name        TEXT NOT NULL,
+      reason          TEXT,
+      message         TEXT,
+      pod_phase       TEXT NOT NULL,
+      pod_created_at  TEXT,
+      workload_kind   TEXT,
+      workload_name   TEXT,
+      first_seen_at   TEXT NOT NULL DEFAULT (datetime('now')),
+      last_seen_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (cluster_id, namespace, pod_name)
+    );
+    CREATE INDEX IF NOT EXISTS idx_pending_pods_cluster_first
+      ON pending_pods (cluster_id, first_seen_at);
 
     CREATE TABLE IF NOT EXISTS update_checks (
       id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -930,6 +952,29 @@ function migrate(db: Database.Database, fromVersion: number): void {
     // evaluator and diagnosis framework name the cause behind a restart
     // loop / unhealthy container instead of word-matching health output.
     try { db.exec('ALTER TABLE container_snapshots ADD COLUMN last_oom_killed_at TEXT'); } catch { /* already exists */ }
+  }
+  if (fromVersion < 41) {
+    // Pods stuck Pending (unschedulable, PVC unbound, image pull, etc.).
+    // Cluster-scoped registry; the alert evaluator fires `pod_pending`
+    // when a row's first_seen_at is older than the threshold.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS pending_pods (
+        cluster_id      TEXT NOT NULL,
+        namespace       TEXT NOT NULL,
+        pod_name        TEXT NOT NULL,
+        reason          TEXT,
+        message         TEXT,
+        pod_phase       TEXT NOT NULL,
+        pod_created_at  TEXT,
+        workload_kind   TEXT,
+        workload_name   TEXT,
+        first_seen_at   TEXT NOT NULL DEFAULT (datetime('now')),
+        last_seen_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (cluster_id, namespace, pod_name)
+      );
+      CREATE INDEX IF NOT EXISTS idx_pending_pods_cluster_first
+        ON pending_pods (cluster_id, first_seen_at);
+    `);
   }
 }
 

--- a/hub/src/ingest.ts
+++ b/hub/src/ingest.ts
@@ -456,6 +456,69 @@ function ingestIngresses(db: Database.Database, clusterId: string, ingresses: In
   logger.info('ingest', `Upserted ${ingresses.length} ingresses for cluster ${clusterId}`);
 }
 
+interface PendingPodRecord {
+  namespace: string;
+  podName: string;
+  reason: string | null;
+  message: string | null;
+  podPhase: string;
+  podCreatedAt: string | null;
+  workloadKind: string | null;
+  workloadName: string | null;
+}
+
+/**
+ * Current-state UPSERT for pending pods. After upserting the batch, delete
+ * any rows for this cluster_id whose last_seen_at is older than the batch
+ * start time — those pods have either left Pending or no longer exist.
+ *
+ * first_seen_at is preserved across cycles (UPSERT doesn't touch it), so
+ * the alert evaluator can age pods by their original observation time
+ * regardless of how many publish cycles have elapsed.
+ */
+function ingestPendingPods(db: Database.Database, clusterId: string, pods: PendingPodRecord[]): void {
+  const batchAt = new Date().toISOString();
+  const upsert = db.prepare(`
+    INSERT INTO pending_pods
+      (cluster_id, namespace, pod_name, reason, message, pod_phase,
+       pod_created_at, workload_kind, workload_name, first_seen_at, last_seen_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(cluster_id, namespace, pod_name) DO UPDATE SET
+      reason         = excluded.reason,
+      message        = excluded.message,
+      pod_phase      = excluded.pod_phase,
+      pod_created_at = excluded.pod_created_at,
+      workload_kind  = excluded.workload_kind,
+      workload_name  = excluded.workload_name,
+      last_seen_at   = excluded.last_seen_at
+  `);
+  const prune = db.prepare(`
+    DELETE FROM pending_pods
+     WHERE cluster_id = ? AND last_seen_at < ?
+  `);
+
+  const tx = db.transaction((items: PendingPodRecord[]) => {
+    for (const p of items) {
+      upsert.run(
+        clusterId,
+        p.namespace,
+        p.podName,
+        p.reason,
+        p.message,
+        p.podPhase,
+        p.podCreatedAt,
+        p.workloadKind,
+        p.workloadName,
+        batchAt,
+        batchAt,
+      );
+    }
+    prune.run(clusterId, batchAt);
+  });
+  tx(pods);
+  logger.info('ingest', `Upserted ${pods.length} pending pods for cluster ${clusterId}`);
+}
+
 interface NodeConditionRecord {
   type: string;
   status: 'True' | 'False' | 'Unknown';
@@ -492,4 +555,4 @@ function ingestNodeConditions(db: Database.Database, hostId: string, conditions:
   upsertMany(conditions);
 }
 
-module.exports = { ingestContainers, ingestDisk, ingestVolumes, ingestPvs, ingestPvcs, ingestEvents, ingestIngresses, ingestNodeConditions, ingestUpdates, upsertHost, ingestHost };
+module.exports = { ingestContainers, ingestDisk, ingestVolumes, ingestPvs, ingestPvcs, ingestEvents, ingestIngresses, ingestPendingPods, ingestNodeConditions, ingestUpdates, upsertHost, ingestHost };

--- a/hub/src/mqtt.ts
+++ b/hub/src/mqtt.ts
@@ -4,7 +4,7 @@ import logger = require('../../shared/utils/logger');
 import type Database from 'better-sqlite3';
 import type { MqttClient, IClientOptions } from 'mqtt';
 
-const { ingestContainers, ingestDisk, ingestVolumes, ingestPvs, ingestPvcs, ingestEvents, ingestIngresses, ingestNodeConditions, ingestUpdates, upsertHost, ingestHost } = require('./ingest') as {
+const { ingestContainers, ingestDisk, ingestVolumes, ingestPvs, ingestPvcs, ingestEvents, ingestIngresses, ingestPendingPods, ingestNodeConditions, ingestUpdates, upsertHost, ingestHost } = require('./ingest') as {
   ingestContainers: (db: Database.Database, hostId: string, containers: any[]) => void;
   ingestDisk: (db: Database.Database, hostId: string, disk: any[]) => void;
   ingestVolumes: (db: Database.Database, hostId: string, volumes: any[]) => void;
@@ -12,6 +12,7 @@ const { ingestContainers, ingestDisk, ingestVolumes, ingestPvs, ingestPvcs, inge
   ingestPvcs: (db: Database.Database, clusterId: string, pvcs: any[]) => void;
   ingestEvents: (db: Database.Database, clusterId: string, events: any[]) => void;
   ingestIngresses: (db: Database.Database, clusterId: string, ingresses: any[]) => void;
+  ingestPendingPods: (db: Database.Database, clusterId: string, pods: any[]) => void;
   ingestNodeConditions: (db: Database.Database, hostId: string, conditions: any[]) => void;
   ingestUpdates: (db: Database.Database, hostId: string, updates: any[]) => void;
   upsertHost: (db: Database.Database, hostId: string, agentVersion?: string | null, runtimeType?: string, hostGroup?: string | null) => void;
@@ -190,6 +191,11 @@ function startSubscriber(db: Database.Database, config: MqttConfig): Promise<Mqt
         else logger.info('mqtt', 'Subscribed to insightd/+/ingresses');
       });
 
+      client!.subscribe('insightd/+/pending-pods', { qos: 1 }, (err) => {
+        if (err) logger.error('mqtt', 'Failed to subscribe to pending-pods topic');
+        else logger.info('mqtt', 'Subscribed to insightd/+/pending-pods');
+      });
+
       client!.subscribe('insightd/+/logs/response', { qos: 1 }, (err) => {
         if (err) logger.error('mqtt', 'Failed to subscribe to logs response topic');
         else logger.info('mqtt', 'Subscribed to insightd/+/logs/response');
@@ -224,10 +230,11 @@ function startSubscriber(db: Database.Database, config: MqttConfig): Promise<Mqt
         // handlers unwrap.
         if (hostId.startsWith('_cluster_')) {
           const clusterId = hostId.slice('_cluster_'.length);
-          if (type === 'pvs')       { handlePvs(db, clusterId, payload); return; }
-          if (type === 'pvcs')      { handlePvcs(db, clusterId, payload); return; }
-          if (type === 'events')    { handleEvents(db, clusterId, payload); return; }
-          if (type === 'ingresses') { handleIngresses(db, clusterId, payload); return; }
+          if (type === 'pvs')           { handlePvs(db, clusterId, payload); return; }
+          if (type === 'pvcs')          { handlePvcs(db, clusterId, payload); return; }
+          if (type === 'events')        { handleEvents(db, clusterId, payload); return; }
+          if (type === 'ingresses')     { handleIngresses(db, clusterId, payload); return; }
+          if (type === 'pending-pods')  { handlePendingPods(db, clusterId, payload); return; }
         }
 
         if (type === 'collection') {
@@ -516,6 +523,34 @@ function handleIngresses(db: Database.Database, clusterId: string, payload: Ingr
   }));
   ingestIngresses(db, clusterId, ingresses);
   logger.info('mqtt', `Ingested ${ingresses.length} ingresses for cluster ${clusterId}`);
+}
+
+interface PendingPodsPayload {
+  items?: Array<{
+    namespace: string;
+    pod_name: string;
+    reason?: string | null;
+    message?: string | null;
+    pod_phase: string;
+    pod_created_at?: string | null;
+    workload_kind?: string | null;
+    workload_name?: string | null;
+  }>;
+}
+
+function handlePendingPods(db: Database.Database, clusterId: string, payload: PendingPodsPayload): void {
+  const pods = (payload.items || []).map(p => ({
+    namespace: p.namespace,
+    podName: p.pod_name,
+    reason: p.reason ?? null,
+    message: p.message ?? null,
+    podPhase: p.pod_phase,
+    podCreatedAt: p.pod_created_at ?? null,
+    workloadKind: p.workload_kind ?? null,
+    workloadName: p.workload_name ?? null,
+  }));
+  ingestPendingPods(db, clusterId, pods);
+  logger.info('mqtt', `Ingested ${pods.length} pending pods for cluster ${clusterId}`);
 }
 
 function handleEvents(db: Database.Database, clusterId: string, payload: EventsPayload): void {

--- a/hub/src/web/queries.ts
+++ b/hub/src/web/queries.ts
@@ -425,6 +425,7 @@ const LEVEL_BY_ALERT_TYPE: Record<string, 'critical' | 'error' | 'warning' | 'in
   node_pressure: 'error',
   container_memory_saturation: 'error',
   cert_invalid: 'error',
+  pod_pending: 'error',
   high_cpu: 'warning',
   high_memory: 'warning',
   high_host_cpu: 'warning',
@@ -448,6 +449,7 @@ const LEVEL_CASE_SQL = `
     WHEN 'node_pressure' THEN 'error'
     WHEN 'container_memory_saturation' THEN 'error'
     WHEN 'cert_invalid' THEN 'error'
+    WHEN 'pod_pending' THEN 'error'
     WHEN 'high_cpu' THEN 'warning'
     WHEN 'high_memory' THEN 'warning'
     WHEN 'high_host_cpu' THEN 'warning'

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import logger = require('../utils/logger');
 
-const SCHEMA_VERSION = 40;
+const SCHEMA_VERSION = 41;
 
 function bootstrap(db: Database.Database): void {
   db.exec(`
@@ -221,6 +221,22 @@ function bootstrap(db: Database.Database): void {
       removed_at      TEXT,
       dismissed_at    TEXT,
       UNIQUE(cluster_id, namespace, name)
+    );
+
+    -- Pending pods (no-op on Docker standalone — see k8s_ingresses note).
+    CREATE TABLE IF NOT EXISTS pending_pods (
+      cluster_id      TEXT NOT NULL,
+      namespace       TEXT NOT NULL,
+      pod_name        TEXT NOT NULL,
+      reason          TEXT,
+      message         TEXT,
+      pod_phase       TEXT NOT NULL,
+      pod_created_at  TEXT,
+      workload_kind   TEXT,
+      workload_name   TEXT,
+      first_seen_at   TEXT NOT NULL DEFAULT (datetime('now')),
+      last_seen_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (cluster_id, namespace, pod_name)
     );
 
     CREATE TABLE IF NOT EXISTS update_checks (
@@ -890,6 +906,24 @@ function migrate(db: Database.Database, fromVersion: number): void {
   }
   if (fromVersion < 40) {
     try { db.exec('ALTER TABLE container_snapshots ADD COLUMN last_oom_killed_at TEXT'); } catch { /* already exists */ }
+  }
+  if (fromVersion < 41) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS pending_pods (
+        cluster_id      TEXT NOT NULL,
+        namespace       TEXT NOT NULL,
+        pod_name        TEXT NOT NULL,
+        reason          TEXT,
+        message         TEXT,
+        pod_phase       TEXT NOT NULL,
+        pod_created_at  TEXT,
+        workload_kind   TEXT,
+        workload_name   TEXT,
+        first_seen_at   TEXT NOT NULL DEFAULT (datetime('now')),
+        last_seen_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (cluster_id, namespace, pod_name)
+      );
+    `);
   }
 }
 

--- a/tests/integration/web-api.test.ts
+++ b/tests/integration/web-api.test.ts
@@ -78,7 +78,7 @@ describe('Web API integration', () => {
     assert.equal(res.status, 200);
     const data = res.json();
     assert.equal(data.status, 'ok');
-    assert.equal(data.schemaVersion, 40);
+    assert.equal(data.schemaVersion, 41);
   });
 
   it('GET /api/hosts returns host list', async () => {

--- a/tests/unit/collectors-k8s-cluster.test.ts
+++ b/tests/unit/collectors-k8s-cluster.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mapPv, mapPvc, mapEvent } from '../../agent/src/collectors/k8s-cluster';
-import type { K8sPv, K8sPvc, K8sEvent } from '../../agent/src/runtime/kubernetes';
+import { mapPv, mapPvc, mapEvent, mapPendingPod, summarizePendingPod, podWorkload } from '../../agent/src/collectors/k8s-cluster';
+import type { K8sPv, K8sPvc, K8sEvent, K8sPod } from '../../agent/src/runtime/kubernetes';
 
 describe('mapPv', () => {
   it('maps a bound PV with claimRef', () => {
@@ -168,5 +168,144 @@ describe('mapEvent', () => {
     assert.equal(mapEvent({ metadata: { uid: 'u' }, involvedObject: { kind: 'Pod' }, reason: 'X', type: 'Warning' }), null, 'missing name');
     assert.equal(mapEvent({ metadata: { uid: 'u' }, involvedObject: { kind: 'Pod', name: 'x' }, type: 'Warning' }), null, 'missing reason');
     assert.equal(mapEvent({ metadata: { uid: 'u' }, involvedObject: { kind: 'Pod', name: 'x' }, reason: 'X' }), null, 'missing type');
+  });
+});
+
+describe('summarizePendingPod', () => {
+  it('prefers PodScheduled=False (Unschedulable) over container waiting reasons', () => {
+    const pod: K8sPod = {
+      metadata: { namespace: 'default', name: 'web-7d-xyz' },
+      status: {
+        phase: 'Pending',
+        conditions: [{
+          type: 'PodScheduled',
+          status: 'False',
+          reason: 'Unschedulable',
+          message: '0/3 nodes available: 3 Insufficient memory',
+        }],
+        containerStatuses: [{
+          name: 'app', ready: false, restartCount: 0, image: 'nginx',
+          state: { waiting: { reason: 'ContainerCreating' } },
+        }],
+      },
+    };
+    const out = summarizePendingPod(pod);
+    assert.equal(out.reason, 'Unschedulable');
+    assert.match(out.message ?? '', /Insufficient memory/);
+  });
+
+  it('surfaces ImagePullBackOff from a container waiting state', () => {
+    const pod: K8sPod = {
+      metadata: { namespace: 'default', name: 'app-xyz' },
+      status: {
+        phase: 'Pending',
+        conditions: [{ type: 'PodScheduled', status: 'True' }],
+        containerStatuses: [{
+          name: 'app', ready: false, restartCount: 0, image: 'foo:bad',
+          state: { waiting: { reason: 'ImagePullBackOff', message: 'Back-off pulling image foo:bad' } },
+        }],
+      },
+    };
+    const out = summarizePendingPod(pod);
+    assert.equal(out.reason, 'ImagePullBackOff');
+    assert.match(out.message ?? '', /Back-off pulling/);
+  });
+
+  it('skips transient ContainerCreating in favor of Initialized=False (e.g. PVC unbound)', () => {
+    const pod: K8sPod = {
+      metadata: { namespace: 'default', name: 'db-0' },
+      status: {
+        phase: 'Pending',
+        conditions: [
+          { type: 'PodScheduled', status: 'True' },
+          { type: 'Initialized', status: 'False', reason: 'ContainersNotInitialized', message: 'containers with incomplete status: [init-volume]' },
+        ],
+        containerStatuses: [{
+          name: 'db', ready: false, restartCount: 0, image: 'postgres',
+          state: { waiting: { reason: 'PodInitializing' } },
+        }],
+      },
+    };
+    const out = summarizePendingPod(pod);
+    assert.equal(out.reason, 'ContainersNotInitialized');
+  });
+
+  it('falls back to first waiting reason when no condition is False', () => {
+    const pod: K8sPod = {
+      metadata: { namespace: 'default', name: 'app-xyz' },
+      status: {
+        phase: 'Pending',
+        conditions: [{ type: 'PodScheduled', status: 'True' }],
+        containerStatuses: [{
+          name: 'app', ready: false, restartCount: 0, image: 'busybox',
+          state: { waiting: { reason: 'ContainerCreating' } },
+        }],
+      },
+    };
+    const out = summarizePendingPod(pod);
+    assert.equal(out.reason, 'ContainerCreating');
+  });
+
+  it('returns nulls when nothing is informative', () => {
+    const pod: K8sPod = { metadata: { name: 'x', namespace: 'd' }, status: { phase: 'Pending' } };
+    const out = summarizePendingPod(pod);
+    assert.equal(out.reason, null);
+    assert.equal(out.message, null);
+  });
+});
+
+describe('podWorkload', () => {
+  it('returns the first ownerReference', () => {
+    const pod: K8sPod = {
+      metadata: {
+        name: 'web-7d', namespace: 'default',
+        ownerReferences: [{ kind: 'ReplicaSet', name: 'web-7d-abc' }],
+      },
+    };
+    assert.deepEqual(podWorkload(pod), { kind: 'ReplicaSet', name: 'web-7d-abc' });
+  });
+
+  it('returns nulls for standalone pod', () => {
+    assert.deepEqual(podWorkload({ metadata: { name: 'p', namespace: 'd' } }), { kind: null, name: null });
+  });
+});
+
+describe('mapPendingPod', () => {
+  it('returns null for non-Pending pods', () => {
+    const out = mapPendingPod({
+      metadata: { namespace: 'd', name: 'p' },
+      status: { phase: 'Running' },
+    });
+    assert.equal(out, null);
+  });
+
+  it('returns null when namespace or name is missing', () => {
+    assert.equal(mapPendingPod({ metadata: { name: 'p' }, status: { phase: 'Pending' } }), null);
+    assert.equal(mapPendingPod({ metadata: { namespace: 'd' }, status: { phase: 'Pending' } }), null);
+  });
+
+  it('captures Unschedulable pod with workload owner', () => {
+    const out = mapPendingPod({
+      metadata: {
+        namespace: 'default', name: 'web-7d-xyz',
+        creationTimestamp: '2026-04-30T10:00:00Z',
+        ownerReferences: [{ kind: 'ReplicaSet', name: 'web-7d' }],
+      },
+      status: {
+        phase: 'Pending',
+        conditions: [{
+          type: 'PodScheduled', status: 'False', reason: 'Unschedulable',
+          message: '0/3 nodes available: 3 Insufficient memory',
+        }],
+      },
+    });
+    assert.ok(out);
+    assert.equal(out!.namespace, 'default');
+    assert.equal(out!.podName, 'web-7d-xyz');
+    assert.equal(out!.reason, 'Unschedulable');
+    assert.equal(out!.podPhase, 'Pending');
+    assert.equal(out!.podCreatedAt, '2026-04-30T10:00:00Z');
+    assert.equal(out!.workloadKind, 'ReplicaSet');
+    assert.equal(out!.workloadName, 'web-7d');
   });
 });

--- a/tests/unit/evaluator-pod-pending.test.ts
+++ b/tests/unit/evaluator-pod-pending.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+const { createTestDb } = require('../helpers/db');
+const { suppressConsole } = require('../helpers/mocks');
+
+const nodemailer = require('nodemailer');
+
+describe('evaluateAlerts — pod_pending', () => {
+  let db: any;
+  let evaluateAlerts: Function;
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = suppressConsole();
+    mock.method(nodemailer, 'createTransport', () => ({ sendMail: mock.fn(async () => ({ messageId: 't' })) }));
+    db = createTestDb();
+    delete require.cache[require.resolve('../../hub/src/alerts/evaluator')];
+    delete require.cache[require.resolve('../../hub/src/alerts/sender')];
+    evaluateAlerts = require('../../hub/src/alerts/evaluator').evaluateAlerts;
+  });
+
+  afterEach(() => {
+    db.close();
+    restore();
+    mock.restoreAll();
+  });
+
+  const cfg = {
+    enabled: true, to: 't@t.com', cooldownMinutes: 60,
+    containerDown: false, restartCount: 0,
+    cpuPercent: 0, memoryMb: 0, diskPercent: 0,
+    hostCpuPercent: 0, hostMemoryAvailableMb: 0, hostLoadThreshold: 0,
+    hostOffline: false, hostOfflineMinutes: 0,
+    containerUnhealthy: false, excludeContainers: '',
+    endpointDown: false, endpointFailureThreshold: 3,
+    podPending: true, podPendingMinutes: 5,
+  };
+
+  function insertPending(opts: {
+    cluster?: string; ns?: string; pod: string;
+    reason?: string | null; message?: string | null;
+    workloadKind?: string | null; workloadName?: string | null;
+    firstSeenAgoMinutes?: number;
+  }): void {
+    const cluster = opts.cluster ?? 'k3s';
+    const ns = opts.ns ?? 'default';
+    const ago = opts.firstSeenAgoMinutes ?? 10;
+    db.prepare(`
+      INSERT INTO pending_pods (cluster_id, namespace, pod_name, reason, message, pod_phase,
+                                pod_created_at, workload_kind, workload_name, first_seen_at, last_seen_at)
+      VALUES (?, ?, ?, ?, ?, 'Pending', NULL, ?, ?, datetime('now', ?), datetime('now'))
+    `).run(cluster, ns, opts.pod,
+      opts.reason ?? null, opts.message ?? null,
+      opts.workloadKind ?? null, opts.workloadName ?? null,
+      `-${ago} minutes`);
+  }
+
+  it('fires pod_pending when first_seen_at is older than threshold', () => {
+    insertPending({ pod: 'web-7d-xyz', reason: 'Unschedulable', message: '0/3 nodes available', firstSeenAgoMinutes: 10 });
+    const { triggered } = evaluateAlerts(db, { alerts: cfg });
+    const fired = triggered.filter((a: any) => a.type === 'pod_pending');
+    assert.equal(fired.length, 1);
+    assert.equal(fired[0].hostId, 'k3s');
+    assert.equal(fired[0].target, 'default/web-7d-xyz');
+    assert.match(fired[0].message, /Unschedulable/);
+    assert.match(fired[0].message, /0\/3 nodes available/);
+  });
+
+  it('does not fire below threshold', () => {
+    insertPending({ pod: 'recent', firstSeenAgoMinutes: 2 });
+    const { triggered } = evaluateAlerts(db, { alerts: cfg });
+    assert.equal(triggered.filter((a: any) => a.type === 'pod_pending').length, 0);
+  });
+
+  it('respects the podPending=false toggle', () => {
+    insertPending({ pod: 'web-7d-xyz', firstSeenAgoMinutes: 60 });
+    const { triggered } = evaluateAlerts(db, { alerts: { ...cfg, podPending: false } });
+    assert.equal(triggered.filter((a: any) => a.type === 'pod_pending').length, 0);
+  });
+
+  it('includes workload owner in message when present', () => {
+    insertPending({ pod: 'web-7d-xyz', workloadKind: 'ReplicaSet', workloadName: 'web-7d', firstSeenAgoMinutes: 10 });
+    const { triggered } = evaluateAlerts(db, { alerts: cfg });
+    const fired = triggered.find((a: any) => a.type === 'pod_pending');
+    assert.match(fired.message, /ReplicaSet\/web-7d/);
+  });
+
+  it('auto-resolves pod_pending when row is gone (left Pending or removed)', () => {
+    insertPending({ pod: 'web-7d-xyz', firstSeenAgoMinutes: 10 });
+    // Simulate the alert was already triggered + persisted as active.
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, notify_count, trigger_value)
+      VALUES (?, 'pod_pending', ?, datetime('now', '-1 hour'), datetime('now', '-1 hour'), 1, 'Unschedulable')
+    `).run('k3s', 'default/web-7d-xyz');
+    // Pod left Pending — row removed by the next ingest cycle.
+    db.prepare('DELETE FROM pending_pods').run();
+
+    const { resolved } = evaluateAlerts(db, { alerts: cfg });
+    const r = resolved.find((a: any) => a.type === 'pod_pending');
+    assert.ok(r, 'auto-resolution fired');
+    assert.equal(r.target, 'default/web-7d-xyz');
+    assert.match(r.message, /no longer Pending/);
+  });
+
+  it('does not auto-resolve while the pod row is still present', () => {
+    insertPending({ pod: 'web-7d-xyz', firstSeenAgoMinutes: 10 });
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, notify_count, trigger_value)
+      VALUES ('k3s', 'pod_pending', 'default/web-7d-xyz', datetime('now', '-1 hour'), datetime('now', '-1 hour'), 1, 'Unschedulable')
+    `).run();
+    const { resolved } = evaluateAlerts(db, { alerts: cfg });
+    assert.equal(resolved.filter((a: any) => a.type === 'pod_pending').length, 0);
+  });
+});

--- a/tests/unit/hub-ingest-pending-pods.test.ts
+++ b/tests/unit/hub-ingest-pending-pods.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+const { createTestDb } = require('../helpers/db');
+const { ingestPendingPods } = require('../../hub/src/ingest');
+
+interface PendingPodRow {
+  cluster_id: string;
+  namespace: string;
+  pod_name: string;
+  reason: string | null;
+  message: string | null;
+  pod_phase: string;
+  workload_kind: string | null;
+  workload_name: string | null;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+function tick(ms = 5): Promise<void> { return new Promise(resolve => setTimeout(resolve, ms)); }
+
+function seed(ns: string, podName: string, reason = 'Unschedulable', message = 'no nodes') {
+  return {
+    namespace: ns,
+    podName,
+    reason,
+    message,
+    podPhase: 'Pending',
+    podCreatedAt: '2026-04-30T10:00:00Z',
+    workloadKind: 'ReplicaSet',
+    workloadName: podName.replace(/-\w+$/, ''),
+  };
+}
+
+describe('ingestPendingPods', () => {
+  let db: any;
+  beforeEach(() => { db = createTestDb(); });
+  afterEach(() => { db.close(); });
+
+  it('upserts on (cluster_id, namespace, pod_name) — preserves first_seen_at across cycles', async () => {
+    ingestPendingPods(db, 'c1', [seed('default', 'web-7d-xyz', 'Unschedulable', 'msg-1')]);
+    const before = db.prepare('SELECT * FROM pending_pods').get() as PendingPodRow;
+    await tick();
+    ingestPendingPods(db, 'c1', [seed('default', 'web-7d-xyz', 'Unschedulable', 'msg-2')]);
+    const after = db.prepare('SELECT * FROM pending_pods').get() as PendingPodRow;
+    assert.equal(after.first_seen_at, before.first_seen_at, 'first_seen_at preserved');
+    assert.notEqual(after.last_seen_at, before.last_seen_at, 'last_seen_at advances');
+    assert.equal(after.message, 'msg-2', 'mutable fields update');
+  });
+
+  it('deletes pods absent from a later batch (left Pending or removed)', async () => {
+    ingestPendingPods(db, 'c1', [
+      seed('default', 'a-pod'),
+      seed('default', 'b-pod'),
+    ]);
+    await tick();
+    // Batch 2 only has 'a-pod' — 'b-pod' should be pruned
+    ingestPendingPods(db, 'c1', [seed('default', 'a-pod')]);
+    const rows = db.prepare('SELECT pod_name FROM pending_pods ORDER BY pod_name').all() as { pod_name: string }[];
+    assert.deepEqual(rows.map(r => r.pod_name), ['a-pod']);
+  });
+
+  it('scopes pruning to cluster_id — other clusters untouched', async () => {
+    ingestPendingPods(db, 'c1', [seed('default', 'a-pod')]);
+    ingestPendingPods(db, 'c2', [seed('default', 'b-pod')]);
+    await tick();
+    ingestPendingPods(db, 'c1', []); // c1 has no more pending pods
+    const c2 = db.prepare('SELECT pod_name FROM pending_pods WHERE cluster_id = ?').all('c2') as { pod_name: string }[];
+    assert.deepEqual(c2.map(r => r.pod_name), ['b-pod'], 'c2 still has its row');
+    const c1 = db.prepare('SELECT pod_name FROM pending_pods WHERE cluster_id = ?').all('c1') as { pod_name: string }[];
+    assert.deepEqual(c1, []);
+  });
+
+  it('stores nullable fields without choking', () => {
+    ingestPendingPods(db, 'c1', [{
+      namespace: 'default',
+      podName: 'standalone',
+      reason: null,
+      message: null,
+      podPhase: 'Pending',
+      podCreatedAt: null,
+      workloadKind: null,
+      workloadName: null,
+    }]);
+    const row = db.prepare('SELECT * FROM pending_pods').get() as PendingPodRow;
+    assert.equal(row.reason, null);
+    assert.equal(row.workload_kind, null);
+  });
+});

--- a/tests/unit/hub-schema-v40.test.ts
+++ b/tests/unit/hub-schema-v40.test.ts
@@ -8,10 +8,6 @@ function getColumns(db: any, table: string): string[] {
 }
 
 describe('schema v40', () => {
-  it('reports version 40', () => {
-    assert.equal(SCHEMA_VERSION, 40);
-  });
-
   it('fresh bootstrap has last_oom_killed_at on container_snapshots', () => {
     const db = new Database(':memory:');
     bootstrap(db);
@@ -66,7 +62,7 @@ describe('schema v40', () => {
     const cols = getColumns(db, 'container_snapshots');
     assert.ok(cols.includes('last_oom_killed_at'), 'v39→v40 migration adds last_oom_killed_at');
     const v = (db.prepare("SELECT value FROM meta WHERE key = 'schema_version'").get() as { value: string }).value;
-    assert.equal(v, '40');
+    assert.equal(parseInt(v, 10), SCHEMA_VERSION);
     db.close();
   });
 });

--- a/tests/unit/hub-schema-v41.test.ts
+++ b/tests/unit/hub-schema-v41.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+const { bootstrap, SCHEMA_VERSION } = require('../../hub/src/db/schema');
+
+function getColumns(db: any, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map(r => r.name);
+}
+
+describe('schema v41', () => {
+  it('reports version 41', () => {
+    assert.equal(SCHEMA_VERSION, 41);
+  });
+
+  it('fresh bootstrap creates pending_pods', () => {
+    const db = new Database(':memory:');
+    bootstrap(db);
+    const cols = getColumns(db, 'pending_pods');
+    assert.deepEqual(
+      cols.sort(),
+      ['cluster_id', 'first_seen_at', 'last_seen_at', 'message', 'namespace',
+       'pod_created_at', 'pod_name', 'pod_phase', 'reason', 'workload_kind', 'workload_name'].sort(),
+    );
+    db.close();
+  });
+
+  it('migrating from v40 adds the table', () => {
+    const db = new Database(':memory:');
+    bootstrap(db);
+    db.exec('DROP TABLE pending_pods');
+    db.prepare("UPDATE meta SET value = '40' WHERE key = 'schema_version'").run();
+    bootstrap(db);
+    const cols = getColumns(db, 'pending_pods');
+    assert.ok(cols.includes('cluster_id'));
+    assert.ok(cols.includes('first_seen_at'));
+    const v = (db.prepare("SELECT value FROM meta WHERE key = 'schema_version'").get() as { value: string }).value;
+    assert.equal(parseInt(v, 10), SCHEMA_VERSION);
+    db.close();
+  });
+});

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -22,7 +22,7 @@ describe('queries', () => {
     it('returns status ok with schema version', () => {
       const health = getHealth(db);
       assert.equal(health.status, 'ok');
-      assert.equal(health.schemaVersion, 40);
+      assert.equal(health.schemaVersion, 41);
       assert.equal(typeof health.uptime, 'number');
     });
   });


### PR DESCRIPTION
## Summary
- New cluster-scoped publisher (leader-elected, same pattern as PV/PVC/Events/Ingresses) that lists all Pending pods cluster-wide and ships them to the hub.
- New `pending_pods` registry table (schema v41) with current-state UPSERT semantics — `first_seen_at` is preserved across cycles, so the alert evaluator can age pods by original observation time.
- New `pod_pending` alert type fires when `first_seen_at >= podPendingMinutes` (default 5). Auto-resolves when the pod leaves Pending or disappears.
- Reason resolution priority: `PodScheduled=False` (Unschedulable) > container waiting reasons (ImagePullBackOff, ErrImagePull, CreateContainerError) > `Initialized=False` (PVC unbound) > first waiting reason.
- Workload (kind, name) captured from ownerReferences so alerts read "Pod ... (ReplicaSet/web-7d) stuck Unschedulable for 12m".

## Why
Pending pods are the most common k8s pain (no node fits, PVC pending, taints) and were a true blind spot — the per-node agent only iterates `pod.status.containerStatuses`, which is empty for unscheduled pods. ImagePullBackOff already flowed into `container_unhealthy`, but Unschedulable pods never appeared anywhere in insightd.

## Config
- `INSIGHTD_ALERT_POD_PENDING` — toggle (default true)
- `INSIGHTD_ALERT_POD_PENDING_MINUTES` — threshold in minutes (default 5)

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 1006 tests pass
- [ ] Spot-check on the k3d-test cluster: deploy a pod with an obviously bogus image (`busybox:does-not-exist`), wait 5 min, see `pod_pending` alert with ImagePullBackOff message
- [ ] Then `kubectl delete` the pod, verify auto-resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)