### PR TITLE
fix(agent): identity-hint honors INSIGHTD_HOST_ROOT for LXC-in-Docker

### DIFF
--- a/agent/src/collectors/identity-hint.ts
+++ b/agent/src/collectors/identity-hint.ts
@@ -13,24 +13,47 @@ function safeRead(path: string): string | null {
   try { return fs.readFileSync(path, 'utf8'); } catch { return null; }
 }
 
-function detectVirtType(): IdentityHint['virt_type'] {
-  const sysVendor = safeRead('/sys/class/dmi/id/sys_vendor');
+/** When agent runs in Docker on a guest VM with `/:/host:ro` mounted (and
+ *  INSIGHTD_HOST_ROOT=/host), prefix paths to read the GUEST host's files
+ *  rather than the docker container's. Same convention as disk collector. */
+function hostPath(hostRoot: string | null, p: string): string {
+  if (!hostRoot) return p;
+  return `${hostRoot}${p}`;
+}
+
+function detectVirtType(hostRoot: string | null): IdentityHint['virt_type'] {
+  // DMI is exposed natively to docker containers (sysfs), so reads the same
+  // value whether or not we use hostRoot. Try hostRoot first for symmetry.
+  const sysVendor = safeRead(hostPath(hostRoot, '/sys/class/dmi/id/sys_vendor'))
+                 ?? safeRead('/sys/class/dmi/id/sys_vendor');
   if (sysVendor && sysVendor.trim() === 'QEMU') return 'qemu';
 
-  const env = safeRead('/proc/1/environ');
+  // /proc/1/environ MUST come from the host when in docker — the container's
+  // own PID 1 environ is the agent process, not the host LXC's init.
+  const env = safeRead(hostPath(hostRoot, '/proc/1/environ'));
   if (env && env.includes('container=lxc')) return 'lxc';
 
-  const cgroup = safeRead('/proc/self/cgroup');
+  const cgroup = safeRead(hostPath(hostRoot, '/proc/self/cgroup'))
+              ?? safeRead('/proc/self/cgroup');
   if (cgroup && /lxc\.payload\.\d+/.test(cgroup)) return 'lxc';
 
   return 'bare';
 }
 
-function readQemuUuid(): string | null {
-  const raw = safeRead('/sys/class/dmi/id/product_uuid');
+function readQemuUuid(hostRoot: string | null): string | null {
+  const raw = safeRead(hostPath(hostRoot, '/sys/class/dmi/id/product_uuid'))
+           ?? safeRead('/sys/class/dmi/id/product_uuid');
   if (!raw) return null;
   const trimmed = raw.trim().toLowerCase();
   return /^[0-9a-f-]{36}$/.test(trimmed) ? trimmed : null;
+}
+
+function readHostHostname(hostRoot: string | null): string {
+  if (hostRoot) {
+    const raw = safeRead(hostPath(hostRoot, '/etc/hostname'));
+    if (raw && raw.trim()) return raw.trim();
+  }
+  return os.hostname();
 }
 
 function pickPrimaryMac(): string | null {
@@ -48,11 +71,12 @@ function pickPrimaryMac(): string | null {
 }
 
 export function collectIdentityHint(): IdentityHint {
-  const virt_type = detectVirtType();
+  const hostRoot = process.env.INSIGHTD_HOST_ROOT?.trim() || null;
+  const virt_type = detectVirtType(hostRoot);
   return {
     virt_type,
-    system_uuid: virt_type === 'qemu' ? readQemuUuid() : null,
-    hostname: os.hostname(),
+    system_uuid: virt_type === 'qemu' ? readQemuUuid(hostRoot) : null,
+    hostname: readHostHostname(hostRoot),
     primary_mac: pickPrimaryMac(),
   };
 }

--- a/tests/agent/identity-hint.test.ts
+++ b/tests/agent/identity-hint.test.ts
@@ -80,3 +80,51 @@ test('skips loopback and zero-MAC interfaces and docker bridges', () => {
 
   mock.restoreAll();
 });
+
+test('honors INSIGHTD_HOST_ROOT for LXC detection (agent in docker on host LXC)', () => {
+  // Container's /proc/1/environ doesn't have container=lxc (it's the agent
+  // process), but the host LXC's /proc/1/environ does. Reading via /host
+  // succeeds.
+  mockReadFile({
+    '/proc/1/environ': 'PATH=/usr/bin\0AGENT=insightd\0',           // agent container's PID 1
+    '/host/proc/1/environ': 'container=lxc\0HOME=/root\0',          // host LXC's PID 1
+    '/host/etc/hostname': 'AdGuard\n',                              // host LXC hostname
+  });
+  mock.method(os, 'hostname', () => 'docker-container-id-abc123');
+  mock.method(os, 'networkInterfaces', () => ({}));
+
+  const prev = process.env.INSIGHTD_HOST_ROOT;
+  process.env.INSIGHTD_HOST_ROOT = '/host';
+  try {
+    const hint = collectIdentityHint();
+    assert.equal(hint.virt_type, 'lxc');
+    assert.equal(hint.hostname, 'AdGuard');
+  } finally {
+    if (prev === undefined) delete process.env.INSIGHTD_HOST_ROOT;
+    else process.env.INSIGHTD_HOST_ROOT = prev;
+    mock.restoreAll();
+  }
+});
+
+test('honors INSIGHTD_HOST_ROOT for qemu UUID (agent in docker on host VM)', () => {
+  mockReadFile({
+    '/host/sys/class/dmi/id/sys_vendor': 'QEMU\n',
+    '/host/sys/class/dmi/id/product_uuid': 'aabbccdd-eeff-0011-2233-445566778899\n',
+    '/host/etc/hostname': 'n8n\n',
+  });
+  mock.method(os, 'hostname', () => 'docker-container-id-xyz');
+  mock.method(os, 'networkInterfaces', () => ({}));
+
+  const prev = process.env.INSIGHTD_HOST_ROOT;
+  process.env.INSIGHTD_HOST_ROOT = '/host';
+  try {
+    const hint = collectIdentityHint();
+    assert.equal(hint.virt_type, 'qemu');
+    assert.equal(hint.system_uuid, 'aabbccdd-eeff-0011-2233-445566778899');
+    assert.equal(hint.hostname, 'n8n');
+  } finally {
+    if (prev === undefined) delete process.env.INSIGHTD_HOST_ROOT;
+    else process.env.INSIGHTD_HOST_ROOT = prev;
+    mock.restoreAll();
+  }
+});


### PR DESCRIPTION
## Summary
- Agent in Docker on a guest LXC was always detecting as \`virt_type=bare\` because \`/proc/1/environ\` inside the docker container is the agent process's environ, not the host LXC's init
- Honor \`INSIGHTD_HOST_ROOT\` (already set to \`/host\` in compose, with \`/:/host:ro\` bind) for \`/proc/1/environ\`, \`/proc/self/cgroup\`, DMI, and \`/etc/hostname\` reads
- Container-only paths stay as fallback so non-docker deploys keep working
- Resolves limitation #1 from \`project_pve_correlation_followups.md\`

## Why
After PR #249 + agent v0.19.0 deploy on Andreas's homelab, only n8n (qemu — DMI works in docker natively) auto-linked. Birthday-invitation-server, AdGuard, HO-Database, HO-Services, and the Insightd dev VM (all LXC) stayed unlinked because their agents detected as bare.

## Test plan
- [x] \`npm test\` (1307 pass — 2 new HOST_ROOT-path tests)
- [x] \`tsc --noEmit\` clean
- [ ] Build agent vdev image, restart in-guest agents, verify all 5 LXCs link to their kingduck VMIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)