### PR TITLE
proxmox: source PVE node host metrics + rootfs disk via REST API

### DIFF
--- a/agent/src/runtime/proxmox.ts
+++ b/agent/src/runtime/proxmox.ts
@@ -4,6 +4,7 @@ import { pveApi, pveAction, isRestMode, configurePveTransport, type PveApiConfig
 import type {
   ContainerRuntime, ContainerInfo, ContainerWithResources,
   LogEntry, LogOptions, ContainerAction, ActionResult, ImageUpdate,
+  HostMetricsOverride, DiskResult,
 } from './types';
 import { LogsUnavailableError } from './types';
 
@@ -49,9 +50,16 @@ interface PveClusterStatusRow {
  *
  * Treats LXC containers and QEMU VMs as `ContainerInfo` rows so they show up
  * in the existing Hosts page / container UI without inventing a parallel
- * "guests" surface. The PVE host itself is a regular host_snapshot — `/proc`
- * collectors work natively on PVE (it's just Debian) so getHostMetrics is
- * not implemented.
+ * "guests" surface.
+ *
+ * Host-level metrics (CPU, memory, swap, load, uptime, rootfs disk):
+ * - **local-shell mode** (agent on the PVE box): /proc + /sys collectors are
+ *   the source of truth — `getHostMetrics` and `getDiskMetrics` return null so
+ *   the scheduler keeps those values.
+ * - **REST mode** (agent on a guest VM talking to PVE over HTTPS): /proc
+ *   reflects the guest, NOT the hypervisor we report under, so both methods
+ *   query `/nodes/{node}/status` and override the local readings. Without
+ *   this, the host detail page shows "Uptime unknown" + the guest's CPU/mem.
  *
  * Capabilities by PR:
  * - PR1: list + resource collection
@@ -360,6 +368,83 @@ export class ProxmoxRuntime implements ContainerRuntime {
     // No "image" concept for VMs/LXC. Returning an empty array is the contract.
     return [];
   }
+
+  /**
+   * REST mode only: source PVE node CPU/memory/swap/load/uptime from
+   * `/nodes/{node}/status` instead of the agent container's local /proc.
+   * Returns null in local-shell mode so /proc keeps winning.
+   *
+   * Field map vs PVE response:
+   *   uptime          → uptimeSeconds (already seconds since boot)
+   *   cpu (0..1)      → cpuPercent (×100, 2dp)
+   *   memory.total/used/free (bytes) → memoryTotalMb/UsedMb/AvailableMb (bytes ÷ 1MiB)
+   *   swap.total/used (bytes)        → swapTotalMb/swapUsedMb
+   *   loadavg ['1.16','1.46','1.65'] → load1/5/15 (parseFloat each)
+   */
+  async getHostMetrics(): Promise<HostMetricsOverride | null> {
+    if (!isRestMode()) return null;
+    try {
+      const status = await pveApi<PveNodeStatus>(`/nodes/${encodeURIComponent(this.nodeName)}/status`);
+      const cpuPercent = typeof status.cpu === 'number'
+        ? Math.round(status.cpu * 100 * 100) / 100
+        : null;
+      const toMb = (b: number | undefined): number | null =>
+        typeof b === 'number' && Number.isFinite(b)
+          ? Math.round((b / 1024 / 1024) * 100) / 100
+          : null;
+      const [l1, l5, l15] = (status.loadavg || []).map(s => parseFloat(s));
+      return {
+        cpuPercent,
+        memoryTotalMb: toMb(status.memory?.total),
+        memoryUsedMb: toMb(status.memory?.used),
+        memoryAvailableMb: toMb(status.memory?.free),
+        swapTotalMb: toMb(status.swap?.total),
+        swapUsedMb: toMb(status.swap?.used),
+        load1: Number.isFinite(l1) ? l1 : null,
+        load5: Number.isFinite(l5) ? l5 : null,
+        load15: Number.isFinite(l15) ? l15 : null,
+        uptimeSeconds: typeof status.uptime === 'number' ? status.uptime : null,
+      };
+    } catch (err) {
+      logger.warn('proxmox', `getHostMetrics failed: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * REST mode only: report the PVE node's rootfs from the same `/status`
+   * payload (PR2's `pve_storage_snapshots` covers the rest of the storages
+   * separately on the Storage tab). Returns null in local-shell mode so
+   * `collectDisk` keeps producing the full mount list from /proc/mounts.
+   */
+  async getDiskMetrics(): Promise<DiskResult[] | null> {
+    if (!isRestMode()) return null;
+    try {
+      const status = await pveApi<PveNodeStatus>(`/nodes/${encodeURIComponent(this.nodeName)}/status`);
+      const fs = status.rootfs;
+      if (!fs || typeof fs.total !== 'number' || fs.total <= 0) return [];
+      const usedBytes = typeof fs.used === 'number'
+        ? fs.used
+        : (typeof fs.avail === 'number' ? fs.total - fs.avail : NaN);
+      if (!Number.isFinite(usedBytes) || usedBytes < 0) return [];
+      const totalGb = Math.round((fs.total / 1e9) * 100) / 100;
+      const usedGb = Math.round((usedBytes / 1e9) * 100) / 100;
+      const usedPercent = totalGb > 0 ? Math.round((usedGb / totalGb) * 100 * 10) / 10 : 0;
+      return [{ mountPoint: '/', totalGb, usedGb, usedPercent }];
+    } catch (err) {
+      logger.warn('proxmox', `getDiskMetrics failed: ${(err as Error).message}`);
+      return null;
+    }
+  }
+}
+
+interface PveNodeStatus {
+  uptime?: number;
+  cpu?: number;
+  loadavg?: string[];
+  memory?: { total?: number; used?: number; free?: number };
+  swap?: { total?: number; used?: number };
+  rootfs?: { total?: number; used?: number; avail?: number; free?: number };
 }
 
 function parseGuestId(id: string): { type: 'qemu' | 'lxc'; vmid: number } | null {

--- a/agent/src/runtime/types.ts
+++ b/agent/src/runtime/types.ts
@@ -191,6 +191,12 @@ export interface HostMetricsOverride {
   memoryUsedMb?: number | null;
   memoryAvailableMb?: number | null;
   memoryTotalMb?: number | null;
+  /** When the runtime can report swap (e.g. PVE node status), the scheduler
+   *  uses these values; when undefined (k8s — no per-node swap concept) the
+   *  scheduler zeros swap to avoid surfacing the underlying machine's
+   *  /proc/meminfo, which is misleading for the reported node. */
+  swapTotalMb?: number | null;
+  swapUsedMb?: number | null;
   load1?: number | null;
   load5?: number | null;
   load15?: number | null;

--- a/agent/src/scheduler.ts
+++ b/agent/src/scheduler.ts
@@ -90,9 +90,11 @@ function startAgentScheduler(runtime: ContainerRuntime, config: SchedulerConfig)
           if (override.memoryUsedMb !== undefined) host.memory.usedMb = override.memoryUsedMb;
           if (override.memoryAvailableMb !== undefined) host.memory.availableMb = override.memoryAvailableMb;
           if (override.memoryTotalMb !== undefined) host.memory.totalMb = override.memoryTotalMb;
-          // Swap is meaningless inside a k8s container — suppress
-          host.memory.swapTotalMb = 0;
-          host.memory.swapUsedMb = 0;
+          // If the runtime supplies swap (PVE), trust it; otherwise zero so we
+          // don't leak the underlying machine's /proc value (k8s, PVE REST
+          // running from a guest VM whose /proc differs from the reported node).
+          host.memory.swapTotalMb = override.swapTotalMb ?? 0;
+          host.memory.swapUsedMb = override.swapUsedMb ?? 0;
         }
         if (override.load1 !== undefined || override.load5 !== undefined || override.load15 !== undefined) {
           host.load = host.load || { load1: 0, load5: 0, load15: 0 };

--- a/tests/unit/proxmox-runtime-api.test.ts
+++ b/tests/unit/proxmox-runtime-api.test.ts
@@ -131,6 +131,60 @@ describe('ProxmoxRuntime — REST API mode', () => {
     assert.deepEqual(await r.checkImageUpdates(), []);
   });
 
+  it('getHostMetrics maps /nodes/{node}/status into the override shape', async () => {
+    const { transport } = fakeRestTransport(call => {
+      if (call.path === '/cluster/status') return CLUSTER_STATUS_REMOTE;
+      if (call.path === '/nodes/pve-01/status') {
+        return {
+          uptime: 11_706_361,
+          cpu: 0.318103241296519,
+          loadavg: ['1.16', '1.46', '1.65'],
+          memory: { total: 33_465_860_096, used: 25_465_696_256, free: 1_052_426_240 },
+          swap:   { total:  8_589_930_496, used:  8_577_904_640 },
+          rootfs: { total: 241_928_577_024, used: 229_581_828_096, avail: 1_729_884_160 },
+        };
+      }
+      return [];
+    });
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    const m = await r.getHostMetrics();
+    assert.ok(m, 'expected a metrics override in REST mode');
+    assert.equal(m!.uptimeSeconds, 11_706_361);
+    assert.equal(m!.cpuPercent, 31.81);
+    assert.equal(m!.load1, 1.16);
+    assert.equal(m!.load15, 1.65);
+    // 33_465_860_096 / 1024 / 1024 ≈ 31_915.07 MiB
+    assert.ok(m!.memoryTotalMb! > 31_900 && m!.memoryTotalMb! < 31_930, `unexpected memTotalMb: ${m!.memoryTotalMb}`);
+    assert.ok(m!.swapTotalMb! > 8_100 && m!.swapTotalMb! < 8_200, `unexpected swapTotalMb: ${m!.swapTotalMb}`);
+  });
+
+  it('getDiskMetrics returns the rootfs entry from /nodes/{node}/status', async () => {
+    const { transport } = fakeRestTransport(call => {
+      if (call.path === '/cluster/status') return CLUSTER_STATUS_REMOTE;
+      if (call.path === '/nodes/pve-01/status') {
+        return { rootfs: { total: 241_928_577_024, used: 229_581_828_096, avail: 1_729_884_160 } };
+      }
+      return [];
+    });
+    __setTestTransport(transport);
+    const r = new ProxmoxRuntime({ api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
+    await r.init();
+    const disks = await r.getDiskMetrics();
+    assert.ok(disks && disks.length === 1, 'expected one rootfs entry');
+    assert.equal(disks![0].mountPoint, '/');
+    assert.ok(disks![0].usedPercent > 90, `rootfs is 95% full per fixture, got ${disks![0].usedPercent}`);
+  });
+
+  it('getHostMetrics + getDiskMetrics return null in local-shell mode (so /proc wins)', async () => {
+    const { ProxmoxRuntime: PR } = require('../../agent/src/runtime/proxmox');
+    // No `api` config → local-shell transport → both methods short-circuit.
+    const r = new PR({ nodeName: 'pve-01' });
+    assert.equal(await r.getHostMetrics(), null);
+    assert.equal(await r.getDiskMetrics(), null);
+  });
+
   it('reports supportsActions=true regardless of allowActions (capability vs authorization)', () => {
     const r = new ProxmoxRuntime({ allowActions: false, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
     assert.equal(r.supportsActions, true);


### PR DESCRIPTION
## Summary
On the kingduck host detail page (PVE 8.4 via REST mode) the host showed "Uptime unknown" and zero CPU/memory — only the guests had real metrics. Root cause: `ProxmoxRuntime` never implemented `getHostMetrics()`, on the assumption the agent runs on the PVE box (bare-metal install) where /proc *is* the hypervisor. PR #236 (REST mode) broke that assumption — when the agent runs on a guest VM, /proc reflects the guest, not the node we report under.

This PR implements `getHostMetrics()` and `getDiskMetrics()` on `ProxmoxRuntime`. Both are REST-mode-only and query `/nodes/{node}/status`, which carries everything we need in one payload:

| PVE field | → | hub field |
| --- | --- | --- |
| `uptime` (sec) | → | `uptime_seconds` |
| `cpu` (0..1) | → | `cpu_percent` (×100) |
| `memory.{total,used,free}` | → | `memory_{total,used,available}_mb` |
| `swap.{total,used}` | → | `swap_{total,used}_mb` (new — see below) |
| `loadavg[3]` | → | `load_{1,5,15}` |
| `rootfs.{total,used,avail}` | → | one `DiskResult` mounted at `/` |

In local-shell mode both methods return null, so `/proc` + `collectDisk` keep winning (no behavior change for users running on the PVE host).

### Why `HostMetricsOverride` gained swap fields
The scheduler used to zero `swapTotalMb` / `swapUsedMb` unconditionally whenever any memory override was set — k8s reasoning ("no per-node swap concept"). With PVE that hides real swap pressure. New behavior: `override.swapTotalMb ?? 0`. Runtime supplies → use it. Runtime doesn't (k8s) → still zero. Backwards-compatible.

## Validation on real hardware (kingduck, PVE 8.4)
After redeploying the rebuilt agent against `agent-kingduck`, `GET /api/hosts/kingduck` now returns:

```
hostMetrics:
  cpu_percent: 32.94
  memory_total_mb: 31915.53
  memory_used_mb:  24291.11
  swap_total_mb:    8192.00
  swap_used_mb:     8173.28
  load_1/5/15: 1.36 / 1.51 / 1.62
  uptime_seconds: 11,706,702 (~135d)
disk:
  /  229.58 / 241.93 GB (94.9%)
```

Bonus signals exposed: 99.7% swap, 94.9% rootfs — both legitimate things to know about, both hidden before this PR.

## Test plan
- [x] `npm test` clean (1255 tests, 0 failures)
- [x] `npm run typecheck` clean
- [x] New tests in `tests/unit/proxmox-runtime-api.test.ts`: `getHostMetrics` maps fields correctly; `getDiskMetrics` returns the rootfs entry; both return null in local-shell mode (so /proc + collectDisk keep winning when the agent runs on PVE itself)
- [x] End-to-end on the live `:vdev` rebuild against PVE 8.4 (kingduck) — see Validation above

🤖 Generated with [Claude Code](https://claude.com/claude-code)