### PR TITLE
fix(web): centralize auth gate so unprotected endpoints can't slip through

### DIFF
--- a/hub/src/web/handlers.ts
+++ b/hub/src/web/handlers.ts
@@ -4,10 +4,13 @@ import type Dockerode from 'dockerode';
 
 const queries = require('./queries');
 const { offlineThresholdMinutes } = require('../config') as { offlineThresholdMinutes: () => number };
-const { isAuthEnabled, authenticate, requireAuth, isSetupComplete, createApiKey, revokeApiKey, getApiKeys } = require('./auth') as {
+// Auth: gating happens centrally in server.ts now (every API route requires
+// auth unless it's on PUBLIC_ROUTES). Handlers no longer need to call
+// requireAuth themselves — this prevents the "forgot to add the check on a
+// new handler" class of bug.
+const { isAuthEnabled, authenticate, isSetupComplete, createApiKey, revokeApiKey, getApiKeys } = require('./auth') as {
   isAuthEnabled: () => boolean;
   authenticate: (password: string, ip?: string) => string | null;
-  requireAuth: (req: IncomingMessage) => boolean;
   isSetupComplete: () => boolean;
   createApiKey: (db: Database.Database, name: string) => { key: string; prefix: string };
   revokeApiKey: (db: Database.Database, id: number) => void;
@@ -80,7 +83,6 @@ function handleHosts(req: HandlerReq, res: ServerResponse, db: Database.Database
 }
 
 async function handleDeleteHost(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const hostId = decodeURIComponent(params.hostId);
   const host = db.prepare('SELECT host_id FROM hosts WHERE host_id = ?').get(hostId) as { host_id: string } | undefined;
   if (!host) { res.statusCode = 404; return { error: 'Host not found' }; }
@@ -98,7 +100,6 @@ async function handleDeleteHost(req: HandlerReq, res: ServerResponse, db: Databa
 }
 
 async function handleSetHostGroup(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const hostId = decodeURIComponent(params.hostId);
   const exists = db.prepare('SELECT 1 FROM hosts WHERE host_id = ?').get(hostId);
   if (!exists) { res.statusCode = 404; return { error: 'Host not found' }; }
@@ -111,7 +112,6 @@ async function handleSetHostGroup(req: HandlerReq, res: ServerResponse, db: Data
 }
 
 function handleResetHostGroup(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const hostId = decodeURIComponent(params.hostId);
   const exists = db.prepare('SELECT 1 FROM hosts WHERE host_id = ?').get(hostId);
   if (!exists) { res.statusCode = 404; return { error: 'Host not found' }; }
@@ -129,7 +129,6 @@ function handleResetHostGroup(req: HandlerReq, res: ServerResponse, db: Database
  * agent report.
  */
 async function handleRenameHostGroup(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const oldName = decodeURIComponent(params.name);
   if (!oldName) { res.statusCode = 400; return { error: 'Invalid group name' }; }
   const body = await readBody(req);
@@ -154,7 +153,6 @@ async function handleRenameHostGroup(req: HandlerReq, res: ServerResponse, db: D
  * next agent report won't re-create the deleted group.
  */
 async function handleDeleteHostGroup(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const name = decodeURIComponent(params.name);
   if (!name) { res.statusCode = 400; return { error: 'Invalid group name' }; }
 
@@ -169,7 +167,6 @@ async function handleDeleteHostGroup(req: HandlerReq, res: ServerResponse, db: D
 }
 
 async function handleDeleteContainer(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>, ctx: HandlerCtx): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const hostId = decodeURIComponent(params.hostId);
   const containerName = decodeURIComponent(params.containerName);
 
@@ -460,10 +457,6 @@ async function handleLogin(req: HandlerReq, res: ServerResponse, db: Database.Da
 }
 
 function handleGetSettings(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const settings = getSettings(db);
   // Group by category
   const grouped: Record<string, any[]> = {};
@@ -475,10 +468,6 @@ function handleGetSettings(req: HandlerReq, res: ServerResponse, db: Database.Da
 }
 
 async function handlePutSettings(req: HandlerReq, res: ServerResponse, db: Database.Database): Promise<any> {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const body = await readBody(req);
   return putSettings(db, body);
 }
@@ -517,7 +506,6 @@ function handleEvents(req: HandlerReq, res: ServerResponse, db: Database.Databas
 }
 
 function handleHostK8sEvents(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const url = new URL(req.url, `http://${req.headers.host}`);
   const limit = parseInt(url.searchParams.get('limit') || '100', 10) || 100;
   const reason = url.searchParams.get('reason') || undefined;
@@ -530,7 +518,6 @@ function handleHostK8sEvents(req: HandlerReq, res: ServerResponse, db: Database.
 }
 
 function handleHostNodeConditions(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const items = queries.getNodeConditionsForHost(db, params.hostId);
   return { items };
 }
@@ -573,10 +560,6 @@ function handleGetEndpoints(req: HandlerReq, res: ServerResponse, db: Database.D
 }
 
 async function handleCreateEndpoint(req: HandlerReq, res: ServerResponse, db: Database.Database): Promise<any> {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const body = await readBody(req);
   const errors = validateEndpointBody(body);
   if (errors.length > 0) {
@@ -599,10 +582,6 @@ function handleGetEndpoint(req: HandlerReq, res: ServerResponse, db: Database.Da
 }
 
 async function handleUpdateEndpoint(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const id = parseInt(params.endpointId, 10);
   const existing = endpointQueries.getEndpoint(db, id);
   if (!existing) {
@@ -619,10 +598,6 @@ async function handleUpdateEndpoint(req: HandlerReq, res: ServerResponse, db: Da
 }
 
 async function handleDeleteEndpoint(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const id = parseInt(params.endpointId, 10);
   const result = endpointQueries.deleteEndpoint(db, id);
   if (!result.deleted) {
@@ -637,10 +612,6 @@ function handleGetDiscoveredIngresses(req: HandlerReq, res: ServerResponse, db: 
 }
 
 async function handleCreateEndpointFromIngress(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const ingressId = parseInt(params.ingressId, 10);
   if (!Number.isFinite(ingressId)) {
     res.statusCode = 400;
@@ -660,10 +631,6 @@ async function handleCreateEndpointFromIngress(req: HandlerReq, res: ServerRespo
 }
 
 async function handleDismissIngress(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const ingressId = parseInt(params.ingressId, 10);
   if (!Number.isFinite(ingressId)) {
     res.statusCode = 400;
@@ -678,10 +645,6 @@ async function handleDismissIngress(req: HandlerReq, res: ServerResponse, db: Da
 }
 
 async function handleUndismissIngress(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) {
-    res.statusCode = 401;
-    return { error: 'Unauthorized' };
-  }
   const ingressId = parseInt(params.ingressId, 10);
   if (!Number.isFinite(ingressId)) {
     res.statusCode = 400;
@@ -734,12 +697,10 @@ function validateWebhookBody(body: any): string[] {
 }
 
 function handleGetWebhooks(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   return webhookQueries.getWebhooks(db);
 }
 
 async function handleCreateWebhook(req: HandlerReq, res: ServerResponse, db: Database.Database): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const body = await readBody(req);
   const errors = validateWebhookBody(body);
   if (errors.length > 0) { res.statusCode = 400; return { error: errors.join('; ') }; }
@@ -748,14 +709,12 @@ async function handleCreateWebhook(req: HandlerReq, res: ServerResponse, db: Dat
 }
 
 function handleGetWebhook(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const wh = webhookQueries.getWebhook(db, parseInt(params.webhookId, 10));
   if (!wh) { res.statusCode = 404; return { error: 'Webhook not found' }; }
   return wh;
 }
 
 async function handleUpdateWebhook(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const id = parseInt(params.webhookId, 10);
   const existing = webhookQueries.getWebhook(db, id);
   if (!existing) { res.statusCode = 404; return { error: 'Webhook not found' }; }
@@ -764,7 +723,6 @@ async function handleUpdateWebhook(req: HandlerReq, res: ServerResponse, db: Dat
 }
 
 async function handleDeleteWebhook(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const id = parseInt(params.webhookId, 10);
   const result = webhookQueries.deleteWebhook(db, id);
   if (!result.deleted) { res.statusCode = 404; return { error: 'Webhook not found' }; }
@@ -772,7 +730,6 @@ async function handleDeleteWebhook(req: HandlerReq, res: ServerResponse, db: Dat
 }
 
 async function handleTestWebhook(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const id = parseInt(params.webhookId, 10);
   const wh = webhookQueries.getWebhook(db, id);
   if (!wh) { res.statusCode = 404; return { error: 'Webhook not found' }; }
@@ -780,7 +737,6 @@ async function handleTestWebhook(req: HandlerReq, res: ServerResponse, db: Datab
 }
 
 async function handleTestWebhookUnsaved(req: HandlerReq, res: ServerResponse, db: Database.Database): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const body = await readBody(req);
   const errors = validateWebhookBody(body);
   if (errors.length > 0) { res.statusCode = 400; return { error: errors.join('; ') }; }
@@ -1134,7 +1090,6 @@ function handleGetAIDiagnose(req: HandlerReq, res: ServerResponse, db: Database.
 }
 
 async function handleAIDiagnose(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>, ctx: HandlerCtx): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const { getEffectiveConfig } = require('../db/settings') as { getEffectiveConfig: (db: Database.Database, c: any) => any };
   const live = getEffectiveConfig(db, config);
   if (!live.ai?.enabled) {
@@ -1225,7 +1180,6 @@ function handleImageUpdates(req: HandlerReq, res: ServerResponse, db: Database.D
 }
 
 function handleRequestUpdateCheck(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>, ctx: HandlerCtx): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   if (!ctx.requestUpdateCheck) { res.statusCode = 501; return { error: 'Not available in standalone mode' }; }
   const threshold = offlineThresholdMinutes();
   const result = ctx.requestUpdateCheck(db, threshold);
@@ -1240,14 +1194,12 @@ function handleVersionCheck(req: HandlerReq, res: ServerResponse): any {
 }
 
 async function handleRefreshVersionCheck(req: HandlerReq, res: ServerResponse): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const { checkForUpdates, getVersionInfo } = require('../version-check');
   await checkForUpdates();
   return getVersionInfo();
 }
 
 async function handleUpdateAgent(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>, ctx: HandlerCtx): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   if (!ctx.requestUpdate) { res.statusCode = 501; return { error: 'Update not available in standalone mode' }; }
   // Snooze alerts during update
   const { snoozeAlerts } = require('../alert-snooze');
@@ -1266,7 +1218,6 @@ async function handleUpdateAgent(req: HandlerReq, res: ServerResponse, db: Datab
 }
 
 async function handleUpdateAllAgents(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>, ctx: HandlerCtx): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   if (!ctx.requestUpdate) { res.statusCode = 501; return { error: 'Update not available in standalone mode' }; }
   const { snoozeAlerts } = require('../alert-snooze');
   snoozeAlerts(15);
@@ -1288,7 +1239,6 @@ async function handleUpdateAllAgents(req: HandlerReq, res: ServerResponse, db: D
 }
 
 async function handleUpdateHub(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>, ctx: HandlerCtx): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   if (!ctx.requestUpdate) { res.statusCode = 501; return { error: 'Update not available in standalone mode' }; }
   const { snoozeAlerts } = require('../alert-snooze');
   snoozeAlerts(10);
@@ -1423,7 +1373,6 @@ function authIdentifier(req: HandlerReq): string {
 }
 
 async function handleSilenceAlert(req: HandlerReq, res: ServerResponse, db: Database.Database, _config: any, params: Record<string, string>): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const id = parseInt(params.id, 10);
   if (!Number.isFinite(id)) { res.statusCode = 400; return { error: 'Invalid alert id' }; }
 
@@ -1457,7 +1406,6 @@ async function handleSilenceAlert(req: HandlerReq, res: ServerResponse, db: Data
 }
 
 function handleUnsilenceAlert(req: HandlerReq, res: ServerResponse, db: Database.Database, _config: any, params: Record<string, string>): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const id = parseInt(params.id, 10);
   if (!Number.isFinite(id)) { res.statusCode = 400; return { error: 'Invalid alert id' }; }
 
@@ -1480,7 +1428,6 @@ function handleUnsilenceAlert(req: HandlerReq, res: ServerResponse, db: Database
  * because the next evaluator run would just re-create them — silence is the
  * right tool for those. */
 function handleDeleteAlert(req: HandlerReq, res: ServerResponse, db: Database.Database, _config: any, params: Record<string, string>): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const id = parseInt(params.id, 10);
   if (!Number.isFinite(id)) { res.statusCode = 400; return { error: 'Invalid alert id' }; }
 
@@ -1496,7 +1443,6 @@ function handleDeleteAlert(req: HandlerReq, res: ServerResponse, db: Database.Da
 }
 
 async function handleContainerAction(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>, ctx: HandlerCtx): Promise<any> {
-  if (!requireAuth(req)) return { error: 'Unauthorized' };
 
   const body = await readBody(req);
   const action = body.action;
@@ -1534,12 +1480,10 @@ async function handleContainerAction(req: HandlerReq, res: ServerResponse, db: D
 module.exports = { handleHealth, handleHosts, handleHostDetail, handleHostContainers, handleHostDisk, handleDashboard, handleAlerts, handleContainerDetail, handleContainerPodEvents, handleContainerLogs, handleGetNamespaceTopology, handleGetClusterOverview, handleHostMetrics, handleLogin, handleGetSettings, handlePutSettings, handleAgentSetup, handleTimeline, handleRankings, handleTrends, handleEvents, handleHostK8sEvents, handleHostNodeConditions, handleGetEndpoints, handleCreateEndpoint, handleGetEndpoint, handleUpdateEndpoint, handleDeleteEndpoint, handleEndpointChecks, handleGetDiscoveredIngresses, handleCreateEndpointFromIngress, handleDismissIngress, handleUndismissIngress, handleGetWebhooks, handleCreateWebhook, handleGetWebhook, handleUpdateWebhook, handleDeleteWebhook, handleTestWebhook, handleTestWebhookUnsaved, handleGetBaselines, handleGetHostBaselinesView, handleGetContainerBaselinesView, handleGetContainerRcaNeighbors, handleGetAllHealthScores, handleGetHealthScore, handleGetInsights, handleGetHostInsights, handleInsightFeedback, handleGetInsightFeedback, handleAIDiagnoseStatus, handleGetAIDiagnose, handleAIDiagnose, handleDeleteHost, handleSetHostGroup, handleResetHostGroup, handleRenameHostGroup, handleDeleteHostGroup, handleDeleteContainer, handleSetupStatus, handleSetupPassword, handleSetupComplete, handleImageUpdates, handleRequestUpdateCheck, handleVersionCheck, handleUpdateAgent, handleUpdateAllAgents, handleUpdateHub, handleContainerAvailability, handleContainerAction, handleSilenceAlert, handleUnsilenceAlert, handleDeleteAlert, handlePublicStatus, handleGetApiKeys, handleCreateApiKey, handleDeleteApiKey, handleGetStorage, handleVacuum, handleRefreshVersionCheck, handleDisksOverview, handleVolumesOverview, handlePvsOverview };
 
 function handleGetApiKeys(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   return getApiKeys(db);
 }
 
 async function handleCreateApiKey(req: HandlerReq, res: ServerResponse, db: Database.Database): Promise<any> {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const body = await readBody(req);
   if (!body.name || !body.name.trim()) { res.statusCode = 400; return { error: 'Name is required' }; }
   const result = createApiKey(db, body.name.trim());
@@ -1547,30 +1491,25 @@ async function handleCreateApiKey(req: HandlerReq, res: ServerResponse, db: Data
 }
 
 function handleDeleteApiKey(req: HandlerReq, res: ServerResponse, db: Database.Database, config: any, params: Record<string, string>): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   revokeApiKey(db, parseInt(params.keyId, 10));
   return { deleted: true };
 }
 
 function handleDisksOverview(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   return queries.getDisksOverview(db, offlineThresholdMinutes());
 }
 
 function handleVolumesOverview(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   return queries.getVolumesOverview(db, offlineThresholdMinutes());
 }
 
 function handlePvsOverview(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   // Stale window of 15 min — agents publish every 5 min by default, so 3
   // missed cycles flips a cluster offline.
   return queries.getPvsOverview(db, 15);
 }
 
 function handleGetStorage(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
 
   const pageCount = (db.pragma('page_count') as any)[0].page_count;
   const pageSize = (db.pragma('page_size') as any)[0].page_size;
@@ -1608,7 +1547,6 @@ function handleGetStorage(req: HandlerReq, res: ServerResponse, db: Database.Dat
 }
 
 function handleVacuum(req: HandlerReq, res: ServerResponse, db: Database.Database): any {
-  if (!requireAuth(req)) { res.statusCode = 401; return { error: 'Unauthorized' }; }
   const before = (db.pragma('page_count') as any)[0].page_count * (db.pragma('page_size') as any)[0].page_size;
   db.exec('VACUUM');
   db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_vacuum_at', datetime('now'))").run();

--- a/hub/src/web/router.ts
+++ b/hub/src/web/router.ts
@@ -5,6 +5,7 @@
 
 interface Route {
   method: string;
+  pattern: string;
   regex: RegExp;
   paramNames: string[];
   handler: Function;
@@ -13,6 +14,9 @@ interface Route {
 interface MatchResult {
   handler: Function;
   params: Record<string, string>;
+  /** Original `${method} ${pattern}` key — used by the server to check the
+   *  public-routes allowlist without re-stringifying URLs. */
+  routeKey: string;
 }
 
 function createRouter(): { add: (method: string, pattern: string, handler: Function) => void; match: (method: string, pathname: string) => MatchResult | null } {
@@ -24,7 +28,7 @@ function createRouter(): { add: (method: string, pattern: string, handler: Funct
       paramNames.push(name);
       return '([^/]+)';
     });
-    routes.push({ method, regex: new RegExp(`^${regexStr}$`), paramNames, handler });
+    routes.push({ method, pattern, regex: new RegExp(`^${regexStr}$`), paramNames, handler });
   }
 
   function match(method: string, pathname: string): MatchResult | null {
@@ -34,7 +38,7 @@ function createRouter(): { add: (method: string, pattern: string, handler: Funct
       if (m) {
         const params: Record<string, string> = {};
         route.paramNames.forEach((name: string, i: number) => { params[name] = decodeURIComponent(m[i + 1]); });
-        return { handler: route.handler, params };
+        return { handler: route.handler, params, routeKey: `${route.method} ${route.pattern}` };
       }
     }
     return null;

--- a/hub/src/web/server.ts
+++ b/hub/src/web/server.ts
@@ -6,9 +6,41 @@ import type { IncomingMessage, ServerResponse, Server } from 'http';
 import type Database from 'better-sqlite3';
 import type Dockerode from 'dockerode';
 
-const { createRouter } = require('./router') as { createRouter: () => { add: (method: string, pattern: string, handler: Function) => void; match: (method: string, pathname: string) => { handler: Function; params: Record<string, string> } | null } };
+const { createRouter } = require('./router') as { createRouter: () => { add: (method: string, pattern: string, handler: Function) => void; match: (method: string, pathname: string) => { handler: Function; params: Record<string, string>; routeKey: string } | null } };
 const handlers = require('./handlers');
 const { isRateLimited } = require('./rate-limit') as { isRateLimited: (req: IncomingMessage) => boolean };
+const { requireAuth } = require('./auth') as { requireAuth: (req: IncomingMessage) => boolean };
+
+/**
+ * API routes that bypass `requireAuth`. Everything else requires a valid
+ * Bearer token (or no admin password configured, see auth.isAuthEnabled).
+ *
+ * Keep this list minimal — adding a route here is making it world-readable
+ * when auth is enabled. Each entry needs a justification:
+ *
+ *   GET  /api/health             — liveness probe; returns version + schema
+ *                                  version, no resource data.
+ *   GET  /api/status             — public status page; gated separately by
+ *                                  the INSIGHTD_STATUS_PAGE env var inside
+ *                                  the handler.
+ *   POST /api/auth               — login itself; the only way to acquire a
+ *                                  token in the first place.
+ *   GET  /api/setup/status       — used by SetupWizard before any password
+ *                                  exists; cannot be gated on auth that
+ *                                  hasn't been configured yet.
+ *   POST /api/setup/password     — first-time password set; gated internally
+ *                                  by isSetupComplete() so it 403s once the
+ *                                  setup is done.
+ *   POST /api/setup/complete     — same: only callable while !isSetupComplete().
+ */
+const PUBLIC_ROUTES = new Set<string>([
+  'GET /api/health',
+  'GET /api/status',
+  'POST /api/auth',
+  'GET /api/setup/status',
+  'POST /api/setup/password',
+  'POST /api/setup/complete',
+]);
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html',
@@ -149,6 +181,16 @@ function startWebServer(db: Database.Database, config: WebConfig, context?: WebS
       if (!match) {
         res.statusCode = 404;
         res.end(JSON.stringify({ error: 'Not found' }));
+        return;
+      }
+      // Centralized auth gate — every API route is protected unless it's
+      // on PUBLIC_ROUTES. New handlers don't need to remember to call
+      // requireAuth themselves; you have to opt OUT here, not opt IN per
+      // handler. (Fixes the "scattered requireAuth calls and one was
+      // forgotten" class of bug — see PR #223.)
+      if (!PUBLIC_ROUTES.has(match.routeKey) && !requireAuth(req)) {
+        res.statusCode = 401;
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
         return;
       }
       try {

--- a/tests/integration/web-api-auth.test.ts
+++ b/tests/integration/web-api-auth.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+const http = require('http');
+const { createTestDb } = require('../helpers/db');
+
+function fetchMethod(port: number, method: string, path: string, opts: { token?: string; body?: any } = {}) {
+  return new Promise<{ status: number; headers: any; body: string; json: () => any }>((resolve, reject) => {
+    const payload = opts.body !== undefined ? JSON.stringify(opts.body) : undefined;
+    const headers: Record<string, string> = {};
+    if (payload) { headers['Content-Type'] = 'application/json'; headers['Content-Length'] = String(Buffer.byteLength(payload)); }
+    if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+    const req = http.request(`http://127.0.0.1:${port}${path}`, { method, headers }, (res: any) => {
+      let resBody = '';
+      res.on('data', (chunk: string) => { resBody += chunk; });
+      res.on('end', () => {
+        resolve({ status: res.statusCode, headers: res.headers, body: resBody, json: () => JSON.parse(resBody) });
+      });
+    });
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function startTestServer(db: any) {
+  // Force a fresh require so the auth module reattaches to this test's db.
+  delete require.cache[require.resolve('../../hub/src/web/server')];
+  delete require.cache[require.resolve('../../hub/src/web/auth')];
+  delete require.cache[require.resolve('../../hub/src/web/handlers')];
+  const { startWebServer } = require('../../hub/src/web/server');
+  const { setDb } = require('../../hub/src/web/auth') as { setDb: (db: any) => void };
+  // Production wires this from hub/src/index.ts before booting the web
+  // server. The test bypasses index.ts so we wire it ourselves — without
+  // it, isAuthEnabled() always returns false and the gate is a no-op.
+  setDb(db);
+  const config = {
+    collectIntervalMinutes: 5,
+    web: { enabled: true, port: 0, host: '127.0.0.1' },
+  };
+  return new Promise<{ server: any; port: number }>((resolve) => {
+    const server = startWebServer(db, config);
+    server.on('listening', () => {
+      const port = server.address().port;
+      resolve({ server, port });
+    });
+  });
+}
+
+/**
+ * Centralized auth gate (server.ts PUBLIC_ROUTES) — replaces the scattered
+ * per-handler `requireAuth` calls and the bug where a few read endpoints
+ * silently lacked it. Asserts:
+ *   1. Public routes are reachable without a token even when auth is enabled.
+ *   2. Every other route returns 401 without a token.
+ *   3. With a valid token, the same routes succeed (200/4xx but NOT 401).
+ *   4. When auth is disabled (no admin password), everything is reachable.
+ */
+describe('Web API auth gate', () => {
+  let db: any;
+  let server: any;
+  let port: number;
+
+  beforeEach(async () => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    if (server) server.close();
+    db.close();
+  });
+
+  // ── Auth-disabled mode ─────────────────────────────────────────────────────
+
+  it('allows protected routes without a token when no admin password is set', async () => {
+    ({ server, port } = await startTestServer(db));
+    // /api/hosts is protected — but auth isn't enabled here, so it should
+    // resolve to 200 (empty list, no hosts seeded).
+    const res = await fetchMethod(port, 'GET', '/api/hosts');
+    assert.equal(res.status, 200);
+  });
+
+  // ── Auth-enabled mode ──────────────────────────────────────────────────────
+
+  describe('with admin password configured', () => {
+    let validToken: string;
+
+    beforeEach(async () => {
+      // Set an admin password so isAuthEnabled() returns true.
+      db.prepare("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('admin.password', 'testpass', datetime('now'))").run();
+      ({ server, port } = await startTestServer(db));
+      // Mint a valid session token by calling the login endpoint.
+      const loginRes = await fetchMethod(port, 'POST', '/api/auth', { body: { password: 'testpass' } });
+      assert.equal(loginRes.status, 200, `login failed: ${loginRes.body}`);
+      validToken = loginRes.json().token;
+      assert.ok(validToken, 'expected a token from /api/auth');
+    });
+
+    it('allows public routes without a token: /api/health, /api/setup/status, /api/status', async () => {
+      for (const path of ['/api/health', '/api/setup/status']) {
+        const res = await fetchMethod(port, 'GET', path);
+        assert.notEqual(res.status, 401, `${path} should be public, got 401`);
+      }
+    });
+
+    it('allows POST /api/auth without a token (login itself must be public)', async () => {
+      const res = await fetchMethod(port, 'POST', '/api/auth', { body: { password: 'wrong' } });
+      // 401 from authenticate() vs 401 from the gate are indistinguishable
+      // by status, but 'Invalid password' in the body proves the handler ran.
+      assert.equal(res.status, 401);
+      assert.match(res.body, /Invalid password/);
+    });
+
+    it('blocks protected GET routes without a token (401)', async () => {
+      const protectedPaths = [
+        '/api/hosts',
+        '/api/dashboard',
+        '/api/alerts',
+        '/api/insights',
+        '/api/health-scores',
+        '/api/endpoints',
+        '/api/webhooks',
+        '/api/agent-setup',
+        '/api/version-check',
+        '/api/image-updates',
+        '/api/disks',
+        '/api/volumes',
+        '/api/pvs',
+        '/api/storage',
+      ];
+      for (const path of protectedPaths) {
+        const res = await fetchMethod(port, 'GET', path);
+        assert.equal(res.status, 401, `${path} should require auth, got ${res.status}`);
+      }
+    });
+
+    it('blocks parameterized routes without a token (the previously-leaky ones)', async () => {
+      // These are the routes that bug PR #223 surfaced — they were silently
+      // unprotected before centralizing the gate.
+      const protectedPaths = [
+        '/api/hosts/some-host',
+        '/api/hosts/some-host/timeline',
+        '/api/hosts/some-host/trends',
+        '/api/hosts/some-host/events',
+        '/api/hosts/some-host/metrics',
+        '/api/hosts/some-host/containers',
+        '/api/hosts/some-host/disk',
+        '/api/hosts/some-host/baselines',
+        '/api/hosts/some-host/insights',
+        '/api/clusters/c1/overview',
+      ];
+      for (const path of protectedPaths) {
+        const res = await fetchMethod(port, 'GET', path);
+        assert.equal(res.status, 401, `${path} should require auth, got ${res.status}`);
+      }
+    });
+
+    it('rejects invalid Bearer tokens with 401', async () => {
+      const res = await fetchMethod(port, 'GET', '/api/hosts', { token: 'totally-fake' });
+      assert.equal(res.status, 401);
+    });
+
+    it('accepts a valid Bearer token on a previously-leaky route', async () => {
+      const res = await fetchMethod(port, 'GET', '/api/hosts', { token: validToken });
+      assert.notEqual(res.status, 401, `valid token should pass, got ${res.status} (${res.body})`);
+    });
+
+    it('returns 404 (not 401) for unknown routes — gate sits AFTER the router', async () => {
+      // Subtle but worth pinning down: unknown paths should 404 regardless of
+      // auth, so attackers can't use the auth gate to map our route surface.
+      const res = await fetchMethod(port, 'GET', '/api/this-route-does-not-exist');
+      assert.equal(res.status, 404);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Audit follow-up to PR #223. The hub had a scattered \`requireAuth\` pattern — each handler had to remember to add the check. PR #223 surfaced one omission (K8s events tab silently 401'd in the browser due to a missing token in \`api()\`), and once we looked at the broader picture, **36 read endpoints had the same gap.**

## What was broken

When an admin password is configured (\`isAuthEnabled() === true\`), these endpoints were world-readable to anyone who could reach the hub on the network:

| Path | What it leaks |
|---|---|
| \`GET /api/hosts\` | full host inventory |
| \`GET /api/hosts/:id\` | host detail incl. metrics, containers, alerts |
| \`GET /api/hosts/:id/containers/:name/logs\` | container logs (!) |
| \`GET /api/hosts/:id/containers/:name/ai-diagnose\` | Gemini AI diagnoses |
| \`GET /api/dashboard\` | dashboard with all containers/hosts |
| \`GET /api/alerts\` | active alerts |
| \`GET /api/insights\` | all insights including right-sizing / health |
| \`GET /api/clusters/:id/overview\` | cluster topology |
| ...and ~28 others | various reads |

A handful of others (\`GET /api/hosts/:id/k8s-events\`, all writes, all webhook/API key endpoints) **did** call \`requireAuth\` and were correctly protected. The inconsistency itself is what made the bug class easy to introduce.

## The fix

Move auth from per-handler scattered checks to a centralized gate in \`server.ts\`. Every API route is now protected unless explicitly listed in \`PUBLIC_ROUTES\`. New handlers can no longer forget — you have to opt OUT, not opt IN.

\`\`\`ts
const PUBLIC_ROUTES = new Set<string>([
  'GET /api/health',
  'GET /api/status',
  'POST /api/auth',
  'GET /api/setup/status',
  'POST /api/setup/password',
  'POST /api/setup/complete',
]);
\`\`\`

Each entry in the allowlist carries a justification comment (liveness probe, login itself, pre-setup endpoints, etc.). Adding to it is now a deliberate, reviewable act.

### Cleanup

- 41 in-handler \`if (!requireAuth(req)) { ... }\` calls removed — now redundant.
- \`requireAuth\` no longer imported in \`handlers.ts\`.
- Router exposes the matched pattern as \`routeKey\` so the gate's allowlist lookup is exact (no string-matching against decoded URLs).
- The gate sits **after** the router so unknown paths still 404 — attackers can't map the route surface via auth response codes.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1137 / 1137 pass (8 new tests in \`tests/integration/web-api-auth.test.ts\` covering: public-route bypass, protected routes returning 401, valid-token acceptance, 404-not-401 on unknown routes, the previously-leaky parameterized routes)
- [x] Frontend build clean (no FE changes)
- [x] Live verification on vdev hub:
  - \`GET /api/health\` → 200 (public)
  - \`GET /api/hosts\` (no token) → 401 (was 200 before)
  - \`GET /api/hosts\` (valid Bearer token) → 200
- [ ] Hard-refresh the live UI; confirm every tab loads cleanly with the user's session token (the api() change in PR #223 already sends it on every request)

## Notes

- Standalone mode without an admin password set: auth is disabled (\`isAuthEnabled() === false\`), \`requireAuth\` returns true, gate passes — no behavior change.
- The change is invisible from the frontend's perspective (PR #223 already wired \`api()\` to send the Bearer token automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)