### PR TITLE
proxmox: add PVE REST API transport mode

### DIFF
--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -51,8 +51,27 @@ const config = Object.freeze({
   // link "the VM as the hypervisor sees it" with "the host the VM's own
   // agent reports under". Both must be set together; either alone is a
   // configuration mistake. See docs/proxmox-setup.md.
+  // NB: separate from the PVE_API vars below — these are set on the
+  // *in-guest* agent pointing back at PVE; the PVE_API vars are set on
+  // the agent that's *talking to* PVE (typically a different process).
   proxmoxNode: process.env.INSIGHTD_PROXMOX_NODE || '',
   proxmoxVmid: process.env.INSIGHTD_PROXMOX_VMID || '',
+
+  // Proxmox VE REST API transport — when set, the agent talks to PVE over
+  // HTTPS instead of shelling out to local pvesh. Lets the agent run from
+  // any guest VM that can reach the PVE web port (default 8006), without
+  // installing Node + the agent on the hypervisor itself. Token model is
+  // `user@realm!tokenid` + secret; create via Datacenter → Permissions →
+  // API Tokens. See docs/proxmox-setup.md for the full walkthrough.
+  pveApiUrl: process.env.INSIGHTD_PVE_API_URL || '',
+  pveTokenId: process.env.INSIGHTD_PVE_TOKEN_ID || '',
+  pveTokenSecret: process.env.INSIGHTD_PVE_TOKEN_SECRET || '',
+  pveVerifyTls: process.env.INSIGHTD_PVE_VERIFY_TLS === 'true',
+  pveCaBundle: process.env.INSIGHTD_PVE_CA_BUNDLE || '',
+  // PVE node this agent is responsible for. Mirrors PR1's "one agent per
+  // PVE node" model — in REST mode there's no `local=1` row to autodiscover
+  // from, so the operator declares which node this process covers.
+  pveNode: process.env.INSIGHTD_PVE_NODE || '',
 
   // Disk warn threshold (used for logging only on agent side)
   diskWarnPercent: parseInt(process.env.INSIGHTD_DISK_WARN_THRESHOLD || '85', 10),
@@ -93,6 +112,40 @@ function validate(): string[] {
   }
   if (config.proxmoxVmid && !/^\d+$/.test(config.proxmoxVmid)) {
     errors.push(`INSIGHTD_PROXMOX_VMID must be a positive integer, got "${config.proxmoxVmid}"`);
+  }
+
+  // PVE REST API mode — when INSIGHTD_PVE_API_URL is set, the token + node
+  // env vars become required. Validates here so misconfigurations surface
+  // at startup, not on the first failed pveApi call mid-cycle.
+  const pveApiActive = !!config.pveApiUrl;
+  if (pveApiActive && !isPve) {
+    errors.push('INSIGHTD_PVE_API_URL is set but INSIGHTD_RUNTIME is not "proxmox" — REST API mode only applies to the proxmox runtime');
+  }
+  if (pveApiActive) {
+    if (!config.pveTokenId) {
+      errors.push('INSIGHTD_PVE_TOKEN_ID is required in PVE REST API mode (format: user@realm!tokenid)');
+    } else if (!/^[^@!]+@[^!]+![^=]+$/.test(config.pveTokenId)) {
+      errors.push(`INSIGHTD_PVE_TOKEN_ID malformed — expected user@realm!tokenid, got "${config.pveTokenId}"`);
+    }
+    if (!config.pveTokenSecret) {
+      errors.push('INSIGHTD_PVE_TOKEN_SECRET is required in PVE REST API mode');
+    } else if (config.pveTokenSecret.length < 16) {
+      // PVE tokens are UUID-shaped (36 chars). Anything shorter is almost
+      // certainly a copy-paste mistake from a credential prefix.
+      errors.push(`INSIGHTD_PVE_TOKEN_SECRET looks too short to be a real PVE token (got ${config.pveTokenSecret.length} chars)`);
+    }
+    if (!config.pveNode) {
+      errors.push('INSIGHTD_PVE_NODE is required in PVE REST API mode (one agent per PVE node — name as PVE knows it, e.g. "proxmox-01")');
+    }
+    if (!config.pveApiUrl.startsWith('https://')) {
+      // Warn only — http:// might be a deliberate test setup against a
+      // localhost reverse proxy. Surfacing as an error here would block.
+      errors.push(`INSIGHTD_PVE_API_URL should use https:// (got "${config.pveApiUrl}") — PVE's API is HTTPS-only by default`);
+    }
+  }
+  // PVE token vars set without API URL — almost certainly a misconfig.
+  if (!pveApiActive && (config.pveTokenId || config.pveTokenSecret)) {
+    errors.push('INSIGHTD_PVE_TOKEN_ID/SECRET set but INSIGHTD_PVE_API_URL is empty — REST mode will not activate');
   }
   if (isK8s && !config.podNamespace) {
     errors.push('POD_NAMESPACE is not set — leader election is disabled, PV/PVC inventory will not be published. Set via downward API (fieldRef metadata.namespace).');

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -5,7 +5,7 @@ import type { ContainerRuntime } from './runtime/types';
 const { config, validate } = require('./config') as {
   config: {
     hostId: string;
-    runtime: 'auto' | 'docker' | 'containerd' | 'kubernetes';
+    runtime: 'auto' | 'docker' | 'containerd' | 'kubernetes' | 'proxmox';
     nodeName: string;
     nodeIp: string;
     kubeletUrl: string;
@@ -22,6 +22,14 @@ const { config, validate } = require('./config') as {
     allowActions: boolean;
     logLines: number;
     logMaxLines: number;
+    // Proxmox VE — REST API transport (set on the agent talking to PVE) +
+    // node identity. See agent/src/config.ts for the env-var origins.
+    pveApiUrl: string;
+    pveTokenId: string;
+    pveTokenSecret: string;
+    pveVerifyTls: boolean;
+    pveCaBundle: string;
+    pveNode: string;
   };
   validate: () => string[];
 };
@@ -45,6 +53,12 @@ async function main(): Promise<void> {
       nodeName: config.nodeName,
       nodeIp: config.nodeIp,
       kubeletUrl: config.kubeletUrl,
+      pveApiUrl: config.pveApiUrl,
+      pveTokenId: config.pveTokenId,
+      pveTokenSecret: config.pveTokenSecret,
+      pveVerifyTls: config.pveVerifyTls,
+      pveCaBundle: config.pveCaBundle,
+      pveNode: config.pveNode,
     });
   } catch (err) {
     logger.error('runtime', 'Cannot initialize container runtime', err);

--- a/agent/src/runtime/detect.ts
+++ b/agent/src/runtime/detect.ts
@@ -24,6 +24,10 @@ const SOCKET_PROBES: Array<{ path: string; runtime: RuntimeName }> = [
  *   2. If pmxcfs is mounted (/etc/pve/.version exists), this is a Proxmox VE node
  *   3. Otherwise probe known container runtime socket paths
  *   4. Fall back to 'docker' if nothing is found (existing behavior)
+ *
+ * Note for PVE REST API mode: that mode runs the agent OFF the hypervisor,
+ * so this probe never matches. Operators using REST mode must set
+ * `INSIGHTD_RUNTIME=proxmox` explicitly. See docs/proxmox-setup.md.
  */
 export function detectRuntime(): RuntimeName {
   if (process.env.KUBERNETES_SERVICE_HOST) {

--- a/agent/src/runtime/index.ts
+++ b/agent/src/runtime/index.ts
@@ -18,6 +18,19 @@ export interface RuntimeOptions {
   nodeIp?: string;
   /** Explicit kubelet URL override. From INSIGHTD_KUBELET_URL env. */
   kubeletUrl?: string;
+  /** PVE REST API base URL — when set, ProxmoxRuntime uses HTTPS instead
+   *  of shelling local pvesh. From INSIGHTD_PVE_API_URL env. */
+  pveApiUrl?: string;
+  /** PVE token id `user@realm!tokenid`. Required in REST mode. */
+  pveTokenId?: string;
+  /** PVE token secret. Required in REST mode. */
+  pveTokenSecret?: string;
+  /** Default false (matches pvesh --insecure). Set true with a real CA. */
+  pveVerifyTls?: boolean;
+  /** Path to CA bundle PEM. Only consulted when pveVerifyTls=true. */
+  pveCaBundle?: string;
+  /** PVE node name this agent is responsible for. Required in REST mode. */
+  pveNode?: string;
 }
 
 /**
@@ -49,7 +62,17 @@ export async function getRuntime(options: RuntimeOptions): Promise<ContainerRunt
       });
       break;
     case 'proxmox':
-      runtime = new ProxmoxRuntime({ allowActions: options.allowActions });
+      runtime = new ProxmoxRuntime({
+        allowActions: options.allowActions,
+        api: options.pveApiUrl ? {
+          url: options.pveApiUrl,
+          tokenId: options.pveTokenId,
+          tokenSecret: options.pveTokenSecret,
+          verifyTls: options.pveVerifyTls,
+          caBundle: options.pveCaBundle,
+        } : undefined,
+        nodeName: options.pveNode,
+      });
       break;
     default:
       throw new Error(`Unknown runtime: ${resolved}`);

--- a/agent/src/runtime/proxmox.ts
+++ b/agent/src/runtime/proxmox.ts
@@ -1,6 +1,6 @@
 import os = require('os');
 import logger = require('../../../shared/utils/logger');
-import { pvesh } from './pvesh';
+import { pveApi, pveAction, isRestMode, configurePveTransport, type PveApiConfig } from './pveApi';
 import type {
   ContainerRuntime, ContainerInfo, ContainerWithResources,
   LogEntry, LogOptions, ContainerAction, ActionResult, ImageUpdate,
@@ -63,40 +63,72 @@ export class ProxmoxRuntime implements ContainerRuntime {
   readonly supportsActions: boolean;
   readonly supportsUpdateChecks = false;  // not meaningful for VMs/LXC
 
-  /** PVE node name as PVE itself sees it (cluster/status local=1 row).
+  /** PVE node name as PVE itself sees it.
+   *  - local-shell mode: resolved from `/cluster/status` `local=1` row.
+   *  - REST mode: provided by INSIGHTD_PVE_NODE (no `local` notion remotely).
    *  Public so the scheduler can pass it into the cluster-scoped collectors
    *  in `agent/src/collectors/proxmox-cluster.ts`. */
   nodeName: string = os.hostname();
 
   private allowActions: boolean;
+  private apiConfig?: PveApiConfig;
+  /** Operator-declared node name from INSIGHTD_PVE_NODE, used only in REST mode. */
+  private configuredNodeName?: string;
 
   /** In-cycle cache so listContainers and collectResources share one pvesh call. */
   private resourceCache = new Map<string, PveResource>();
 
-  constructor(options: { allowActions?: boolean } = {}) {
+  constructor(options: {
+    allowActions?: boolean;
+    api?: PveApiConfig;
+    nodeName?: string;
+  } = {}) {
     this.allowActions = options.allowActions === true;
+    this.apiConfig = options.api;
+    this.configuredNodeName = options.nodeName;
     // supportsActions advertises capability, not authorization — true even
     // when allowActions=false so the UI doesn't claim "actions unsupported"
     // when the operator just hasn't enabled them. The performAction() guard
     // returns the actionable error message in that case.
     this.supportsActions = true;
+
+    // Wire the transport before anything else can call pveApi/pveAction.
+    // configurePveTransport with empty config selects local-shell.
+    configurePveTransport(this.apiConfig ?? {});
   }
 
   async init(): Promise<void> {
-    // Confirm pvesh is reachable. A clear error here beats an obscure ENOENT
-    // on every collection cycle.
+    // Confirm the chosen transport works. A clear error here beats an obscure
+    // ENOENT (local-shell missing pvesh) or 401 (REST bad token) on every
+    // collection cycle.
     try {
-      const status = await pvesh<PveClusterStatusRow[]>('/cluster/status');
-      const local = status.find(r => r.type === 'node' && r.local === 1);
-      if (local?.name) this.nodeName = local.name;
-      logger.info('proxmox', `Connected via pvesh — local node: ${this.nodeName}`);
+      const status = await pveApi<PveClusterStatusRow[]>('/cluster/status');
+      if (isRestMode()) {
+        // No `local` notion when we're remote — the operator told us which
+        // node we cover. Validate it actually exists in the cluster so a
+        // typo surfaces here, not as silently-empty listContainers later.
+        if (!this.configuredNodeName) {
+          throw new Error('REST mode requires INSIGHTD_PVE_NODE to declare which node this agent covers');
+        }
+        const match = status.find(r => r.type === 'node' && r.name === this.configuredNodeName);
+        if (!match) {
+          const known = status.filter(r => r.type === 'node').map(r => r.name).join(', ');
+          throw new Error(`INSIGHTD_PVE_NODE="${this.configuredNodeName}" not found in cluster. Known nodes: ${known || '(none)'}`);
+        }
+        this.nodeName = this.configuredNodeName;
+        logger.info('proxmox', `Connected via REST API — node: ${this.nodeName}`);
+      } else {
+        const local = status.find(r => r.type === 'node' && r.local === 1);
+        if (local?.name) this.nodeName = local.name;
+        logger.info('proxmox', `Connected via pvesh — local node: ${this.nodeName}`);
+      }
     } catch (err) {
       throw new Error(`ProxmoxRuntime init failed: ${(err as Error).message}`);
     }
   }
 
   async listContainers(): Promise<ContainerInfo[]> {
-    const resources = await pvesh<PveResource[]>('/cluster/resources');
+    const resources = await pveApi<PveResource[]>('/cluster/resources');
     this.resourceCache.clear();
 
     const guests: ContainerInfo[] = [];
@@ -181,6 +213,17 @@ export class ProxmoxRuntime implements ContainerRuntime {
     if (!parsed) throw new Error(`Unrecognised PVE guest id: "${containerId}"`);
     const lines = Math.max(1, Math.min(10_000, options.lines ?? 100));
 
+    if (isRestMode()) {
+      // PVE's `/exec` REST endpoint is async/streaming and only useful with
+      // VM.Console on the token — too much surface for a feature that's
+      // already best-effort on LXC and unavailable on QEMU. The UI catches
+      // this exact error and renders the in-guest-agent empty state.
+      throw new Error(
+        'Logs are not available when insightd reads PVE via REST API. ' +
+        'Install insightd-agent inside the guest to surface its logs here.'
+      );
+    }
+
     if (parsed.type === 'qemu') {
       throw new Error(
         'Logs are not available for QEMU guests from the hypervisor. ' +
@@ -259,22 +302,48 @@ export class ProxmoxRuntime implements ContainerRuntime {
     }
 
     // Look up the type fresh — caches go stale, action requests don't.
-    const resources = await pvesh<PveResource[]>('/cluster/resources');
+    const resources = await pveApi<PveResource[]>('/cluster/resources');
     const guest = resources.find(r => r.vmid === vmid && r.node === targetNode && (r.type === 'lxc' || r.type === 'qemu'));
     if (!guest) {
       throw new Error(`PVE guest vmid=${vmid} not found on node "${targetNode}"`);
     }
 
-    const tool = guest.type === 'qemu' ? 'qm' : 'pct';
     const verb = pveActionVerb(action);
-    logger.info('actions', `Performing ${action} on ${guest.type}/${vmid} via ${tool} ${verb}`);
+    const past = action === 'stop' ? 'shutdown initiated'
+      : action === 'restart' ? 'reboot initiated'
+      : action === 'remove' ? 'destroyed'
+      : 'started';
 
+    if (isRestMode()) {
+      // REST mode: fire-and-forget; surface the UPID in the success message
+      // so operators can poll PVE's task log for completion if they want to.
+      // remove → DELETE /nodes/{node}/{type}/{vmid}; everything else POST
+      // /nodes/{node}/{type}/{vmid}/status/{verb}.
+      const basePath = `/nodes/${encodeURIComponent(guest.node)}/${guest.type}/${vmid}`;
+      logger.info('actions', `Performing ${action} on ${guest.type}/${vmid} via REST ${verb}`);
+      try {
+        const upid = action === 'remove'
+          ? await pveAction('DELETE', basePath)
+          : await pveAction('POST', `${basePath}/status/${verb}`);
+        const upidPart = typeof upid === 'string' && upid.length > 0
+          ? ` — UPID:${upid}`
+          : '';
+        return {
+          status: 'success',
+          message: `Proxmox guest "${containerName}" ${past}${upidPart}`,
+        };
+      } catch (err) {
+        // REST errors already include the PVE error envelope detail (see
+        // pveApi.ts:describeError) — pass through unchanged.
+        throw new Error(`PVE ${verb} on ${guest.type}/${vmid} failed: ${(err as Error).message}`);
+      }
+    }
+
+    // Local-shell mode — same shape as before PR5.
+    const tool = guest.type === 'qemu' ? 'qm' : 'pct';
+    logger.info('actions', `Performing ${action} on ${guest.type}/${vmid} via ${tool} ${verb}`);
     try {
       const out = await execStdout(tool, [verb, String(vmid)], ACTION_TIMEOUT_MS);
-      const past = action === 'stop' ? 'shutdown initiated'
-        : action === 'restart' ? 'reboot initiated'
-        : action === 'remove' ? 'destroyed'
-        : 'started';
       const trailer = out.trim() ? ` — ${out.trim()}` : '';
       return {
         status: 'success',

--- a/agent/src/runtime/pveApi.ts
+++ b/agent/src/runtime/pveApi.ts
@@ -1,0 +1,271 @@
+/**
+ * PVE API helper with a transport-pluggable backend. Both ProxmoxRuntime and
+ * the cluster-scoped collectors at `agent/src/collectors/proxmox-cluster.ts`
+ * call `pveApi(path)` to read PVE state. The same call site works in two
+ * deployment modes:
+ *
+ *   - **local-shell** — the agent runs on the PVE hypervisor itself and
+ *     shells out to `/usr/bin/pvesh`. This was the only mode pre-PR5;
+ *     `pvesh.ts` is now a one-line shim re-exporting from this module.
+ *   - **rest-api** — the agent runs anywhere with reachability to PVE's
+ *     web port (default 8006) and authenticates with an API token. No
+ *     install on the hypervisor.
+ *
+ * Mode is selected by env vars at agent startup (see `agent/src/config.ts`):
+ * if `INSIGHTD_PVE_API_URL` is set, REST mode wins; otherwise local-shell.
+ *
+ * Why a transport interface (not just a flag in one function): the local
+ * path is mocked at the `child_process.execFile` boundary in existing tests,
+ * the REST path is mocked at the `https.request` boundary in new tests.
+ * Keeping them as discrete implementations means each test file mocks one
+ * surface only, with no spillover.
+ *
+ * Lazy require()s inside the call sites keep the test mocks honest — same
+ * lesson as PR1's pvesh.ts: destructured top-level bindings don't see
+ * `mock.method` updates after a require-cache bust.
+ */
+
+import logger = require('../../../shared/utils/logger');
+
+export interface PveApiConfig {
+  /** When set, switch to REST transport. Format: `https://host:port`. */
+  url?: string;
+  /** PVE token identifier in the form `user@realm!tokenid`. */
+  tokenId?: string;
+  /** PVE token secret (UUID-ish opaque string). */
+  tokenSecret?: string;
+  /** Default false — most PVE installs use the auto-generated self-signed
+   *  cert. Set true once you've configured Let's Encrypt or pinned a CA. */
+  verifyTls?: boolean;
+  /** Path to a PEM CA bundle. Only consulted when verifyTls=true. */
+  caBundle?: string;
+}
+
+export type PveActionMethod = 'POST' | 'DELETE';
+
+export interface Transport {
+  /** Diagnostic label for `init()` log lines. */
+  readonly mode: 'local-shell' | 'rest-api';
+  /** GET <path> and return the parsed (and, in REST mode, unwrapped) body. */
+  get<T>(path: string): Promise<T>;
+  /**
+   * POST or DELETE <path> with an optional form-encoded body. Used for
+   * actions (start / shutdown / reboot / destroy). The local-shell
+   * transport throws — actions go through `pct`/`qm` directly from
+   * ProxmoxRuntime in that mode, not through pvesh.
+   */
+  action(method: PveActionMethod, path: string, body?: Record<string, string>): Promise<unknown>;
+}
+
+let transport: Transport | null = null;
+let configured: PveApiConfig = {};
+let testOverride: Transport | null = null;
+
+/**
+ * Apply runtime config. Called by ProxmoxRuntime's constructor with the
+ * env-derived values. Resets the cached transport so the next pveApi call
+ * rebuilds with the new config — but does NOT clear a test override
+ * installed via __setTestTransport, so tests can construct runtimes
+ * without losing their fake transport.
+ */
+export function configurePveTransport(cfg: PveApiConfig): void {
+  configured = cfg;
+  transport = null;
+}
+
+/**
+ * Test-only: inject a fake transport. Stays set across configurePveTransport
+ * calls (so a test can construct ProxmoxRuntime AFTER calling this without
+ * the constructor wiping the fake). Pass null to clear.
+ */
+export function __setTestTransport(t: Transport | null): void {
+  testOverride = t;
+}
+
+function getTransport(): Transport {
+  if (testOverride) return testOverride;
+  if (transport) return transport;
+  transport = configured.url
+    ? createRestTransport(configured)
+    : createLocalShellTransport();
+  return transport;
+}
+
+/** Drop-in replacement for the old `pvesh()` helper. */
+export async function pveApi<T>(path: string): Promise<T> {
+  return getTransport().get<T>(path);
+}
+
+/**
+ * Write-side API. ProxmoxRuntime.performAction routes through this in REST
+ * mode; in local-shell mode it bypasses (calls pct/qm directly) because
+ * pvesh's CLI doesn't model the "POST /status/start" idiom cleanly.
+ */
+export async function pveAction(method: PveActionMethod, path: string, body?: Record<string, string>): Promise<unknown> {
+  return getTransport().action(method, path, body);
+}
+
+/** True if the active transport is REST mode (helps ProxmoxRuntime pick its branches). */
+export function isRestMode(): boolean {
+  return getTransport().mode === 'rest-api';
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Local-shell transport
+// ─────────────────────────────────────────────────────────────────────────
+
+const PVESH_PATH = '/usr/bin/pvesh';
+const PVESH_TIMEOUT_MS = 10_000;
+const PVESH_MAX_BUFFER = 8 * 1024 * 1024;
+
+function createLocalShellTransport(): Transport {
+  return {
+    mode: 'local-shell',
+    async get<T>(path: string): Promise<T> {
+      const { execFile } = require('child_process') as typeof import('child_process');
+      const stdout: string = await new Promise((resolve, reject) => {
+        execFile(
+          PVESH_PATH,
+          ['get', path, '--output-format', 'json'],
+          { timeout: PVESH_TIMEOUT_MS, maxBuffer: PVESH_MAX_BUFFER },
+          (err, out) => err ? reject(err) : resolve(out),
+        );
+      });
+      return JSON.parse(stdout) as T;
+    },
+    async action(_method, _path, _body) {
+      // Local-shell mode runs actions via pct/qm in ProxmoxRuntime directly.
+      // Calling action() here is a programmer error — would silently succeed
+      // with no observable effect on PVE. Throw so the caller learns now.
+      throw new Error(
+        'local-shell transport does not implement action(); ProxmoxRuntime.performAction must shell pct/qm directly in local mode'
+      );
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// REST transport — pure Node `https`, no new deps.
+// ─────────────────────────────────────────────────────────────────────────
+
+const ACTION_TIMEOUT_MS = 30_000;
+
+interface RestRequestResult {
+  status: number;
+  body: string;
+}
+
+function createRestTransport(cfg: PveApiConfig): Transport {
+  // configurePveTransport callers should have validated these, but defend
+  // anyway so a misconfigured env doesn't surface as a confusing TypeError.
+  if (!cfg.url) throw new Error('REST transport requires INSIGHTD_PVE_API_URL');
+  if (!cfg.tokenId || !cfg.tokenSecret) {
+    throw new Error('REST transport requires INSIGHTD_PVE_TOKEN_ID and INSIGHTD_PVE_TOKEN_SECRET');
+  }
+
+  const parsed = new URL(cfg.url);
+  const port = parsed.port ? Number(parsed.port) : 8006;
+  const verifyTls = cfg.verifyTls === true;
+  const authHeader = `PVEAPIToken=${cfg.tokenId}=${cfg.tokenSecret}`;
+
+  // One https.Agent per transport instance, keepAlive on. PVE's TLS handshake
+  // adds 50–100ms per cold call; the per-cycle pattern (one node-status +
+  // one cluster-resources + per-guest snapshot calls) benefits a lot.
+  // Built lazily so test instances that immediately swap transports don't
+  // hold open sockets.
+  let httpsAgent: any | null = null;
+  function getAgent(): any {
+    if (httpsAgent) return httpsAgent;
+    const https = require('https') as typeof import('https');
+    const fs = require('fs') as typeof import('fs');
+    const opts: any = { keepAlive: true, rejectUnauthorized: verifyTls };
+    if (verifyTls && cfg.caBundle) {
+      try { opts.ca = fs.readFileSync(cfg.caBundle); }
+      catch (err) {
+        logger.warn('proxmox', `Failed to read CA bundle ${cfg.caBundle}: ${(err as Error).message}`);
+      }
+    }
+    httpsAgent = new https.Agent(opts);
+    return httpsAgent;
+  }
+
+  function request(method: string, path: string, body: string | undefined, timeoutMs: number): Promise<RestRequestResult> {
+    return new Promise((resolve, reject) => {
+      const https = require('https') as typeof import('https');
+      const headers: Record<string, string | number> = {
+        'Authorization': authHeader,
+        'Accept': 'application/json',
+      };
+      if (body !== undefined) {
+        headers['Content-Type'] = 'application/x-www-form-urlencoded';
+        headers['Content-Length'] = Buffer.byteLength(body);
+      }
+      const req = https.request({
+        host: parsed.hostname,
+        port,
+        path: '/api2/json' + path,
+        method,
+        agent: getAgent(),
+        headers,
+      } as any, (res: any) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => resolve({
+          status: res.statusCode || 0,
+          body: Buffer.concat(chunks).toString('utf8'),
+        }));
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.setTimeout(timeoutMs, () => req.destroy(new Error(`PVE API ${method} ${path} timed out after ${timeoutMs}ms`)));
+      if (body !== undefined) req.write(body);
+      req.end();
+    });
+  }
+
+  /** Strip PVE's `{ "data": ... }` envelope. Endpoints that error out may
+   *  return non-JSON bodies; we tolerate those by returning the raw body. */
+  function unwrap(raw: string): unknown {
+    let parsed: any;
+    try { parsed = JSON.parse(raw); }
+    catch { return raw; }
+    return parsed && typeof parsed === 'object' && 'data' in parsed ? parsed.data : parsed;
+  }
+
+  /** Pull a useful detail string out of a PVE error response. */
+  function describeError(method: string, path: string, status: number, body: string): Error {
+    let detail = body;
+    try {
+      const parsed = JSON.parse(body);
+      // PVE error envelope variants:
+      //   { "data": null, "errors": { "field": "message", ... } }
+      //   { "message": "...short..." }
+      if (parsed && typeof parsed === 'object') {
+        if (parsed.errors && typeof parsed.errors === 'object' && Object.keys(parsed.errors).length > 0) {
+          detail = Object.entries(parsed.errors)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join('; ');
+        } else if (typeof parsed.message === 'string') {
+          detail = parsed.message;
+        }
+      }
+    } catch { /* non-JSON body, use raw */ }
+    // Trim aggressively — long HTML 500 pages would otherwise dominate logs.
+    return new Error(`PVE API ${method} ${path} returned ${status}: ${detail.slice(0, 500)}`);
+  }
+
+  return {
+    mode: 'rest-api',
+    async get<T>(path: string): Promise<T> {
+      const { status, body } = await request('GET', path, undefined, PVESH_TIMEOUT_MS);
+      if (status < 200 || status >= 300) throw describeError('GET', path, status, body);
+      return unwrap(body) as T;
+    },
+    async action(method, path, body) {
+      const encoded = body ? new URLSearchParams(body).toString() : undefined;
+      const { status, body: respBody } = await request(method, path, encoded, ACTION_TIMEOUT_MS);
+      if (status < 200 || status >= 300) throw describeError(method, path, status, respBody);
+      return unwrap(respBody);
+    },
+  };
+}

--- a/agent/src/runtime/pvesh.ts
+++ b/agent/src/runtime/pvesh.ts
@@ -1,36 +1,8 @@
 /**
- * Shared pvesh helper. Both ProxmoxRuntime (guests) and the cluster-scoped
- * collectors in `agent/src/collectors/proxmox-cluster.ts` (storage, ZFS,
- * cluster status) shell out to pvesh — keeping the spawn plumbing in one
- * place avoids drift in timeout/maxBuffer/path handling.
- *
- * Reads `child_process.execFile` lazily inside the call (rather than
- * destructuring at module load) so tests can replace the export via
- * `mock.method` without race conditions around when the require-cache was
- * busted. PR1 lessons learned.
+ * Backwards-compatible shim. The implementation moved to `pveApi.ts` in PR
+ * "proxmox: PVE REST API transport mode" (2026-05-05) so the same call
+ * site can target either local pvesh OR the REST API depending on agent
+ * config. Imports of `pvesh` keep working through this shim for one
+ * release; new code should import `pveApi` directly.
  */
-
-const PVESH_PATH = '/usr/bin/pvesh';
-const PVESH_TIMEOUT_MS = 10_000;
-const PVESH_MAX_BUFFER = 8 * 1024 * 1024;
-
-/**
- * Run `pvesh get <path> --output-format json` and parse the result.
- * Throws if pvesh exits non-zero, the JSON is malformed, or the call times out.
- */
-export async function pvesh<T>(path: string): Promise<T> {
-  const { execFile } = require('child_process') as typeof import('child_process');
-  const stdout: string = await new Promise((resolve, reject) => {
-    execFile(
-      PVESH_PATH,
-      ['get', path, '--output-format', 'json'],
-      { timeout: PVESH_TIMEOUT_MS, maxBuffer: PVESH_MAX_BUFFER },
-      (err, out) => {
-        // execFile with default options returns stdout as a string.
-        if (err) reject(err);
-        else resolve(out);
-      },
-    );
-  });
-  return JSON.parse(stdout) as T;
-}
+export { pveApi as pvesh } from './pveApi';

--- a/docs/proxmox-setup.md
+++ b/docs/proxmox-setup.md
@@ -1,97 +1,180 @@
 # Proxmox VE setup
 
-Run insightd-agent natively on a Proxmox VE hypervisor to surface its LXC
+Run insightd-agent against a Proxmox VE hypervisor to surface its LXC
 containers and QEMU VMs as first-class entries in the hosts/containers UI,
 alongside ZFS pool health, storage saturation, cluster quorum, and per-guest
-backup/snapshot state. Same agent binary as Docker; no separate package.
+backup/snapshot state.
 
-## Quick start
+The agent has two transports for talking to PVE:
 
-1. **Install Node.js 20 on the PVE host** (Proxmox is Debian-based):
+- **REST API mode (recommended)** — agent runs from a guest VM (or anywhere
+  with reachability to PVE's web port), authenticates with an API token. No
+  install on the hypervisor.
+- **Bare-metal install (alternative)** — agent runs on the PVE host itself
+  and shells out to local `pvesh` / `pct` / `qm`. Full LXC log support but
+  requires Node 20 + the agent source on the hypervisor.
 
-   ```bash
-   curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-   apt install -y nodejs
-   ```
+REST mode is the path most homelabbers want. The bare-metal install is
+documented in the appendix at the bottom for users who explicitly want
+on-host operation (full LXC log support).
 
-2. **Drop the agent source onto the PVE host** (clone, scp, whatever fits):
+## Quick start (REST API mode)
 
-   ```bash
-   git clone https://github.com/goldenproductions/insightd.git /opt/insightd
-   cd /opt/insightd && npm ci --omit=dev
-   ```
+### 1. Create a PVE API token
 
-3. **Create a systemd unit at `/etc/systemd/system/insightd-agent.service`:**
+In the PVE UI: Datacenter → Permissions → API Tokens → Add. Pick a user (or
+create one — `insightd@pve` is a fine convention), set Token ID `agent01`,
+leave **Privilege Separation enabled**, save. Copy the secret immediately —
+PVE only shows it once.
 
-   ```ini
-   [Unit]
-   Description=insightd agent (Proxmox VE)
-   After=network-online.target pve-cluster.service
-   Wants=network-online.target
+Or via CLI on the PVE host:
 
-   [Service]
-   Type=simple
-   User=root
-   WorkingDirectory=/opt/insightd
-   Environment=INSIGHTD_RUNTIME=proxmox
-   Environment=INSIGHTD_HOST_ID=proxmox-01
-   Environment=INSIGHTD_HOST_GROUP=home-cluster
-   Environment=INSIGHTD_MQTT_URL=mqtt://your-broker:1883
-   Environment=INSIGHTD_ALLOW_ACTIONS=true
-   ExecStart=/usr/bin/npx tsx agent/src/index.ts
-   Restart=on-failure
-   RestartSec=10
+```bash
+pveum user add insightd@pve
+pveum user token add insightd@pve agent01 --privsep 1
+# secret is printed once — copy it
+```
 
-   [Install]
-   WantedBy=multi-user.target
-   ```
+### 2. Grant the token permissions
 
-4. **Enable + start:**
+The token needs read access to everything insightd reports on, plus power-
+management for actions:
 
-   ```bash
-   systemctl daemon-reload
-   systemctl enable --now insightd-agent
-   journalctl -u insightd-agent -f
-   ```
+```bash
+pveum acl modify / --tokens 'insightd@pve!agent01' --roles 'PVEAuditor,PVEVMAdmin'
+```
 
-   Within one collection cycle (5 min by default) the PVE node appears on the
-   Hosts page with a purple `proxmox` badge and its LXC/QEMU guests show up as
-   containers.
+`PVEAuditor` covers all the read paths (cluster status, node disks/storage,
+VM listings, task log). `PVEVMAdmin` adds `VM.PowerMgmt` (start / stop /
+reboot) and `VM.Allocate` (destroy). Drop `PVEVMAdmin` if you only want
+read-only monitoring.
 
-## Why root?
+### 3. Run the agent on any guest VM
 
-`pvesh`, `pct`, and `qm` need root or a custom polkit rule. The agent already
-runs as root in Docker mode (it talks to `/var/run/docker.sock`); single-user
-homelab posture matches. Containerized deployment isn't supported on PVE —
-PVE explicitly discourages running workloads on the hypervisor and Docker
-fights with PVE's own LXC tooling.
+The agent is a Node 20 app — anywhere you can run Node and reach PVE's
+:8006 from will work. systemd unit example:
 
-## Environment variables
+```ini
+# /etc/systemd/system/insightd-agent.service
+[Unit]
+Description=insightd agent (Proxmox REST API mode)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=insightd
+WorkingDirectory=/opt/insightd
+Environment=INSIGHTD_RUNTIME=proxmox
+Environment=INSIGHTD_HOST_ID=proxmox-01
+Environment=INSIGHTD_HOST_GROUP=home-cluster
+Environment=INSIGHTD_MQTT_URL=mqtt://your-broker:1883
+Environment=INSIGHTD_PVE_API_URL=https://proxmox-01.lan:8006
+Environment=INSIGHTD_PVE_TOKEN_ID=insightd@pve!agent01
+Environment=INSIGHTD_PVE_TOKEN_SECRET=PASTE-THE-SECRET-FROM-STEP-1
+Environment=INSIGHTD_PVE_NODE=proxmox-01
+Environment=INSIGHTD_ALLOW_ACTIONS=true
+ExecStart=/usr/bin/npx tsx agent/src/index.ts
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Note we do *not* run as root — REST mode doesn't need it. Pick any user that
+can read the agent source.
+
+```bash
+systemctl daemon-reload
+systemctl enable --now insightd-agent
+journalctl -u insightd-agent -f
+```
+
+Within ~5 min the PVE node appears on the Hosts page with the purple `proxmox`
+badge and its LXC/QEMU guests show up as containers.
+
+## REST mode environment variables
 
 | Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `INSIGHTD_RUNTIME` | yes | `auto` | Set to `proxmox`. `auto` also detects PVE via `/etc/pve/.version` if it exists. |
-| `INSIGHTD_HOST_ID` | yes | — | Stable identifier (e.g. `proxmox-01`). Used as the host_id throughout the UI. |
-| `INSIGHTD_HOST_GROUP` | recommended | — | Cluster name. The hub uses this to associate the host with cluster-scoped data; pick the same value on every node of a cluster. |
+| `INSIGHTD_RUNTIME` | yes | `auto` | Set explicitly to `proxmox`. Auto-detect only triggers on the bare-metal install path; REST-mode users from a guest must set it. |
+| `INSIGHTD_HOST_ID` | yes | — | Stable identifier for the PVE node. Used as the host_id throughout the UI. |
+| `INSIGHTD_HOST_GROUP` | recommended | — | Cluster name. Pick the same value on every node-agent of one cluster. |
 | `INSIGHTD_MQTT_URL` | yes | — | mqtt:// URL of your broker. |
-| `INSIGHTD_MQTT_USER` / `_PASS` | optional | — | Broker credentials. |
-| `INSIGHTD_ALLOW_ACTIONS` | optional | `false` | Enable `pct`/`qm` start/stop/restart/destroy from the UI. Without this, action buttons return an error from the agent. |
+| `INSIGHTD_PVE_API_URL` | yes | — | `https://hostname:8006`. The presence of this var is what selects REST mode. |
+| `INSIGHTD_PVE_TOKEN_ID` | yes | — | Format `user@realm!tokenid`, e.g. `insightd@pve!agent01`. |
+| `INSIGHTD_PVE_TOKEN_SECRET` | yes | — | The secret PVE shows once on token creation. |
+| `INSIGHTD_PVE_NODE` | yes | — | The PVE node this agent monitors. Required because there's no "local" node when reading remotely. |
+| `INSIGHTD_PVE_VERIFY_TLS` | optional | `false` | Default off because most PVE installs use the auto-generated self-signed cert. Set `true` once you've configured Let's Encrypt or pinned a CA. |
+| `INSIGHTD_PVE_CA_BUNDLE` | optional | — | Path to a PEM CA bundle. Only consulted when `INSIGHTD_PVE_VERIFY_TLS=true`. |
+| `INSIGHTD_ALLOW_ACTIONS` | optional | `false` | Enable start / stop / restart / destroy from the UI. Without this, action buttons return a clear error from the agent. |
 | `INSIGHTD_COLLECT_INTERVAL` | optional | `5` | Minutes between collection cycles. |
 
-### `INSIGHTD_RUNTIME=docker` override
+### Multi-node clusters
 
-If your PVE host *also* runs Docker for utility containers, the runtime
-auto-detector picks `proxmox` (single-runtime model). Set `INSIGHTD_RUNTIME=docker`
-to flip the priority — you'll lose PVE coverage but keep the Docker view.
+The agent monitors **one PVE node per process** (mirrors the bare-metal
+model). For a 3-node cluster, run 3 agent processes from one VM, each with
+its own `INSIGHTD_HOST_ID` and `INSIGHTD_PVE_NODE`. They can share the same
+API token (or get one each for audit clarity).
 
-## Identity bridge (PR4): linking the in-guest agent to the hypervisor view
+```ini
+Environment=INSIGHTD_HOST_ID=proxmox-01
+Environment=INSIGHTD_PVE_NODE=proxmox-01
+
+# … and a separate systemd unit for proxmox-02:
+Environment=INSIGHTD_HOST_ID=proxmox-02
+Environment=INSIGHTD_PVE_NODE=proxmox-02
+```
+
+## What the agent reports
+
+| Source endpoint | Surface |
+| --- | --- |
+| `/cluster/resources` (per cycle) | Per-guest CPU, mem, network, disk I/O, status |
+| `/nodes/{node}/storage` | Per-storage usage → `pve_storage_saturation` alert |
+| `/nodes/{node}/disks/zfs` | Per-pool health → `pve_zfs_unhealthy` alert |
+| `/cluster/status` | Quorate flag → `pve_cluster_quorum_lost` alert |
+| `/nodes/{node}/{type}/{vmid}/snapshot` | Per-guest snapshot count → "many snapshots" insight |
+| `/cluster/tasks` + `/cluster/backup-info/not-backed-up` | Per-guest backup history → `pve_backup_overdue` alert |
+
+## Actions (`INSIGHTD_ALLOW_ACTIONS=true`)
+
+| Action | LXC | QEMU |
+| --- | --- | --- |
+| Start | `POST /…/lxc/<vmid>/status/start` | `POST /…/qemu/<vmid>/status/start` |
+| Stop | `POST /…/lxc/<vmid>/status/shutdown` (graceful, ACPI) | `POST /…/qemu/<vmid>/status/shutdown` (graceful, ACPI) |
+| Restart | `POST /…/lxc/<vmid>/status/reboot` | `POST /…/qemu/<vmid>/status/reboot` (needs guest agent or ACPI-aware OS) |
+| Remove | `DELETE /…/lxc/<vmid>` (PVE refuses if running) | `DELETE /…/qemu/<vmid>` (PVE refuses if running) |
+
+REST actions are fire-and-forget: the agent returns success once PVE accepts
+the request (with the task UPID surfaced in the message), then the next
+collection cycle reflects the new state. If the guest ignores ACPI for
+shutdown / reboot, no error fires — same as `pct shutdown` doesn't fail when
+the guest doesn't comply.
+
+## Logs (REST mode caveat)
+
+REST mode does **not** support log fetch. The container detail Logs tab
+renders an empty state pointing at the in-guest agent for both LXC and QEMU.
+
+Why: PVE's `/exec` REST endpoint is async-streaming and only useful with
+`VM.Console` permission, which broadens the token's blast radius
+considerably. The "install insightd-agent inside the guest" path was the
+better answer for QEMU even on bare-metal install, and it remains the
+recommendation here.
+
+If you need the host-side `journalctl --machine=<vmid>` LXC log path (works
+for unprivileged systemd LXCs), use the bare-metal install in the appendix.
+
+## Identity bridge: linking the in-guest agent to the hypervisor view
 
 If you also run insightd-agent *inside* a VM, you can link the two views so
 the UI offers cross-navigation between them. The hypervisor sees the VM as
 "VMID 103 on proxmox-01"; the in-guest agent reports under its own host_id
 (e.g. `web-1`). Without a hint, the hub can't tell those are the same VM.
 
-Set two env vars on the **in-guest agent** (NOT on the PVE host):
+Set two env vars on the **in-guest agent** (NOT on the agent talking to PVE):
 
 ```bash
 INSIGHTD_PROXMOX_NODE=proxmox-01    # The PVE node name
@@ -111,49 +194,92 @@ The two records stay independent — that's deliberate. "The VM is up per PVE
 but its in-guest agent stopped reporting 20 minutes ago" is exactly the kind
 of signal you want visible.
 
-## What the agent reports
-
-| Source | Surface |
-| --- | --- |
-| `/cluster/resources` (per cycle) | Per-guest CPU, mem, network, disk I/O, status |
-| `/nodes/{node}/storage` | Per-storage usage → `pve_storage_saturation` alert |
-| `/nodes/{node}/disks/zfs` | Per-pool health → `pve_zfs_unhealthy` alert |
-| `/cluster/status` | Quorate flag → `pve_cluster_quorum_lost` alert |
-| `/nodes/{node}/{type}/{vmid}/snapshot` | Per-guest snapshot count → "many snapshots" insight |
-| `/cluster/tasks` + `/cluster/backup-info/not-backed-up` | Per-guest backup history → `pve_backup_overdue` alert |
-| `/proc/*` and `/sys/*` (Linux native) | Hypervisor-level CPU/mem/load/temps/disk-IO/network-IO |
-
-## Logs
-
-| Guest type | Log fetch path |
-| --- | --- |
-| LXC | `journalctl --machine=<vmid>` (preferred), falls back to `pct exec <vmid> -- journalctl` |
-| QEMU | **Not available from the hypervisor.** The container detail page renders an empty-state pointing at the in-guest agent. |
-
-## Actions (`INSIGHTD_ALLOW_ACTIONS=true`)
-
-| Action | LXC | QEMU |
-| --- | --- | --- |
-| Start | `pct start <vmid>` | `qm start <vmid>` |
-| Stop  | `pct shutdown <vmid>` (graceful, ACPI) | `qm shutdown <vmid>` (graceful, ACPI) |
-| Restart | `pct reboot <vmid>` | `qm reboot <vmid>` (requires guest agent or ACPI-aware OS) |
-| Remove | `pct destroy <vmid>` (refuses if running) | `qm destroy <vmid>` (refuses if running) |
-
-Stop/restart on QEMU need either the guest's qemu-guest-agent or a kernel
-that responds to ACPI. Without either, `shutdown`/`reboot` will time out
-silently from the agent's perspective — PVE returns success but the VM
-keeps running. There's no way around this from the hypervisor side.
+The bridge env vars are **separate** from `INSIGHTD_PVE_*` vars: the bridge
+goes on the in-guest agent pointing back at PVE; the API vars go on the
+agent talking *to* PVE (typically a different process on a different host).
 
 ## Troubleshooting
 
-- **"ProxmoxRuntime init failed: spawn /usr/bin/pvesh ENOENT"** — pvesh isn't
-  on `$PATH`. On a stock PVE install it's at `/usr/bin/pvesh`; check that
-  the systemd unit's `Environment=PATH=...` (or unset) includes `/usr/bin`.
-- **"PVE guest vmid=X not found on node Y"** when triggering an action — the
-  guest was migrated to another node between the action request and its
-  execution. Refresh the UI; the guest should now appear under the new node's
-  hosts page.
+- **"REST mode requires INSIGHTD_PVE_NODE…"** — set it. The agent won't
+  guess which node to monitor from a remote viewpoint.
+- **"INSIGHTD_PVE_NODE='typo' not found in cluster. Known nodes: …"** —
+  fix the node name to match what `pvesh get /nodes` lists.
+- **"PVE API GET … returned 401"** — token id or secret is wrong, or the
+  token doesn't exist anymore. Recreate via `pveum user token list insightd@pve`.
+- **"PVE API … returned 403"** — the token's role doesn't include the needed
+  permission. For actions, you need `PVEVMAdmin` (or at least `VM.PowerMgmt`).
+- **"PVE API … returned 595" (TLS error)** — your PVE cert isn't trusted
+  by the agent's Node runtime. Either set `INSIGHTD_PVE_VERIFY_TLS=false`
+  (default) or point `INSIGHTD_PVE_CA_BUNDLE` at the right CA PEM.
 - **Cluster quorum alert keeps firing on a single-node install** — shouldn't
-  happen; standalone PVE doesn't publish a cluster-status row at all. If it
-  does, check `pvesh get /cluster/status --output-format json` and confirm
-  there's no `type:'cluster'` row.
+  happen; standalone PVE doesn't publish a cluster row. Check
+  `pvesh get /cluster/status --output-format json` and confirm there's no
+  `type:'cluster'` row.
+
+---
+
+## Appendix: bare-metal install on the PVE hypervisor
+
+This was the original install path before REST API mode existed. Choose this
+over REST mode only if you specifically want LXC log fetch via `journalctl
+--machine` / `pct exec`. Trade-off: Node 20 + the agent source live on the
+hypervisor.
+
+### 1. Install Node 20 on the PVE host (it's Debian-based)
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt install -y nodejs git
+```
+
+### 2. Drop the agent source onto the PVE host
+
+```bash
+git clone https://github.com/goldenproductions/insightd.git /opt/insightd
+cd /opt/insightd && npm ci --omit=dev
+```
+
+### 3. Systemd unit at `/etc/systemd/system/insightd-agent.service`
+
+```ini
+[Unit]
+Description=insightd agent (Proxmox VE, bare-metal)
+After=network-online.target pve-cluster.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/insightd
+Environment=INSIGHTD_RUNTIME=proxmox
+Environment=INSIGHTD_HOST_ID=proxmox-01
+Environment=INSIGHTD_HOST_GROUP=home-cluster
+Environment=INSIGHTD_MQTT_URL=mqtt://your-broker:1883
+Environment=INSIGHTD_ALLOW_ACTIONS=true
+ExecStart=/usr/bin/npx tsx agent/src/index.ts
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl daemon-reload
+systemctl enable --now insightd-agent
+journalctl -u insightd-agent -f
+```
+
+The bare-metal path runs as root because `pvesh`, `pct`, and `qm` need root
+or a polkit rule. The agent already runs as root in Docker mode (it talks
+to `/var/run/docker.sock`); single-user homelab posture matches.
+
+The runtime auto-detects PVE via `/etc/pve/.version`, so even
+`INSIGHTD_RUNTIME=auto` works — but explicit is clearer in a unit file.
+
+### `INSIGHTD_RUNTIME=docker` override on a Docker-on-PVE host
+
+If your PVE host *also* runs Docker for utility containers, the runtime
+auto-detector picks `proxmox` (single-runtime model). Set
+`INSIGHTD_RUNTIME=docker` to flip the priority — you'll lose PVE coverage
+but keep the Docker view.

--- a/tests/unit/collectors-proxmox-cluster-api.test.ts
+++ b/tests/unit/collectors-proxmox-cluster-api.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { __setTestTransport } = require('../../agent/src/runtime/pveApi');
+
+/**
+ * Cluster collector tests in REST mode. Same fixtures as
+ * collectors-proxmox-cluster.test.ts, but going through the Transport
+ * abstraction with a fake REST transport instead of mocking child_process.
+ *
+ * Validates that the unwrap layer (`{data: [...]}` → `[...]`) is applied
+ * by the transport, so the collectors' downstream parsing is identical
+ * regardless of mode.
+ */
+
+interface RecordedCall {
+  kind: 'get' | 'action';
+  path: string;
+}
+
+function fakeRestTransport(stub: (path: string) => unknown): { transport: any; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    transport: {
+      mode: 'rest-api',
+      async get(path: string) {
+        calls.push({ kind: 'get', path });
+        const out = stub(path);
+        if (out instanceof Error) throw out;
+        return out;
+      },
+      async action() {
+        throw new Error('REST collector tests should not invoke action()');
+      },
+    },
+  };
+}
+
+describe('proxmox-cluster collectors — REST mode', () => {
+  beforeEach(() => __setTestTransport(null));
+  afterEach(() => __setTestTransport(null));
+
+  it('collectStoragePools: REST transport returns unwrapped data identical to local mode', async () => {
+    const { transport, calls } = fakeRestTransport(path => {
+      if (path === '/nodes/pve-01/storage') {
+        return [
+          { storage: 'local', type: 'dir', total: 100_000_000_000, used: 30_000_000_000, active: 1, shared: 0 },
+          { storage: 'local-zfs', type: 'zfspool', total: 1_000_000_000_000, used: 200_000_000_000, active: 1, shared: 0 },
+        ];
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+    __setTestTransport(transport);
+
+    const { collectStoragePools } = require('../../agent/src/collectors/proxmox-cluster');
+    const pools = await collectStoragePools('pve-01');
+    assert.equal(pools.length, 2);
+    assert.equal(pools[0].storageName, 'local');
+    assert.equal(pools[0].active, true);
+    // The collector called the REST transport once with the right path.
+    assert.deepEqual(calls.map(c => c.path), ['/nodes/pve-01/storage']);
+  });
+
+  it('collectZfsPools: returns [] when REST transport throws (host without ZFS)', async () => {
+    const { transport } = fakeRestTransport(() => new Error('PVE API GET /nodes/pve-01/disks/zfs returned 500: zpool list failed'));
+    __setTestTransport(transport);
+    const { collectZfsPools } = require('../../agent/src/collectors/proxmox-cluster');
+    const pools = await collectZfsPools('pve-01');
+    // Same calm fallback as local mode — one bad endpoint shouldn't sink the whole cycle.
+    assert.deepEqual(pools, []);
+  });
+
+  it('collectClusterStatus: extracts quorate + node counts from REST response', async () => {
+    const { transport } = fakeRestTransport(path => {
+      if (path === '/cluster/status') {
+        return [
+          { type: 'cluster', name: 'home', quorate: 1, nodes: 3 },
+          { type: 'node', name: 'pve-01', online: 1 },
+          { type: 'node', name: 'pve-02', online: 1 },
+          { type: 'node', name: 'pve-03', online: 0 },
+        ];
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+    __setTestTransport(transport);
+    const { collectClusterStatus } = require('../../agent/src/collectors/proxmox-cluster');
+    const status = await collectClusterStatus();
+    assert.equal(status.clusterName, 'home');
+    assert.equal(status.quorate, true);
+    assert.equal(status.totalNodes, 3);
+    assert.equal(status.onlineNodes, 2);
+  });
+
+  it('collectGuestSnapshots: per-guest fan-out routes one REST call per vmid', async () => {
+    const calledPaths: string[] = [];
+    const { transport } = fakeRestTransport(path => {
+      calledPaths.push(path);
+      if (path.endsWith('/qemu/103/snapshot')) {
+        return [
+          { name: 'current', parent: 'pre-upgrade' },
+          { name: 'pre-upgrade', snaptime: 1_700_000_000 },
+        ];
+      }
+      if (path.endsWith('/lxc/200/snapshot')) {
+        return [{ name: 'current' }];
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+    __setTestTransport(transport);
+    const { collectGuestSnapshots } = require('../../agent/src/collectors/proxmox-cluster');
+    const out = await collectGuestSnapshots('pve-01', [
+      { vmid: 103, type: 'qemu' },
+      { vmid: 200, type: 'lxc' },
+    ]);
+    assert.equal(out.length, 2);
+    assert.deepEqual(calledPaths.sort(), [
+      '/nodes/pve-01/lxc/200/snapshot',
+      '/nodes/pve-01/qemu/103/snapshot',
+    ]);
+    const qemu = out.find((o: any) => o.guestVmid === 103);
+    assert.equal(qemu.snapshotCount, 1);
+  });
+
+  it('collectGuestBackups: REST transport gives the same shape as local — calls /cluster/tasks', async () => {
+    const { transport } = fakeRestTransport(path => {
+      if (path === '/cluster/tasks') {
+        return [
+          { type: 'vzdump', id: '103', endtime: 1_700_000_000, status: 'OK' },
+          { type: 'vzdump', id: '103', endtime: 1_690_000_000, status: 'OK' },
+          { type: 'qmstart', id: '200', endtime: 1_701_000_000, status: 'OK' },
+        ];
+      }
+      if (path === '/cluster/backup-info/not-backed-up') return [];
+      throw new Error(`unexpected path: ${path}`);
+    });
+    __setTestTransport(transport);
+    const { collectGuestBackups } = require('../../agent/src/collectors/proxmox-cluster');
+    const out = await collectGuestBackups([
+      { vmid: 103, type: 'qemu' },
+      { vmid: 200, type: 'lxc' },
+    ]);
+    // 200 wasn't in vzdump tasks AND wasn't in not-backed-up — skipped.
+    // 103 picked the newer of two OK rows.
+    assert.equal(out.length, 1);
+    assert.equal(out[0].guestVmid, 103);
+    assert.equal(out[0].lastStatus, 'OK');
+  });
+});

--- a/tests/unit/proxmox-actions-api.test.ts
+++ b/tests/unit/proxmox-actions-api.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { ProxmoxRuntime } = require('../../agent/src/runtime/proxmox');
+const { __setTestTransport } = require('../../agent/src/runtime/pveApi');
+
+interface RecordedCall {
+  kind: 'get' | 'action';
+  method?: string;
+  path: string;
+  body?: Record<string, string>;
+}
+
+function fakeRestTransport(stub: (call: RecordedCall) => unknown): { transport: any; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    transport: {
+      mode: 'rest-api',
+      async get(path: string) {
+        const c: RecordedCall = { kind: 'get', path };
+        calls.push(c);
+        return stub(c);
+      },
+      async action(method: string, path: string, body?: Record<string, string>) {
+        const c: RecordedCall = { kind: 'action', method, path, body };
+        calls.push(c);
+        return stub(c);
+      },
+    },
+  };
+}
+
+const CLUSTER_STATUS_REMOTE = [
+  { type: 'cluster', name: 'home', quorate: 1 },
+  { type: 'node', name: 'pve-01', online: 1 },
+];
+
+const CLUSTER_RESOURCES = [
+  { type: 'lxc', id: 'lxc/200', node: 'pve-01', vmid: 200, name: 'web', status: 'running' },
+  { type: 'qemu', id: 'qemu/103', node: 'pve-01', vmid: 103, name: 'db', status: 'running' },
+];
+
+function defaultStub(call: RecordedCall): unknown {
+  if (call.path === '/cluster/status') return CLUSTER_STATUS_REMOTE;
+  if (call.path === '/cluster/resources') return CLUSTER_RESOURCES;
+  // Action calls return the UPID string PVE would normally hand back.
+  if (call.kind === 'action') return 'UPID:pve-01:0001234A:00000000:00000000:vzdump';
+  throw new Error(`unexpected call: ${JSON.stringify(call)}`);
+}
+
+describe('ProxmoxRuntime.performAction — REST API mode', () => {
+  beforeEach(() => __setTestTransport(null));
+  afterEach(() => __setTestTransport(null));
+
+  it('refuses when allowActions=false (env-var gate fires before any HTTP)', async () => {
+    const { transport, calls } = fakeRestTransport(defaultStub);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: false, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    const beforeCalls = calls.length;
+    await assert.rejects(
+      () => r.performAction('pve-01/200', 'start'),
+      /actions are disabled/i,
+    );
+    // No HTTP calls beyond the init's /cluster/status.
+    assert.equal(calls.length, beforeCalls, 'gate must fire before the resource lookup HTTP call');
+  });
+
+  it('start → POST /nodes/{node}/lxc/{vmid}/status/start, with UPID in success message', async () => {
+    const { transport, calls } = fakeRestTransport(defaultStub);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    const result = await r.performAction('pve-01/200', 'start');
+    const action = calls.find(c => c.kind === 'action');
+    assert.ok(action);
+    assert.equal(action!.method, 'POST');
+    assert.equal(action!.path, '/nodes/pve-01/lxc/200/status/start');
+    assert.equal(result.status, 'success');
+    assert.match(result.message, /UPID:pve-01:0001234A/);
+  });
+
+  it('stop → POST /…/status/shutdown (graceful, NOT /stop)', async () => {
+    const { transport, calls } = fakeRestTransport(defaultStub);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    await r.performAction('pve-01/103', 'stop');
+    const action = calls.find(c => c.kind === 'action');
+    // Graceful shutdown is the right semantic — `/stop` is a hard kill we
+    // deliberately don't expose.
+    assert.equal(action!.path, '/nodes/pve-01/qemu/103/status/shutdown');
+  });
+
+  it('restart → POST /…/status/reboot', async () => {
+    const { transport, calls } = fakeRestTransport(defaultStub);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    await r.performAction('pve-01/103', 'restart');
+    const action = calls.find(c => c.kind === 'action');
+    assert.equal(action!.path, '/nodes/pve-01/qemu/103/status/reboot');
+  });
+
+  it('remove → DELETE /nodes/{node}/{type}/{vmid} (no /status/destroy)', async () => {
+    const { transport, calls } = fakeRestTransport(defaultStub);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    await r.performAction('pve-01/103', 'remove');
+    const action = calls.find(c => c.kind === 'action');
+    assert.equal(action!.method, 'DELETE');
+    // No `/status/...` suffix — destroy is a top-level DELETE on the guest.
+    assert.equal(action!.path, '/nodes/pve-01/qemu/103');
+  });
+
+  it('rejects actions targeting a guest on a different node', async () => {
+    const { transport } = fakeRestTransport(defaultStub);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    await assert.rejects(
+      () => r.performAction('pve-02/999', 'start'),
+      /not this agent's node/i,
+    );
+  });
+
+  it('surfaces PVE API errors verbatim (e.g. 403 on missing VM.PowerMgmt)', async () => {
+    const { transport } = fakeRestTransport(call => {
+      if (call.path === '/cluster/status') return CLUSTER_STATUS_REMOTE;
+      if (call.path === '/cluster/resources') return CLUSTER_RESOURCES;
+      if (call.kind === 'action') {
+        throw new Error('PVE API POST /nodes/pve-01/lxc/200/status/start returned 403: Permission denied (VM.PowerMgmt)');
+      }
+      return [];
+    });
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    await assert.rejects(
+      () => r.performAction('pve-01/200', 'start'),
+      /Permission denied \(VM\.PowerMgmt\)/,
+    );
+  });
+
+  it('returns success even when PVE returns no UPID (no trailing UPID part in message)', async () => {
+    const { transport } = fakeRestTransport(call => {
+      if (call.path === '/cluster/status') return CLUSTER_STATUS_REMOTE;
+      if (call.path === '/cluster/resources') return CLUSTER_RESOURCES;
+      // Some PVE error responses with status 200 return null in .data.
+      if (call.kind === 'action') return null;
+      return [];
+    });
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    const result = await r.performAction('pve-01/200', 'start');
+    assert.equal(result.status, 'success');
+    assert.doesNotMatch(result.message, /UPID:/);
+  });
+});

--- a/tests/unit/proxmox-runtime-api.test.ts
+++ b/tests/unit/proxmox-runtime-api.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { ProxmoxRuntime } = require('../../agent/src/runtime/proxmox');
+const { __setTestTransport } = require('../../agent/src/runtime/pveApi');
+
+/**
+ * REST-mode tests inject a fake Transport via the __setTestTransport hook
+ * exported from pveApi.ts. That avoids mocking https.request and keeps the
+ * tests focused on ProxmoxRuntime's behavior in REST mode (init validates
+ * INSIGHTD_PVE_NODE, fetchLogs throws the in-guest-agent message, etc).
+ *
+ * Lower-level HTTP wire format (auth header, URL building, .data unwrap)
+ * is exercised separately in proxmox-actions-api.test.ts via the same hook.
+ */
+
+interface RecordedCall {
+  kind: 'get' | 'action';
+  method?: string;
+  path: string;
+  body?: Record<string, string>;
+}
+
+function fakeRestTransport(stub: (call: RecordedCall) => unknown): { transport: any; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    transport: {
+      mode: 'rest-api',
+      async get(path: string) {
+        const c: RecordedCall = { kind: 'get', path };
+        calls.push(c);
+        return stub(c);
+      },
+      async action(method: string, path: string, body?: Record<string, string>) {
+        const c: RecordedCall = { kind: 'action', method, path, body };
+        calls.push(c);
+        return stub(c);
+      },
+    },
+  };
+}
+
+const CLUSTER_STATUS_REMOTE = [
+  { type: 'cluster', name: 'home', quorate: 1 },
+  { type: 'node', name: 'pve-01', online: 1 },  // no `local=1` — we're remote
+  { type: 'node', name: 'pve-02', online: 1 },
+];
+
+describe('ProxmoxRuntime — REST API mode', () => {
+  beforeEach(() => __setTestTransport(null));
+  afterEach(() => __setTestTransport(null));
+
+  it('init() resolves nodeName from INSIGHTD_PVE_NODE (no local=1 row remotely)', async () => {
+    const { transport } = fakeRestTransport(call =>
+      call.path === '/cluster/status' ? CLUSTER_STATUS_REMOTE : []
+    );
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    assert.equal(r.nodeName, 'pve-01');
+  });
+
+  it('init() throws when INSIGHTD_PVE_NODE is missing in REST mode', async () => {
+    const { transport } = fakeRestTransport(() => CLUSTER_STATUS_REMOTE);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' } /* no nodeName */ });
+    await assert.rejects(() => r.init(), /requires INSIGHTD_PVE_NODE/);
+  });
+
+  it('init() throws when the configured node name is not in the cluster', async () => {
+    const { transport } = fakeRestTransport(() => CLUSTER_STATUS_REMOTE);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' }, nodeName: 'typo-04' });
+    await assert.rejects(() => r.init(), /typo-04.*not found.*Known nodes: pve-01, pve-02/);
+  });
+
+  it('listContainers filters by configured node + maps the same fields as local mode', async () => {
+    const { transport } = fakeRestTransport(call => {
+      if (call.path === '/cluster/status') return CLUSTER_STATUS_REMOTE;
+      if (call.path === '/cluster/resources') {
+        return [
+          { type: 'lxc', id: 'lxc/200', node: 'pve-01', vmid: 200, name: 'web', status: 'running', uptime: 3600 },
+          { type: 'qemu', id: 'qemu/103', node: 'pve-01', vmid: 103, name: 'db', status: 'stopped' },
+          { type: 'qemu', id: 'qemu/999', node: 'pve-02', vmid: 999, name: 'other', status: 'running' },
+          { type: 'qemu', id: 'qemu/9000', node: 'pve-01', vmid: 9000, name: 'tmpl', template: 1 },
+        ];
+      }
+      return [];
+    });
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    const list = await r.listContainers();
+    // pve-02's guest is filtered out, the template is filtered out.
+    const names = list.map((c: any) => c.name).sort();
+    assert.deepEqual(names, ['pve-01/103', 'pve-01/200']);
+    const lxc = list.find((c: any) => c.guestVmid === 200);
+    assert.equal(lxc.guestType, 'lxc');
+    assert.equal(lxc.status, 'running');
+    assert.equal(lxc.guestUptimeSeconds, 3600);
+  });
+
+  it('fetchLogs throws the in-guest-agent message in REST mode (LXC and QEMU)', async () => {
+    const { transport } = fakeRestTransport(() => CLUSTER_STATUS_REMOTE);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    // Same error for both — the UI uses this to render the empty state.
+    await assert.rejects(
+      () => r.fetchLogs('lxc/200', { lines: 50 }),
+      /Logs are not available when insightd reads PVE via REST API.*Install insightd-agent inside the guest/i,
+    );
+    await assert.rejects(
+      () => r.fetchLogs('qemu/103', { lines: 50 }),
+      /Install insightd-agent inside the guest/i,
+    );
+  });
+
+  it('checkImageUpdates is a no-op array (same as local mode)', async () => {
+    const { transport } = fakeRestTransport(() => CLUSTER_STATUS_REMOTE);
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    assert.deepEqual(await r.checkImageUpdates(), []);
+  });
+
+  it('reports supportsActions=true regardless of allowActions (capability vs authorization)', () => {
+    const r = new ProxmoxRuntime({ allowActions: false, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    assert.equal(r.supportsActions, true);
+    assert.equal(r.name, 'proxmox');
+  });
+});


### PR DESCRIPTION
## Summary

Lets the agent monitor a Proxmox VE host from any guest VM (or other machine) that can reach PVE's web port — no install on the hypervisor itself. Same agent binary, same UI, same tables and alerts. Selected by setting \`INSIGHTD_PVE_API_URL\`; without that, the existing local-pvesh path keeps working unchanged.

**Why:** The on-hypervisor install (Node 20 + the agent source) feels heavy on a PVE host. REST API mode lets the agent live anywhere with reachability to PVE's web port and authenticate with an API token.

## Architecture

- New \`agent/src/runtime/pveApi.ts\` exports a \`Transport\` interface with two implementations: \`LocalShellTransport\` (lifted from the pre-PR5 \`pvesh.ts\`) and \`RestTransport\` (pure Node \`https\` — no new deps).
- Same \`pveApi(path)\` call site works in both modes. \`pvesh.ts\` collapses to a one-line re-export shim.
- Seven existing pvesh paths map 1:1 to REST by prepending \`/api2/json/\` and unwrapping the \`{"data": ...}\` envelope.
- One agent per PVE node (matches PR1's bare-metal model). \`INSIGHTD_PVE_NODE\` declares which node this process covers; multi-node clusters run N agent processes from one VM.

## Auth + config

| Var | Notes |
| --- | --- |
| \`INSIGHTD_PVE_API_URL\` | \`https://host:8006\`. Presence selects REST mode. |
| \`INSIGHTD_PVE_TOKEN_ID\` | \`user@realm!tokenid\` — format-validated. |
| \`INSIGHTD_PVE_TOKEN_SECRET\` | UUID-shaped opaque string. |
| \`INSIGHTD_PVE_NODE\` | Required in REST mode (no \`local=1\` notion remotely). |
| \`INSIGHTD_PVE_VERIFY_TLS\` | Default \`false\` — most PVE installs use the auto-generated self-signed cert. |
| \`INSIGHTD_PVE_CA_BUNDLE\` | Opt-in PEM path when verify is on. |

Auth header: \`PVEAPIToken=USER@REALM!TOKENID=SECRET\`. Keep-alive https.Agent reused per call.

Token ACL in docs: \`PVEAuditor\` + \`PVEVMAdmin\` on \`/\` with privsep enabled (broad-but-scoped homelab posture).

## Behavior in REST mode

- **Actions** go through the REST transport. Fire-and-forget — success message includes the PVE UPID. Local-shell mode keeps shelling \`pct\`/\`qm\` directly; \`ProxmoxRuntime.performAction\` branches on \`isRestMode()\`.
- **Logs** throw "Install insightd-agent inside the guest" for both LXC and QEMU. The streaming \`/exec\` endpoint needs \`VM.Console\` and is too much complexity for an already-best-effort feature.

The bare-metal install path is **still supported and still tested**. Demoted in docs/proxmox-setup.md to an Appendix — the only thing it offers over REST mode is \`journalctl --machine\` LXC logs.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 1252 pass, 0 fail (20 new across runtime / actions / collectors). All 35 pre-existing PVE tests still pass — local-shell mode is byte-compatible.
- [x] \`npm run build\` (frontend) clean (no FE changes; transport is invisible to the hub)
- [ ] **Manual on a real PVE host:** create token, drop the env vars into a guest VM's systemd unit, confirm the PVE node shows up on the Hosts page within ~5 min with all the v48–v50 surfaces (Proxmox tab, alerts, insights).
- [ ] **Manual:** Restart an LXC via the UI, confirm \`pct reboot\` runs (visible in PVE's task log).
- [ ] **Manual:** Open the Logs tab on any PVE guest in REST mode — should show the in-guest-agent empty state.

## No schema bump

Schema stays at v50. Transport selection is invisible to the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)