### PR TITLE
k8s: split image_pull_failure out of container_unhealthy

### DIFF
--- a/hub/src/alerts/evaluator.ts
+++ b/hub/src/alerts/evaluator.ts
@@ -31,6 +31,10 @@ interface AlertsConfig {
   hostOffline: boolean;
   hostOfflineMinutes: number;
   containerUnhealthy: boolean;
+  /** Distinct subtype for ImagePullBackOff/ErrImagePull/InvalidImageName/
+   *  CreateContainerConfigError. When false, those rows still count toward
+   *  containerUnhealthy. Default true. */
+  imagePullFailure?: boolean;
   excludeContainers: string;
   endpointDown: boolean | undefined;
   endpointFailureThreshold: number;
@@ -145,10 +149,28 @@ function evaluateAlerts(db: Database.Database, config: EvaluatorConfig): Evaluat
     triggered.push(...checkHostOffline(db, alerts.hostOfflineMinutes));
   }
 
-  // Container health
+  // Container health.
+  //
+  // image_pull_failure runs first and *replaces* container_unhealthy for
+  // rows whose unhealthy reason is image-pull-related (ImagePullBackOff /
+  // ErrImagePull / InvalidImageName / CreateContainerConfigError). The
+  // generic container_unhealthy message ("container X is unhealthy —
+  // ImagePullBackOff: ...") is far less actionable than a dedicated alert
+  // type that names the cause and its remedy (image name typo, missing
+  // pull secret, registry unreachable). Splitting them lets webhooks/UX
+  // route the two failure modes differently without operators having to
+  // pattern-match on `health_check_output`.
+  //
+  // When imagePullFailure is disabled, image-pull rows fall back to the
+  // legacy container_unhealthy behaviour so users never end up with a
+  // silent failure mode.
+  const splitImagePull = alerts.imagePullFailure !== false;
   for (const { host_id } of hosts) {
+    if (splitImagePull) {
+      triggered.push(...checkImagePullFailure(db, host_id).filter(notExcluded));
+    }
     if (alerts.containerUnhealthy) {
-      triggered.push(...checkContainerUnhealthy(db, host_id).filter(notExcluded));
+      triggered.push(...checkContainerUnhealthy(db, host_id, splitImagePull).filter(notExcluded));
     }
   }
 
@@ -507,13 +529,91 @@ function checkHostOffline(db: Database.Database, thresholdMinutes: number): Aler
   }));
 }
 
-function checkContainerUnhealthy(db: Database.Database, hostId: string): AlertItem[] {
+/**
+ * Image-pull failure reasons surfaced by k8s through `state.waiting.reason`.
+ * The agent stamps these into `health_check_output` as `<reason>: <message>`
+ * (or just `<reason>`) when the container is unhealthy due to a pull problem.
+ *
+ * - `ImagePullBackOff` — kubelet is backing off after one or more failed pulls
+ * - `ErrImagePull`     — most recent pull attempt failed (auth/network/missing tag)
+ * - `InvalidImageName` — manifest references an image string the runtime can't parse
+ * - `CreateContainerConfigError` — usually a missing secret/configMap referenced
+ *   by the container; surfaces here because the user-actionable fix is the
+ *   same shape as a pull-secret problem
+ */
+const IMAGE_PULL_FAILURE_REASONS = [
+  'ImagePullBackOff',
+  'ErrImagePull',
+  'InvalidImageName',
+  'CreateContainerConfigError',
+] as const;
+
+function isImagePullFailureReason(healthCheckOutput: string | null): boolean {
+  if (!healthCheckOutput) return false;
+  const prefix = healthCheckOutput.split(':', 1)[0].trim();
+  return (IMAGE_PULL_FAILURE_REASONS as readonly string[]).includes(prefix);
+}
+
+/**
+ * Build the LIKE patterns used to filter `health_check_output` against the
+ * known image-pull reasons. `<Reason>` and `<Reason>: ...` both match.
+ */
+const IMAGE_PULL_LIKE_CLAUSE = IMAGE_PULL_FAILURE_REASONS
+  .map(() => '(health_check_output = ? OR health_check_output LIKE ?)')
+  .join(' OR ');
+const IMAGE_PULL_LIKE_PARAMS = IMAGE_PULL_FAILURE_REASONS.flatMap(r => [r, `${r}:%`]);
+
+function checkImagePullFailure(db: Database.Database, hostId: string): AlertItem[] {
+  const rows = db.prepare(`
+    SELECT container_name, health_check_output FROM container_snapshots
+    WHERE host_id = ? AND collected_at = (
+      SELECT MAX(collected_at) FROM container_snapshots WHERE host_id = ?
+    ) AND health_status = 'unhealthy'
+      AND (${IMAGE_PULL_LIKE_CLAUSE})
+  `).all(hostId, hostId, ...IMAGE_PULL_LIKE_PARAMS) as
+    { container_name: string; health_check_output: string | null }[];
+
+  return rows.map(r => {
+    const reason = (r.health_check_output ?? '').split(':', 1)[0].trim() || 'image pull failure';
+    const detail = r.health_check_output?.slice(0, 300);
+    const remedy = reason === 'CreateContainerConfigError'
+      ? 'Check that the referenced ConfigMap/Secret exists and the keys match.'
+      : 'Check the image name + tag, the registry is reachable, and any imagePullSecrets are correct.';
+    return {
+      type: 'image_pull_failure',
+      hostId,
+      target: r.container_name,
+      message: `Container "${r.container_name}" on ${hostId} can't pull its image — ${detail}. ${remedy}`,
+      value: reason,
+    };
+  });
+}
+
+function checkContainerUnhealthy(db: Database.Database, hostId: string, excludeImagePull: boolean): AlertItem[] {
+  // When the dedicated `image_pull_failure` alert is enabled (default),
+  // exclude image-pull rows here so a single root cause doesn't fan out
+  // into two alerts with conflicting suggested-action wording. When
+  // disabled, image-pull rows still surface as generic container_unhealthy.
+  //
+  // SQL trickiness: `health_check_output` is nullable, and `NOT (NULL = X
+  // OR NULL LIKE X)` evaluates to NULL — which WHERE treats as false and
+  // would silently drop every row whose output is NULL (i.e. the common
+  // case for a Docker liveness-probe failure). The `IS NULL OR …`
+  // disjunction keeps those rows in.
+  const exclusion = excludeImagePull
+    ? `AND (health_check_output IS NULL OR NOT (${IMAGE_PULL_LIKE_CLAUSE}))`
+    : '';
+  const params = excludeImagePull
+    ? [hostId, hostId, ...IMAGE_PULL_LIKE_PARAMS]
+    : [hostId, hostId];
   const rows = db.prepare(`
     SELECT container_name, health_status, health_check_output, last_oom_killed_at FROM container_snapshots
     WHERE host_id = ? AND collected_at = (
       SELECT MAX(collected_at) FROM container_snapshots WHERE host_id = ?
     ) AND health_status = 'unhealthy'
-  `).all(hostId, hostId) as { container_name: string; health_status: string; health_check_output: string | null; last_oom_killed_at: string | null }[];
+      ${exclusion}
+  `).all(...params) as
+    { container_name: string; health_status: string; health_check_output: string | null; last_oom_killed_at: string | null }[];
 
   return rows.map(r => {
     const base = `Container "${r.container_name}" on ${hostId} is unhealthy`;
@@ -913,6 +1013,7 @@ const CONTAINER_ALERT_TYPES = new Set<string>([
   'high_cpu',
   'high_memory',
   'container_unhealthy',
+  'image_pull_failure',
   'container_memory_saturation',
   'container_cpu_saturation',
 ]);
@@ -1023,6 +1124,22 @@ function checkResolutions(db: Database.Database, alertsConfig: AlertsConfig): Al
     } else if (alert.alert_type === 'container_unhealthy') {
       const latest = db.prepare('SELECT health_status FROM container_snapshots WHERE host_id = ? AND container_name = ? ORDER BY collected_at DESC LIMIT 1').get(alert.host_id, alert.target) as { health_status: string } | undefined;
       isResolved = !!latest && latest.health_status !== 'unhealthy';
+    } else if (alert.alert_type === 'image_pull_failure') {
+      // Resolved when the container is no longer unhealthy, OR the row
+      // is still unhealthy but the cause has flipped to something else
+      // (e.g. pull succeeded and the next failure mode is a CrashLoopBackOff).
+      // The CrashLoopBackOff would then trip container_unhealthy on the
+      // next pass, so it stays surfaced — just under the right alert type.
+      const latest = db.prepare(
+        'SELECT health_status, health_check_output FROM container_snapshots ' +
+        'WHERE host_id = ? AND container_name = ? ORDER BY collected_at DESC LIMIT 1'
+      ).get(alert.host_id, alert.target) as
+        { health_status: string; health_check_output: string | null } | undefined;
+      if (!latest || latest.health_status !== 'unhealthy') {
+        isResolved = true;
+      } else {
+        isResolved = !isImagePullFailureReason(latest.health_check_output);
+      }
     } else if (alert.alert_type === 'endpoint_down') {
       // If the endpoint was deleted or disabled, the http-monitor stops
       // probing it — no new is_up=1 check is ever going to roll in. Treat
@@ -1218,6 +1335,7 @@ function getResolutionMessage(type: string, target: string, hostId: string): str
     case 'high_load': return `Host${on} load back to normal`;
     case 'host_offline': return `Host "${hostId}" is back online`;
     case 'container_unhealthy': return `Container "${target}"${on} is healthy again`;
+    case 'image_pull_failure': return `Container "${target}"${on} pulled its image successfully`;
     case 'endpoint_down': return `Endpoint "${target}" is reachable again`;
     case 'node_pressure': return `Node${on} ${target} cleared`;
     case 'node_not_ready': return `Node "${hostId}" is Ready again`;

--- a/hub/src/config.ts
+++ b/hub/src/config.ts
@@ -77,6 +77,7 @@ const config = Object.freeze({
     hostOffline: process.env.INSIGHTD_ALERT_HOST_OFFLINE !== 'false',
     hostOfflineMinutes: parseInt(process.env.INSIGHTD_ALERT_HOST_OFFLINE_MINUTES || '15', 10),
     containerUnhealthy: process.env.INSIGHTD_ALERT_UNHEALTHY !== 'false',
+    imagePullFailure: process.env.INSIGHTD_ALERT_IMAGE_PULL_FAILURE !== 'false',
     excludeContainers: process.env.INSIGHTD_ALERT_EXCLUDE || '',
     endpointDown: process.env.INSIGHTD_ALERT_ENDPOINT_DOWN !== 'false',
     endpointFailureThreshold: parseInt(process.env.INSIGHTD_ALERT_ENDPOINT_FAILURES || '3', 10),

--- a/hub/src/db/settings.ts
+++ b/hub/src/db/settings.ts
@@ -61,6 +61,7 @@ interface AlertsConfig {
   hostOffline: boolean;
   hostOfflineMinutes: number;
   containerUnhealthy: boolean;
+  imagePullFailure: boolean;
   excludeContainers: string;
   endpointDown: boolean;
   endpointFailureThreshold: number;
@@ -124,6 +125,7 @@ const SETTING_DEFS: SettingDef[] = [
   { key: 'alerts.hostOffline', env: 'INSIGHTD_ALERT_HOST_OFFLINE', type: 'bool', category: 'Alerts', label: 'Host Offline Alerts', hotReload: true, default: 'true', description: 'Fire an alert when an agent stops reporting (host down, crashed, network partition).' },
   { key: 'alerts.hostOfflineMinutes', env: 'INSIGHTD_ALERT_HOST_OFFLINE_MINUTES', type: 'int', category: 'Alerts', label: 'Host Offline Threshold (minutes)', hotReload: true, default: '15', description: 'Minutes without a report before the host is considered offline. Agents publish every 5 min by default.' },
   { key: 'alerts.containerUnhealthy', env: 'INSIGHTD_ALERT_UNHEALTHY', type: 'bool', category: 'Alerts', label: 'Unhealthy Container Alerts', hotReload: true, default: 'true' },
+  { key: 'alerts.imagePullFailure', env: 'INSIGHTD_ALERT_IMAGE_PULL_FAILURE', type: 'bool', category: 'Alerts', label: 'Image Pull Failure Alerts', hotReload: true, default: 'true', description: 'Fire a dedicated alert for ImagePullBackOff/ErrImagePull/InvalidImageName/CreateContainerConfigError instead of the generic container_unhealthy. Disable to fall back to container_unhealthy for these.' },
   { key: 'alerts.excludeContainers', env: 'INSIGHTD_ALERT_EXCLUDE', type: 'string', category: 'Alerts', label: 'Exclude Containers (patterns)', hotReload: true, default: '', description: 'Comma-separated patterns. Use * as wildcard. E.g. dev-*,test-*,insightd-*' },
   { key: 'alerts.endpointDown', env: 'INSIGHTD_ALERT_ENDPOINT_DOWN', type: 'bool', category: 'Alerts', label: 'Endpoint Down Alerts', hotReload: true, default: 'true' },
   { key: 'alerts.endpointFailureThreshold', env: 'INSIGHTD_ALERT_ENDPOINT_FAILURES', type: 'int', category: 'Alerts', label: 'Endpoint Failure Threshold', hotReload: true, default: '3', description: 'Consecutive failures before alerting' },
@@ -291,6 +293,7 @@ function getEffectiveConfig(db: Database.Database, baseConfig: BaseConfig): Base
       hostOffline: get('alerts.hostOffline'),
       hostOfflineMinutes: get('alerts.hostOfflineMinutes') || baseConfig.alerts?.hostOfflineMinutes || 15,
       containerUnhealthy: get('alerts.containerUnhealthy'),
+      imagePullFailure: get('alerts.imagePullFailure') ?? baseConfig.alerts?.imagePullFailure ?? true,
       excludeContainers: get('alerts.excludeContainers') || baseConfig.alerts?.excludeContainers || '',
       endpointDown: get('alerts.endpointDown'),
       endpointFailureThreshold: get('alerts.endpointFailureThreshold') || baseConfig.alerts?.endpointFailureThreshold || 3,

--- a/hub/src/web/frontend/src/lib/formatters.ts
+++ b/hub/src/web/frontend/src/lib/formatters.ts
@@ -76,6 +76,7 @@ export function fmtDurationMs(ms: number): string {
 const ALERT_TYPE_LABELS: Record<string, string> = {
   container_down: 'Container stopped',
   container_unhealthy: 'Container unhealthy',
+  image_pull_failure: 'Image pull failed',
   restart_loop: 'Restart loop',
   high_cpu: 'Container CPU high',
   high_memory: 'Container memory high',

--- a/hub/src/web/queries.ts
+++ b/hub/src/web/queries.ts
@@ -525,6 +525,7 @@ const LEVEL_BY_ALERT_TYPE: Record<string, 'critical' | 'error' | 'warning' | 'in
   workload_unavailable: 'critical',
   pve_cluster_quorum_lost: 'critical',
   container_unhealthy: 'error',
+  image_pull_failure: 'error',
   restart_loop: 'error',
   disk_full: 'error',
   node_pressure: 'error',
@@ -556,6 +557,7 @@ const LEVEL_CASE_SQL = `
     WHEN 'workload_unavailable' THEN 'critical'
     WHEN 'pve_cluster_quorum_lost' THEN 'critical'
     WHEN 'container_unhealthy' THEN 'error'
+    WHEN 'image_pull_failure' THEN 'error'
     WHEN 'restart_loop' THEN 'error'
     WHEN 'disk_full' THEN 'error'
     WHEN 'node_pressure' THEN 'error'

--- a/tests/unit/evaluator-image-pull-failure.test.ts
+++ b/tests/unit/evaluator-image-pull-failure.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+const { createTestDb } = require('../helpers/db');
+const { suppressConsole } = require('../helpers/mocks');
+const nodemailer = require('nodemailer');
+
+describe('evaluateAlerts — image_pull_failure', () => {
+  let db: any;
+  let evaluateAlerts: Function;
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = suppressConsole();
+    mock.method(nodemailer, 'createTransport', () => ({ sendMail: mock.fn(async () => ({ messageId: 't' })) }));
+    db = createTestDb();
+    delete require.cache[require.resolve('../../hub/src/alerts/evaluator')];
+    delete require.cache[require.resolve('../../hub/src/alerts/sender')];
+    evaluateAlerts = require('../../hub/src/alerts/evaluator').evaluateAlerts;
+    db.prepare(
+      `INSERT INTO hosts (host_id, first_seen, last_seen, runtime_type)
+       VALUES ('k3s', datetime('now'), datetime('now'), 'kubernetes')`
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+    restore();
+    mock.restoreAll();
+  });
+
+  // Minimal evaluator config — only the container-health checks and
+  // their friends. Other alert types stay disabled so the test output
+  // doesn't have to filter through unrelated noise.
+  const cfg = {
+    enabled: true, to: 't@t.com', cooldownMinutes: 60,
+    containerDown: false, restartCount: 0,
+    cpuPercent: 0, memoryMb: 0, diskPercent: 0,
+    hostCpuPercent: 0, hostMemoryAvailableMb: 0, hostLoadThreshold: 0,
+    hostOffline: false, hostOfflineMinutes: 0,
+    containerUnhealthy: true,
+    imagePullFailure: true,
+    excludeContainers: '',
+    endpointDown: false, endpointFailureThreshold: 3,
+    containerMemoryLimitPercent: 0, containerCpuLimitPercent: 0,
+    certExpiry: false,
+    podPending: false,
+    workloadUnavailable: false, workloadDegraded: false, workloadRolloutStuck: false,
+  };
+
+  function seedUnhealthy(opts: { name: string; output: string | null; hostId?: string }) {
+    const host = opts.hostId ?? 'k3s';
+    db.prepare(`
+      INSERT INTO container_snapshots
+        (host_id, container_name, container_id, status, restart_count,
+         health_status, health_check_output, collected_at)
+      VALUES (?, ?, ?, 'running', 0, 'unhealthy', ?, datetime('now'))
+    `).run(host, opts.name, `cid-${opts.name}`, opts.output);
+    // Mirror the production ingest path — a snapshot insert always upserts
+    // the registry row so the stale-target auto-resolve doesn't trip in
+    // tests that exercise the type-specific resolver.
+    db.prepare(`
+      INSERT INTO containers (host_id, container_name, first_seen, last_seen, removed_at)
+      VALUES (?, ?, datetime('now'), datetime('now'), NULL)
+      ON CONFLICT(host_id, container_name) DO UPDATE SET
+        last_seen = datetime('now'),
+        removed_at = NULL
+    `).run(host, opts.name);
+  }
+
+  it('fires image_pull_failure for ImagePullBackOff and not container_unhealthy', () => {
+    seedUnhealthy({ name: 'web', output: 'ImagePullBackOff: Back-off pulling image "foo:bad"' });
+    const { triggered } = evaluateAlerts(db, { alerts: cfg });
+    const ipf = triggered.filter((a: any) => a.type === 'image_pull_failure');
+    const cu = triggered.filter((a: any) => a.type === 'container_unhealthy');
+    assert.equal(ipf.length, 1);
+    assert.equal(cu.length, 0, 'image-pull rows must not double-fire as container_unhealthy');
+    assert.equal(ipf[0].target, 'web');
+    assert.equal(ipf[0].hostId, 'k3s');
+    assert.match(ipf[0].message, /can't pull its image/);
+    assert.match(ipf[0].message, /imagePullSecrets/);
+    assert.equal(ipf[0].value, 'ImagePullBackOff');
+  });
+
+  it('fires image_pull_failure for ErrImagePull, InvalidImageName, CreateContainerConfigError', () => {
+    seedUnhealthy({ name: 'a', output: 'ErrImagePull: rpc error' });
+    seedUnhealthy({ name: 'b', output: 'InvalidImageName: ":latest" is not valid' });
+    seedUnhealthy({ name: 'c', output: 'CreateContainerConfigError: secret "missing" not found' });
+    const { triggered } = evaluateAlerts(db, { alerts: cfg });
+    const targets = triggered.filter((a: any) => a.type === 'image_pull_failure').map((a: any) => a.target).sort();
+    assert.deepEqual(targets, ['a', 'b', 'c']);
+    const cccfg = triggered.find((a: any) => a.target === 'c' && a.type === 'image_pull_failure');
+    assert.match(cccfg!.message, /ConfigMap\/Secret/);
+  });
+
+  it('matches reasons even when they appear with no trailing message', () => {
+    seedUnhealthy({ name: 'bare', output: 'ImagePullBackOff' });
+    const { triggered } = evaluateAlerts(db, { alerts: cfg });
+    assert.equal(triggered.filter((a: any) => a.type === 'image_pull_failure').length, 1);
+  });
+
+  it('still fires container_unhealthy for non-pull reasons (CrashLoopBackOff)', () => {
+    seedUnhealthy({ name: 'crasher', output: 'CrashLoopBackOff: back-off 5m0s restarting failed container' });
+    const { triggered } = evaluateAlerts(db, { alerts: cfg });
+    assert.equal(triggered.filter((a: any) => a.type === 'image_pull_failure').length, 0);
+    assert.equal(triggered.filter((a: any) => a.type === 'container_unhealthy').length, 1);
+  });
+
+  it('falls back to container_unhealthy for image-pull rows when imagePullFailure=false', () => {
+    seedUnhealthy({ name: 'web', output: 'ImagePullBackOff: bad' });
+    const { triggered } = evaluateAlerts(db, { alerts: { ...cfg, imagePullFailure: false } });
+    assert.equal(triggered.filter((a: any) => a.type === 'image_pull_failure').length, 0);
+    assert.equal(triggered.filter((a: any) => a.type === 'container_unhealthy').length, 1);
+  });
+
+  it('does not fire image_pull_failure when imagePullFailure=false', () => {
+    seedUnhealthy({ name: 'web', output: 'ImagePullBackOff: bad' });
+    const { triggered } = evaluateAlerts(db, { alerts: { ...cfg, imagePullFailure: false } });
+    assert.equal(triggered.filter((a: any) => a.type === 'image_pull_failure').length, 0);
+  });
+
+  it('resolves image_pull_failure when health flips to healthy', () => {
+    seedUnhealthy({ name: 'web', output: 'ImagePullBackOff' });
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, notify_count, message)
+      VALUES ('k3s', 'image_pull_failure', 'web', datetime('now', '-1 hour'), datetime('now', '-1 hour'), 1, 'pull failed')
+    `).run();
+    // Newer snapshot with healthy status — should clear the alert.
+    db.prepare(`
+      INSERT INTO container_snapshots
+        (host_id, container_name, container_id, status, restart_count,
+         health_status, health_check_output, collected_at)
+      VALUES ('k3s', 'web', 'cid-web', 'running', 0, 'healthy', NULL, datetime('now', '+1 second'))
+    `).run();
+    const { resolved } = evaluateAlerts(db, { alerts: cfg });
+    const r = resolved.find((a: any) => a.type === 'image_pull_failure' && a.target === 'web');
+    assert.ok(r);
+    assert.match(r!.message, /pulled its image successfully/);
+  });
+
+  it('resolves image_pull_failure when the unhealthy reason flips to a non-pull cause (CrashLoop takes over)', () => {
+    // Pull succeeded but the container now crashes — image_pull_failure
+    // should resolve and container_unhealthy should re-fire on the same
+    // pass with the new cause.
+    seedUnhealthy({ name: 'web', output: 'CrashLoopBackOff: back-off 5m0s' });
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, notify_count, message)
+      VALUES ('k3s', 'image_pull_failure', 'web', datetime('now', '-1 hour'), datetime('now', '-1 hour'), 1, 'pull failed')
+    `).run();
+    const { triggered, resolved } = evaluateAlerts(db, { alerts: cfg });
+    assert.ok(resolved.find((a: any) => a.type === 'image_pull_failure' && a.target === 'web'));
+    assert.ok(triggered.find((a: any) => a.type === 'container_unhealthy' && a.target === 'web'));
+  });
+});


### PR DESCRIPTION
## Summary
- New \`image_pull_failure\` alert subtype for ImagePullBackOff / ErrImagePull / InvalidImageName / CreateContainerConfigError. Today these all surface as generic \`container_unhealthy\` whose only hint at the cause is the raw kubelet reason embedded in the message. Splitting them out lets the suggested action be specific (image name, registry, pull secret) instead of "the container is unhealthy."
- The new check runs before \`container_unhealthy\` and the latter is filtered to skip image-pull rows, so a single root cause never fans out to two alerts. NULL-safe SQL keeps non-k8s unhealthy containers (Docker liveness-probe failures with NULL output) firing as before.
- New toggle \`alerts.imagePullFailure\` / \`INSIGHTD_ALERT_IMAGE_PULL_FAILURE\` (default true). When false, image-pull rows fall back to the old \`container_unhealthy\` behaviour so disabling never produces a silent failure mode.

## Resolution semantics
- Resolves when \`health_status\` flips off \`unhealthy\`.
- Also resolves when the unhealthy reason flips to a non-pull cause (e.g. pull succeeds, container then crashes) — \`container_unhealthy\` re-fires on the same pass with the new cause.
- Listed in \`CONTAINER_ALERT_TYPES\`, so pod removal auto-resolves it.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm test\` (1267 pass, 0 fail)
- [x] New tests: fire on all 4 reasons, no double-fire, NULL-safe filter for plain unhealthy, toggle fallback, resolution on health flip + on cause-flip
- [ ] Deploy to k3d/kingduck and intentionally roll out an image with a typo to confirm the new alert + suggested-action wording in webhook + email

🤖 Generated with [Claude Code](https://claude.com/claude-code)