### PR TITLE
proxmox: identify guests by display name, not VMID

### DIFF
--- a/agent/src/runtime/proxmox.ts
+++ b/agent/src/runtime/proxmox.ts
@@ -151,11 +151,17 @@ export class ProxmoxRuntime implements ContainerRuntime {
       if (r.node !== this.nodeName) continue;
 
       this.resourceCache.set(r.id, r);
+      // Display-friendly identifier `<node>/<guest-name>` — readable on the
+      // host detail page and across the UI (was previously `<node>/<vmid>`,
+      // which forced users to memorise PVE numbers). Falls back to the VMID
+      // when PVE returns an empty name (rare but possible). The leading
+      // `<node>/` is load-bearing — `getProxmoxContainerMeta` in the hub
+      // splits on the first slash to find the PVE node, and the in-guest
+      // identity bridge does the same lookup keyed on `(node, vmid)` rather
+      // than the container name, so renames in PVE don't break the link.
+      const displayName = r.name && r.name.length > 0 ? r.name : String(r.vmid);
       guests.push({
-        // Stable cluster-wide identifier — matches the label format the
-        // in-guest agent stamps via INSIGHTD_PROXMOX_NODE/_VMID for the
-        // identity bridge in PR 4.
-        name: `${r.node}/${r.vmid}`,
+        name: `${r.node}/${displayName}`,
         id: r.id,                                                // "lxc/200"
         status: mapStatus(r.status),
         restartCount: 0,                                         // no concept on PVE
@@ -299,24 +305,29 @@ export class ProxmoxRuntime implements ContainerRuntime {
 
     const slash = containerName.indexOf('/');
     if (slash < 0) {
-      throw new Error(`Unrecognised PVE container name "${containerName}" — expected "<node>/<vmid>"`);
+      throw new Error(`Unrecognised PVE container name "${containerName}" — expected "<node>/<guest>"`);
     }
     const targetNode = containerName.slice(0, slash);
-    const vmidPart = containerName.slice(slash + 1);
-    const vmid = Number(vmidPart);
-    if (!Number.isInteger(vmid) || vmid <= 0) {
-      throw new Error(`Unrecognised PVE container name "${containerName}" — non-numeric vmid`);
-    }
+    const guestKey = containerName.slice(slash + 1);
     if (targetNode !== this.nodeName) {
-      throw new Error(`Guest ${vmid} lives on node "${targetNode}", not this agent's node "${this.nodeName}"`);
+      throw new Error(`Guest "${guestKey}" lives on node "${targetNode}", not this agent's node "${this.nodeName}"`);
     }
 
     // Look up the type fresh — caches go stale, action requests don't.
+    // Resolve the guest by display name first (the new identifier format
+    // since the rename PR), falling back to numeric VMID for any stale UI
+    // state still using the old `<node>/<vmid>` shape.
     const resources = await pveApi<PveResource[]>('/cluster/resources');
-    const guest = resources.find(r => r.vmid === vmid && r.node === targetNode && (r.type === 'lxc' || r.type === 'qemu'));
+    const candidates = resources.filter(r =>
+      r.node === targetNode && (r.type === 'lxc' || r.type === 'qemu')
+    );
+    const numericVmid = /^\d+$/.test(guestKey) ? Number(guestKey) : null;
+    const guest = candidates.find(r => r.name === guestKey)
+      ?? (numericVmid != null ? candidates.find(r => r.vmid === numericVmid) : undefined);
     if (!guest) {
-      throw new Error(`PVE guest vmid=${vmid} not found on node "${targetNode}"`);
+      throw new Error(`PVE guest "${guestKey}" not found on node "${targetNode}"`);
     }
+    const vmid = guest.vmid as number;
 
     const verb = pveActionVerb(action);
     const past = action === 'stop' ? 'shutdown initiated'

--- a/tests/unit/proxmox-actions-api.test.ts
+++ b/tests/unit/proxmox-actions-api.test.ts
@@ -60,7 +60,7 @@ describe('ProxmoxRuntime.performAction — REST API mode', () => {
     await r.init();
     const beforeCalls = calls.length;
     await assert.rejects(
-      () => r.performAction('pve-01/200', 'start'),
+      () => r.performAction('pve-01/web', 'start'),
       /actions are disabled/i,
     );
     // No HTTP calls beyond the init's /cluster/status.
@@ -72,7 +72,7 @@ describe('ProxmoxRuntime.performAction — REST API mode', () => {
     __setTestTransport(transport);
     const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
     await r.init();
-    const result = await r.performAction('pve-01/200', 'start');
+    const result = await r.performAction('pve-01/web', 'start');
     const action = calls.find(c => c.kind === 'action');
     assert.ok(action);
     assert.equal(action!.method, 'POST');
@@ -86,7 +86,7 @@ describe('ProxmoxRuntime.performAction — REST API mode', () => {
     __setTestTransport(transport);
     const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
     await r.init();
-    await r.performAction('pve-01/103', 'stop');
+    await r.performAction('pve-01/db', 'stop');
     const action = calls.find(c => c.kind === 'action');
     // Graceful shutdown is the right semantic — `/stop` is a hard kill we
     // deliberately don't expose.
@@ -98,7 +98,7 @@ describe('ProxmoxRuntime.performAction — REST API mode', () => {
     __setTestTransport(transport);
     const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
     await r.init();
-    await r.performAction('pve-01/103', 'restart');
+    await r.performAction('pve-01/db', 'restart');
     const action = calls.find(c => c.kind === 'action');
     assert.equal(action!.path, '/nodes/pve-01/qemu/103/status/reboot');
   });
@@ -108,7 +108,7 @@ describe('ProxmoxRuntime.performAction — REST API mode', () => {
     __setTestTransport(transport);
     const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
     await r.init();
-    await r.performAction('pve-01/103', 'remove');
+    await r.performAction('pve-01/db', 'remove');
     const action = calls.find(c => c.kind === 'action');
     assert.equal(action!.method, 'DELETE');
     // No `/status/...` suffix — destroy is a top-level DELETE on the guest.
@@ -139,7 +139,7 @@ describe('ProxmoxRuntime.performAction — REST API mode', () => {
     const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
     await r.init();
     await assert.rejects(
-      () => r.performAction('pve-01/200', 'start'),
+      () => r.performAction('pve-01/web', 'start'),
       /Permission denied \(VM\.PowerMgmt\)/,
     );
   });
@@ -155,7 +155,7 @@ describe('ProxmoxRuntime.performAction — REST API mode', () => {
     __setTestTransport(transport);
     const r = new ProxmoxRuntime({ allowActions: true, api: { url: 'https://pve.lan:8006' }, nodeName: 'pve-01' });
     await r.init();
-    const result = await r.performAction('pve-01/200', 'start');
+    const result = await r.performAction('pve-01/web', 'start');
     assert.equal(result.status, 'success');
     assert.doesNotMatch(result.message, /UPID:/);
   });

--- a/tests/unit/proxmox-actions.test.ts
+++ b/tests/unit/proxmox-actions.test.ts
@@ -56,7 +56,7 @@ describe('ProxmoxRuntime.performAction (PR4)', () => {
     const r = new ProxmoxRuntime({ allowActions: false });
     await r.init();
     await assert.rejects(
-      () => r.performAction('pve-01/200', 'start'),
+      () => r.performAction('pve-01/web', 'start'),
       /actions are disabled/i,
     );
   });
@@ -69,7 +69,7 @@ describe('ProxmoxRuntime.performAction (PR4)', () => {
     });
     const r = new ProxmoxRuntime({ allowActions: true });
     await r.init();
-    const result = await r.performAction('pve-01/200', 'start');
+    const result = await r.performAction('pve-01/web', 'start');
     assert.equal(result.status, 'success');
     const pctCall = calls.find(c => c.file === 'pct');
     assert.ok(pctCall);
@@ -84,7 +84,7 @@ describe('ProxmoxRuntime.performAction (PR4)', () => {
     });
     const r = new ProxmoxRuntime({ allowActions: true });
     await r.init();
-    await r.performAction('pve-01/103', 'stop');
+    await r.performAction('pve-01/db', 'stop');
     const qmCall = calls.find(c => c.file === 'qm');
     assert.ok(qmCall);
     // 'shutdown' = graceful ACPI, not 'stop' (which would be a hard kill).
@@ -99,8 +99,8 @@ describe('ProxmoxRuntime.performAction (PR4)', () => {
     });
     const r = new ProxmoxRuntime({ allowActions: true });
     await r.init();
-    await r.performAction('pve-01/103', 'restart');
-    await r.performAction('pve-01/103', 'remove');
+    await r.performAction('pve-01/db', 'restart');
+    await r.performAction('pve-01/db', 'remove');
     const qmCalls = calls.filter(c => c.file === 'qm');
     assert.deepEqual(qmCalls.map(c => c.args[0]), ['reboot', 'destroy']);
   });
@@ -131,13 +131,31 @@ describe('ProxmoxRuntime.performAction (PR4)', () => {
     const r = new ProxmoxRuntime({ allowActions: true });
     await r.init();
     await assert.rejects(
-      () => r.performAction('not-a-vmid', 'start'),
-      /expected "<node>\/<vmid>"/,
+      () => r.performAction('not-a-guest', 'start'),
+      /expected "<node>\/<guest>"/,
     );
+    // Unknown guest name on the right node — falls through to the lookup
+    // and surfaces a "not found" error rather than a parse error.
     await assert.rejects(
-      () => r.performAction('pve-01/notnumeric', 'start'),
-      /non-numeric vmid/,
+      () => r.performAction('pve-01/missing', 'start'),
+      /not found/,
     );
+  });
+
+  it('still accepts the legacy numeric-VMID identifier (backward compat)', async () => {
+    const calls: Array<{ file: string; args: string[] }> = [];
+    const { ProxmoxRuntime } = loadRuntime((file, args) => {
+      calls.push({ file, args });
+      return defaultStub(file, args);
+    });
+    const r = new ProxmoxRuntime({ allowActions: true });
+    await r.init();
+    // UI state cached before the rename PR may still pass `<node>/<vmid>`.
+    const result = await r.performAction('pve-01/200', 'start');
+    assert.equal(result.status, 'success');
+    const pctCall = calls.find(c => c.file === 'pct');
+    assert.ok(pctCall);
+    assert.deepEqual(pctCall!.args, ['start', '200']);
   });
 
   it('surfaces pct/qm errors from the underlying tool unchanged', async () => {
@@ -148,7 +166,7 @@ describe('ProxmoxRuntime.performAction (PR4)', () => {
     const r = new ProxmoxRuntime({ allowActions: true });
     await r.init();
     await assert.rejects(
-      () => r.performAction('pve-01/200', 'start'),
+      () => r.performAction('pve-01/web', 'start'),
       /container is locked/,
     );
   });

--- a/tests/unit/proxmox-runtime-api.test.ts
+++ b/tests/unit/proxmox-runtime-api.test.ts
@@ -95,8 +95,9 @@ describe('ProxmoxRuntime — REST API mode', () => {
     const list = await r.listContainers();
     // pve-02's guest is filtered out, the template is filtered out.
     const names = list.map((c: any) => c.name).sort();
-    assert.deepEqual(names, ['pve-01/103', 'pve-01/200']);
+    assert.deepEqual(names, ['pve-01/db', 'pve-01/web']);
     const lxc = list.find((c: any) => c.guestVmid === 200);
+    assert.equal(lxc.name, 'pve-01/web');
     assert.equal(lxc.guestType, 'lxc');
     assert.equal(lxc.status, 'running');
     assert.equal(lxc.guestUptimeSeconds, 3600);

--- a/tests/unit/proxmox-runtime.test.ts
+++ b/tests/unit/proxmox-runtime.test.ts
@@ -90,7 +90,7 @@ describe('ProxmoxRuntime', () => {
     const list = await r.listContainers();
     // proxmox-02's VM is filtered out; templates and storage rows too.
     const names = list.map(c => c.name).sort();
-    assert.deepEqual(names, ['proxmox-01/103', 'proxmox-01/200']);
+    assert.deepEqual(names, ['proxmox-01/db', 'proxmox-01/web']);
   });
 
   it('listContainers maps lxc/qemu rows to ContainerInfo with guest fields', async () => {


### PR DESCRIPTION
## Summary
The container_name for a PVE guest was \`<node>/<vmid>\` (e.g. \`kingduck/101\`), so the host detail page was a wall of numbers — the user had to remember which VMID was which. Now it's the PVE display name (\`kingduck/AdGuard\`, \`kingduck/NextCloud\`, …), with the VMID falling back only when the name is empty.

The leading \`<node>/\` is preserved because the hub's identity-bridge code (\`getProxmoxContainerMeta\` in \`hub/src/web/queries.ts:1199\`) splits \`container_name\` on the first slash to find the PVE node, and the in-guest agent identity bridge keys on \`(node, vmid)\` rather than the container name — so PVE renames and this rename both leave the bridge intact.

\`performAction\` learns to resolve the guest by **name first**, then by numeric VMID for backward compat — any UI state cached before this PR still passing \`<node>/<vmid>\` keeps working without a forced reload. A dedicated test locks that fallback in.

## Transition behaviour
Existing rows in \`container_snapshots\` keyed under the old \`<node>/<vmid>\` names stop receiving updates and age out via the normal prune cron (default 30d raw retention). Users will briefly see duplicates in long-window views — not auto-migrated because:
- a hash-name SQL migration on a live DB is risky for limited gain
- PVE-side renames produce the same effect already (a homelab tool should handle it gracefully either way)

## Validated on real hardware (kingduck, PVE 8.4)
\`\`\`
container_name               status
---------------------------  -------
kingduck/AdGuard             running
kingduck/Claude              running
kingduck/CloudFlare-Tunnel   running
kingduck/HA-DUCKFAM          running
kingduck/Home-Organizer      running
kingduck/Insightd            running
kingduck/NextCloud           running
kingduck/birthday            exited
kingduck/bitwarden           running
kingduck/monitoring          running
kingduck/twingate-connector  running
… (14 total)
\`\`\`

## Test plan
- [x] \`npm test\` clean (1256 tests, 0 failures)
- [x] \`npm run typecheck\` clean
- [x] Existing list-containers tests in both \`proxmox-runtime.test.ts\` and \`proxmox-runtime-api.test.ts\` updated to assert the name-keyed format
- [x] Existing performAction tests use the new name-keyed identifier; **new test** locks in legacy numeric-VMID still works (backward compat for cached UI state)
- [x] End-to-end on the live \`:vdev\` rebuild against PVE 8.4 (kingduck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)