### PR TITLE
proxmox: stop pve_backup_overdue NEVER firestorm

### DIFF
--- a/hub/src/alerts/evaluator.ts
+++ b/hub/src/alerts/evaluator.ts
@@ -12,6 +12,9 @@ interface AlertItem {
   threshold?: any;
   triggeredAt?: string;
   isResolution?: boolean;
+  /** Resolve the alert in the DB but skip email/webhook notification. Used
+   *  when retiring an alert subtype so existing rows clear without spamming. */
+  isSilentResolution?: boolean;
   reminderNumber?: number;
 }
 
@@ -837,10 +840,13 @@ function checkPveStorageSaturation(db: Database.Database, threshold: number): Al
 
 /**
  * Fire `pve_backup_overdue` for any PVE guest whose last successful vzdump
- * is older than `warnDays` days, OR whose last_status is 'NEVER'. Target =
- * "<host_id>/<vmid>" so the alert dedups per-guest. Threshold of 0 disables
- * the check entirely (some homelabbers don't run vzdump and don't want the
- * noise).
+ * has aged past `warnDays`. Target = "<host_id>/<vmid>" so the alert dedups
+ * per-guest. Threshold of 0 disables the check entirely.
+ *
+ * `last_status='NEVER'` is *not* a per-guest alert — that's a config gap
+ * (the homelab never set up vzdump), not a runtime regression. It surfaces
+ * as a single host-scoped insight via proxmox-checks instead, so a host
+ * with 14 unbacked-up guests doesn't generate 14 simultaneous warnings.
  */
 function checkPveBackupOverdue(db: Database.Database, warnDays: number): AlertItem[] {
   if (warnDays <= 0) return [];
@@ -850,14 +856,13 @@ function checkPveBackupOverdue(db: Database.Database, warnDays: number): AlertIt
   // container_name in PR1) rather than just the bare vmid.
   const rows = db.prepare(`
     SELECT b.host_id, b.guest_vmid, b.last_backup_at, b.last_status,
-           CAST((strftime('%s','now') - strftime('%s', COALESCE(b.last_backup_at, '1970-01-01'))) / 86400 AS INTEGER) AS age_days,
+           CAST((strftime('%s','now') - strftime('%s', b.last_backup_at)) / 86400 AS INTEGER) AS age_days,
            (SELECT cs.container_name
               FROM container_snapshots cs
              WHERE cs.host_id = b.host_id AND cs.guest_vmid = b.guest_vmid
              ORDER BY cs.collected_at DESC LIMIT 1) AS guest_name
     FROM pve_guest_backups b
-    WHERE b.last_status = 'NEVER'
-       OR (b.last_backup_at IS NOT NULL AND b.last_backup_at < ${cutoffSql})
+    WHERE b.last_backup_at IS NOT NULL AND b.last_backup_at < ${cutoffSql}
   `).all() as Array<{
     host_id: string; guest_vmid: number; last_backup_at: string | null;
     last_status: string; age_days: number; guest_name: string | null;
@@ -865,14 +870,11 @@ function checkPveBackupOverdue(db: Database.Database, warnDays: number): AlertIt
 
   return rows.map(r => {
     const display = r.guest_name ?? `${r.host_id}/${r.guest_vmid}`;
-    const detail = r.last_status === 'NEVER'
-      ? 'never backed up'
-      : `last backup ${r.age_days}d ago (threshold ${warnDays}d)`;
     return {
       type: 'pve_backup_overdue',
       hostId: r.host_id,
       target: String(r.guest_vmid),
-      message: `Proxmox guest "${display}" — ${detail}.`,
+      message: `Proxmox guest "${display}" — last backup ${r.age_days}d ago (threshold ${warnDays}d).`,
       value: r.last_backup_at ?? 'never',
       threshold: `${warnDays}d`,
     };
@@ -1112,18 +1114,40 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
       // the warn window AND the status flipped to OK — so a fresh failure
       // (status='FAILED' even with old date) keeps the alert open. Or the
       // row vanished entirely (guest destroyed/migrated).
+      //
+      // last_status='NEVER' also resolves *silently*: the per-guest alert
+      // no longer fires for NEVER state (it surfaces as a host-scoped
+      // insight now), so any pre-existing NEVER alerts in alert_state
+      // should auto-clear on the next pass. Marked silent so a host with
+      // 14 legacy NEVER alerts doesn't blast 14 "resolved" emails.
       const warnDays = alertsConfig.pveBackupAgeWarnDays ?? 7;
       const cutoffSql = `datetime('now', '-${warnDays} days')`;
       const row = db.prepare(
         `SELECT last_backup_at, last_status FROM pve_guest_backups WHERE host_id = ? AND guest_vmid = ?`
       ).get(alert.host_id, Number(alert.target)) as { last_backup_at: string | null; last_status: string } | undefined;
+      let silent = false;
       if (!row) {
         isResolved = true;
+      } else if (row.last_status === 'NEVER') {
+        isResolved = true;
+        silent = true;
       } else if (row.last_status === 'OK' && row.last_backup_at) {
         const stillOld = (db.prepare(
           `SELECT (julianday(?) < julianday(${cutoffSql})) AS old`
         ).get(row.last_backup_at) as { old: number }).old === 1;
         isResolved = !stillOld;
+      }
+      if (isResolved && silent) {
+        resolved.push({
+          type: alert.alert_type,
+          hostId: alert.host_id,
+          target: alert.target,
+          message: getResolutionMessage(alert.alert_type, alert.target, alert.host_id),
+          triggeredAt: alert.triggered_at,
+          isResolution: true,
+          isSilentResolution: true,
+        });
+        continue;
       }
     } else if (alert.alert_type === 'pve_storage_saturation') {
       // Resolved when latest snapshot is back under the disk threshold, or
@@ -1263,6 +1287,7 @@ function processAlerts(db: Database.Database, config: EvaluatorConfig, { trigger
     db.prepare(
       "UPDATE alert_state SET resolved_at = datetime('now') WHERE host_id = ? AND alert_type = ? AND target = ? AND resolved_at IS NULL"
     ).run(alert.hostId, alert.type, alert.target);
+    if (alert.isSilentResolution) continue;
     toSend.push(alert);
   }
 

--- a/hub/src/insights/proxmox-checks.ts
+++ b/hub/src/insights/proxmox-checks.ts
@@ -41,7 +41,12 @@ export function generateProxmoxInsights(db: Database.Database, insert: InsightIn
   let count = 0;
   count += hostQuorumLostInsight(db, insert);
   count += hostZfsDegradedInsights(db, insert);
-  count += guestNoBackupInsights(db, insert);
+  // The host-scope check runs first and returns the set of host_ids that
+  // got a "no backups configured at all" insight. The per-guest check then
+  // skips those hosts so a 14-guest homelab gets one warning, not 14.
+  const noBackupHosts = hostNoBackupsConfiguredInsights(db, insert);
+  count += noBackupHosts.size;
+  count += guestNoBackupInsights(db, insert, noBackupHosts);
   count += guestSnapshotAccumulationInsights(db, insert);
   return count;
 }
@@ -97,13 +102,50 @@ function hostZfsDegradedInsights(db: Database.Database, insert: InsightInsert): 
 }
 
 /**
- * Per-guest "never backed up" / "very stale backup" insights. Bumped to
- * warning for QEMU (full VMs — losing a disk image is a recovery
- * project), info for LXC (rebuilding from a Debian template is cheap by
- * comparison). Skipped when a backup matching alerts.pveBackupAgeWarnDays
- * exists — at that point the alert covers it.
+ * One host-scoped insight per PVE host with no automated backups at all
+ * (every tracked guest reports last_status='NEVER'). Replaces what used to
+ * be an N-row firestorm of per-guest "never backed up" insights *and* a
+ * matching N-row alert blast — when the entire host is unbackuped the
+ * actionable answer is the same for every guest ("set up vzdump"), so
+ * a single warning at host scope is the right granularity.
+ *
+ * Returns the set of host_ids covered so the per-guest check can skip
+ * them and avoid duplication.
  */
-function guestNoBackupInsights(db: Database.Database, insert: InsightInsert): number {
+function hostNoBackupsConfiguredInsights(db: Database.Database, insert: InsightInsert): Set<string> {
+  const rows = db.prepare(`
+    SELECT host_id,
+           COUNT(*) AS total,
+           SUM(CASE WHEN last_status = 'NEVER' THEN 1 ELSE 0 END) AS never_count,
+           SUM(CASE WHEN last_status = 'OK' THEN 1 ELSE 0 END) AS ok_count
+    FROM pve_guest_backups
+    GROUP BY host_id
+    HAVING ok_count = 0 AND never_count > 0
+  `).all() as Array<{ host_id: string; total: number; never_count: number; ok_count: number }>;
+
+  const covered = new Set<string>();
+  for (const r of rows) {
+    insert.run(
+      'host', r.host_id, 'proxmox', 'warning',
+      `Proxmox host "${r.host_id}" has no automated backups configured`,
+      `${r.never_count} guest${r.never_count === 1 ? '' : 's'} would be unrecoverable on disk loss. ` +
+      `Configure vzdump under Datacenter → Backup.`,
+      'guests_without_backup', r.never_count, null, null,
+    );
+    covered.add(r.host_id);
+  }
+  return covered;
+}
+
+/**
+ * Per-guest "never backed up" insight for the *mixed* case — host has
+ * some guests on a backup schedule but a few are missing. That's a
+ * forgot-this-one signal, distinct from the host-scope "no backups at
+ * all" case (which `hostNoBackupsConfiguredInsights` covers and passes
+ * down via `skipHosts`). Severity tracks recovery cost: warning for QEMU
+ * full VMs, info for LXC.
+ */
+function guestNoBackupInsights(db: Database.Database, insert: InsightInsert, skipHosts: Set<string>): number {
   const rows = db.prepare(`
     SELECT b.host_id, b.guest_vmid, b.last_backup_at, b.last_status,
            cs.container_name AS guest_name,
@@ -123,7 +165,9 @@ function guestNoBackupInsights(db: Database.Database, insert: InsightInsert): nu
     WHERE b.last_status = 'NEVER'
   `).all() as BackupRow[];
 
+  let inserted = 0;
   for (const r of rows) {
+    if (skipHosts.has(r.host_id)) continue;
     const name = r.guest_name ?? `${r.host_id}/${r.guest_vmid}`;
     const sev: 'warning' | 'info' = r.guest_type === 'qemu' ? 'warning' : 'info';
     const recovery = r.guest_type === 'qemu'
@@ -135,8 +179,9 @@ function guestNoBackupInsights(db: Database.Database, insert: InsightInsert): nu
       `${recovery}`,
       'backup_age_days', null, null, null,
     );
+    inserted++;
   }
-  return rows.length;
+  return inserted;
 }
 
 /**

--- a/tests/unit/detector-proxmox.test.ts
+++ b/tests/unit/detector-proxmox.test.ts
@@ -123,9 +123,22 @@ describe('detector — Proxmox VE checks (PR3)', () => {
 
   // ── guest-scope: backups ───────────────────────────────────────────────────
 
-  it('emits a warning insight when a QEMU guest has never been backed up', () => {
+  // Per-guest backup insights only fire in the *mixed* case — host has some
+  // backed-up guests + a few forgotten ones. When the entire host has no
+  // backups, the host-scope "no automated backups configured" insight covers
+  // it (see "host-scope: no backups configured" suite below).
+  function upsertBackupWithDate(opts: { vmid: number; status: 'OK' | 'FAILED'; daysAgo: number; hostId?: string }) {
+    db.prepare(`
+      INSERT INTO pve_guest_backups (host_id, guest_vmid, last_backup_at, last_status)
+      VALUES (?, ?, datetime('now', '-${opts.daysAgo} days'), ?)
+    `).run(opts.hostId ?? 'pve-01', opts.vmid, opts.status);
+  }
+
+  it('emits a warning insight when a QEMU guest has never been backed up (mixed host)', () => {
     insertGuest({ vmid: 103, name: 'pve-01/103', type: 'qemu' });
+    insertGuest({ vmid: 104, name: 'pve-01/104', type: 'qemu' });
     upsertBackup({ vmid: 103, status: 'NEVER' });
+    upsertBackupWithDate({ vmid: 104, status: 'OK', daysAgo: 1 });
     generateInsights(db);
     const items = getInsightsByCategory('proxmox');
     const backup = items.find(i => i.title.includes('never been backed up'));
@@ -134,15 +147,38 @@ describe('detector — Proxmox VE checks (PR3)', () => {
     assert.match(backup!.message, /VM disk image/);
   });
 
-  it('emits info-level insight (not warning) for an LXC guest that has never been backed up', () => {
+  it('emits info-level insight (not warning) for an LXC guest that has never been backed up (mixed host)', () => {
     insertGuest({ vmid: 200, name: 'pve-01/200', type: 'lxc' });
+    insertGuest({ vmid: 201, name: 'pve-01/201', type: 'qemu' });
     upsertBackup({ vmid: 200, status: 'NEVER' });
+    upsertBackupWithDate({ vmid: 201, status: 'OK', daysAgo: 1 });
     generateInsights(db);
     const items = getInsightsByCategory('proxmox');
     const backup = items.find(i => i.title.includes('never been backed up'));
     assert.ok(backup);
     assert.equal(backup!.severity, 'info');
     assert.match(backup!.message, /LXC containers are cheap to rebuild/);
+  });
+
+  // ── host-scope: no backups configured ──────────────────────────────────────
+
+  it('emits one host-scope insight (not N per-guest insights) when ALL guests are NEVER', () => {
+    insertGuest({ vmid: 100, name: 'pve-01/100', type: 'qemu' });
+    insertGuest({ vmid: 101, name: 'pve-01/101', type: 'lxc' });
+    insertGuest({ vmid: 102, name: 'pve-01/102', type: 'qemu' });
+    upsertBackup({ vmid: 100, status: 'NEVER' });
+    upsertBackup({ vmid: 101, status: 'NEVER' });
+    upsertBackup({ vmid: 102, status: 'NEVER' });
+    generateInsights(db);
+    const items = getInsightsByCategory('proxmox');
+    const hostScope = items.filter(i => i.title.includes('no automated backups configured'));
+    assert.equal(hostScope.length, 1);
+    assert.equal(hostScope[0].entity_type, 'host');
+    assert.equal(hostScope[0].entity_id, 'pve-01');
+    assert.equal(hostScope[0].severity, 'warning');
+    assert.match(hostScope[0].message, /3 guests/);
+    assert.match(hostScope[0].message, /Datacenter → Backup/);
+    assert.equal(items.filter(i => i.title.includes('never been backed up')).length, 0);
   });
 
   // ── guest-scope: snapshot accumulation ─────────────────────────────────────

--- a/tests/unit/evaluator-pve-alerts.test.ts
+++ b/tests/unit/evaluator-pve-alerts.test.ts
@@ -189,13 +189,33 @@ describe('evaluateAlerts — Proxmox VE (PR2)', () => {
     assert.match(fired[0].message, /14d ago/);
   });
 
-  it('fires pve_backup_overdue with NEVER message for guests that have never been backed up', () => {
+  it('does NOT fire pve_backup_overdue for last_status=NEVER (host-scope insight covers it)', () => {
+    // Regression: a host with 14 unbackuped guests used to emit 14 simultaneous
+    // alerts (kingduck firestorm). NEVER state is now insight-only — the alert
+    // is reserved for "your backup pipeline broke" (aged-out OK rows), not
+    // "you never set one up".
     insertGuestSnapshot({ vmid: 200, name: 'pve-01/200' });
+    insertGuestSnapshot({ vmid: 201, name: 'pve-01/201' });
     upsertBackup({ vmid: 200, daysAgo: null, status: 'NEVER' });
+    upsertBackup({ vmid: 201, daysAgo: null, status: 'NEVER' });
     const { triggered } = evaluateAlerts(db, { alerts: { ...cfg, pveBackupAgeWarnDays: 7 } });
-    const fired = triggered.filter((a: any) => a.type === 'pve_backup_overdue');
-    assert.equal(fired.length, 1);
-    assert.match(fired[0].message, /never backed up/);
+    assert.equal(triggered.filter((a: any) => a.type === 'pve_backup_overdue').length, 0);
+  });
+
+  it('silently resolves a pre-existing pve_backup_overdue alert when the row is now NEVER', () => {
+    // Migration path: an alert created under the old NEVER-fires logic must
+    // auto-clear once the new code ships, without spamming a "resolved"
+    // notification per guest. isSilentResolution=true keeps it out of toSend.
+    insertGuestSnapshot({ vmid: 300, name: 'pve-01/300' });
+    upsertBackup({ vmid: 300, daysAgo: null, status: 'NEVER' });
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, notify_count, message)
+      VALUES ('pve-01', 'pve_backup_overdue', '300', datetime('now', '-1 day'), datetime('now', '-1 day'), 1, 'legacy')
+    `).run();
+    const { resolved } = evaluateAlerts(db, { alerts: { ...cfg, pveBackupAgeWarnDays: 7 } });
+    const matched = resolved.filter((a: any) => a.type === 'pve_backup_overdue' && a.target === '300');
+    assert.equal(matched.length, 1);
+    assert.equal(matched[0].isSilentResolution, true);
   });
 
   it('does not fire pve_backup_overdue when backup is within the warn window', () => {
@@ -207,7 +227,7 @@ describe('evaluateAlerts — Proxmox VE (PR2)', () => {
 
   it('disables pve_backup_overdue when pveBackupAgeWarnDays is 0', () => {
     insertGuestSnapshot({ vmid: 103 });
-    upsertBackup({ vmid: 103, daysAgo: null, status: 'NEVER' });
+    upsertBackup({ vmid: 103, daysAgo: 30, status: 'OK' });
     const { triggered } = evaluateAlerts(db, { alerts: { ...cfg, pveBackupAgeWarnDays: 0 } });
     assert.equal(triggered.filter((a: any) => a.type === 'pve_backup_overdue').length, 0);
   });


### PR DESCRIPTION
## Summary
- Closes the kingduck-style firestorm where a homelab with no vzdump configured got one `pve_backup_overdue` alert per guest the instant the agent attached (14 simultaneous warnings).
- `last_status='NEVER'` is a config gap, not a runtime regression. Alerts now fire only on aged-out `OK` rows ("your backup pipeline broke"), and the never-configured case surfaces as a single host-scope insight ("Proxmox host *X* has no automated backups configured").
- Pre-existing NEVER alerts in `alert_state` auto-clear silently on next pass — no "resolved" email blast as the rows tip over.

## Behaviour matrix
| Host state | Before | After |
|---|---|---|
| All guests `NEVER` | N alerts + N insights | 1 host-scope insight |
| Mixed (`OK` + `NEVER`) | N alerts + N insights | Per-guest "never backed up" insight (alert quiet) |
| `OK` row aged out | 1 alert per guest | 1 alert per guest (unchanged) |
| `FAILED` with old date | 1 alert per guest | 1 alert per guest (unchanged) |

## Test plan
- [x] `npm test` (1259 pass)
- [x] `npm run typecheck`
- [x] New tests cover: NEVER no-fire, silent resolution of legacy alert, host-scope all-NEVER insight, mixed-host per-guest insight
- [ ] Deploy to kingduck, confirm 14 active alerts auto-resolve silently and one host-scope insight appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)