### PR TITLE
fix(agent): identity-hint LXC detection in unprivileged-LXC namespaces

### DIFF
--- a/agent/src/collectors/identity-hint.ts
+++ b/agent/src/collectors/identity-hint.ts
@@ -22,20 +22,27 @@ function hostPath(hostRoot: string | null, p: string): string {
 }
 
 function detectVirtType(hostRoot: string | null): IdentityHint['virt_type'] {
-  // DMI is exposed natively to docker containers (sysfs), so reads the same
-  // value whether or not we use hostRoot. Try hostRoot first for symmetry.
   const sysVendor = safeRead(hostPath(hostRoot, '/sys/class/dmi/id/sys_vendor'))
                  ?? safeRead('/sys/class/dmi/id/sys_vendor');
   if (sysVendor && sysVendor.trim() === 'QEMU') return 'qemu';
 
-  // /proc/1/environ MUST come from the host when in docker — the container's
-  // own PID 1 environ is the agent process, not the host LXC's init.
   const env = safeRead(hostPath(hostRoot, '/proc/1/environ'));
   if (env && env.includes('container=lxc')) return 'lxc';
 
   const cgroup = safeRead(hostPath(hostRoot, '/proc/self/cgroup'))
               ?? safeRead('/proc/self/cgroup');
   if (cgroup && /lxc\.payload\.\d+/.test(cgroup)) return 'lxc';
+
+  // Docker-on-LXC fallback: when the agent runs in Docker inside an unprivileged
+  // PVE LXC, `/host/proc/1/environ` is unreadable due to user-namespace mapping
+  // (the agent's "root" doesn't match the host LXC's "root"), and DMI shows the
+  // bare-metal hypervisor (e.g. "FUJITSU"), not QEMU. But `/host/etc/hostname`
+  // IS world-readable and reflects the LXC's hostname. If that file exists,
+  // is readable, and differs from the container's hostname, we're in an LXC.
+  if (hostRoot) {
+    const hostHostname = safeRead(hostPath(hostRoot, '/etc/hostname'))?.trim();
+    if (hostHostname && hostHostname !== os.hostname()) return 'lxc';
+  }
 
   return 'bare';
 }
@@ -56,7 +63,24 @@ function readHostHostname(hostRoot: string | null): string {
   return os.hostname();
 }
 
-function pickPrimaryMac(): string | null {
+function pickPrimaryMac(hostRoot: string | null): string | null {
+  // Prefer host's network interfaces when available — agent's own
+  // `os.networkInterfaces()` shows the docker container's interfaces, not the
+  // host LXC's eth0. `/host/sys/class/net/<iface>/address` is world-readable
+  // and gives the actual host MAC.
+  if (hostRoot) {
+    try {
+      const ifaceDir = hostPath(hostRoot, '/sys/class/net');
+      const ifaces = fs.readdirSync(ifaceDir);
+      for (const name of ifaces) {
+        if (name === 'lo' || name === 'bonding_masters') continue;
+        if (/^(docker|br-|veth|virbr|cni|flannel|cali)/.test(name)) continue;
+        const mac = safeRead(`${ifaceDir}/${name}/address`)?.trim().toLowerCase();
+        if (mac && mac !== '00:00:00:00:00:00') return mac;
+      }
+    } catch { /* fall through */ }
+  }
+
   const ifaces = os.networkInterfaces();
   for (const [name, addrs] of Object.entries(ifaces)) {
     if (!addrs) continue;
@@ -70,13 +94,23 @@ function pickPrimaryMac(): string | null {
   return null;
 }
 
+/** Resolve effective hostRoot: explicit env var, or default `/host` if that
+ *  directory exists (i.e. the docker-compose `/:/host:ro` bind is present).
+ *  Returns null on bare-metal/container deploys without the bind. */
+function resolveHostRoot(): string | null {
+  const explicit = process.env.INSIGHTD_HOST_ROOT?.trim();
+  if (explicit) return explicit;
+  try { if (fs.statSync('/host').isDirectory()) return '/host'; } catch { /* no /host */ }
+  return null;
+}
+
 export function collectIdentityHint(): IdentityHint {
-  const hostRoot = process.env.INSIGHTD_HOST_ROOT?.trim() || null;
+  const hostRoot = resolveHostRoot();
   const virt_type = detectVirtType(hostRoot);
   return {
     virt_type,
     system_uuid: virt_type === 'qemu' ? readQemuUuid(hostRoot) : null,
     hostname: readHostHostname(hostRoot),
-    primary_mac: pickPrimaryMac(),
+    primary_mac: pickPrimaryMac(hostRoot),
   };
 }

--- a/tests/agent/identity-hint.test.ts
+++ b/tests/agent/identity-hint.test.ts
@@ -128,3 +128,51 @@ test('honors INSIGHTD_HOST_ROOT for qemu UUID (agent in docker on host VM)', () 
     mock.restoreAll();
   }
 });
+
+test('falls back to LXC via hostname-diff when /host/proc/1/environ is unreadable (unprivileged LXC namespace)', () => {
+  // In docker-on-unprivileged-PVE-LXC, /host/proc/1/environ returns EACCES
+  // because the docker container's "root" doesn't match the host LXC's "root"
+  // in the user-namespace mapping. DMI shows the bare-metal hypervisor (e.g.
+  // FUJITSU), not QEMU. But /host/etc/hostname IS world-readable.
+  mockReadFile({
+    '/sys/class/dmi/id/sys_vendor': 'FUJITSU\n',
+    '/host/sys/class/dmi/id/sys_vendor': 'FUJITSU\n',
+    // /host/proc/1/environ deliberately omitted -> ENOENT (mocks EACCES)
+    '/host/etc/hostname': 'AdGuard\n',
+  });
+  mock.method(os, 'hostname', () => 'docker-container-id-abc');
+  mock.method(os, 'networkInterfaces', () => ({}));
+
+  const prev = process.env.INSIGHTD_HOST_ROOT;
+  process.env.INSIGHTD_HOST_ROOT = '/host';
+  try {
+    const hint = collectIdentityHint();
+    assert.equal(hint.virt_type, 'lxc');
+    assert.equal(hint.hostname, 'AdGuard');
+  } finally {
+    if (prev === undefined) delete process.env.INSIGHTD_HOST_ROOT;
+    else process.env.INSIGHTD_HOST_ROOT = prev;
+    mock.restoreAll();
+  }
+});
+
+test('hostname-diff fallback does NOT trigger when host hostname matches container hostname (bare metal with /host=/) ', () => {
+  mockReadFile({
+    '/sys/class/dmi/id/sys_vendor': 'FUJITSU\n',
+    '/host/sys/class/dmi/id/sys_vendor': 'FUJITSU\n',
+    '/host/etc/hostname': 'samebox\n',
+  });
+  mock.method(os, 'hostname', () => 'samebox');
+  mock.method(os, 'networkInterfaces', () => ({}));
+
+  const prev = process.env.INSIGHTD_HOST_ROOT;
+  process.env.INSIGHTD_HOST_ROOT = '/host';
+  try {
+    const hint = collectIdentityHint();
+    assert.equal(hint.virt_type, 'bare');
+  } finally {
+    if (prev === undefined) delete process.env.INSIGHTD_HOST_ROOT;
+    else process.env.INSIGHTD_HOST_ROOT = prev;
+    mock.restoreAll();
+  }
+});


### PR DESCRIPTION
## Summary
Two follow-up issues found while live-testing PR #250 on Andreas's homelab:

1. **HOST_ROOT not auto-defaulted.** Disk collector defaults to `/host` (config.ts:33), but identity-hint required `INSIGHTD_HOST_ROOT` env to be set explicitly. Auto-default to `/host` if that directory exists.

2. **`/host/proc/1/environ` unreadable in unprivileged PVE LXCs.** When the agent runs in Docker inside an unprivileged PVE LXC, the docker container's "root" doesn't match the host LXC's "root" in user-namespace mapping. Mode 0400 file → EACCES. DMI `sys_vendor` reads as the bare-metal hypervisor (e.g. "FUJITSU"), not QEMU. So all detection paths fell through to `bare`.

Add a fallback: when hostRoot is set and `/host/etc/hostname` is readable AND differs from `os.hostname()`, classify as `lxc`. `/etc/hostname` is mode 0644 and survives namespace mapping.

Also use `/host/sys/class/net/<iface>/address` for primary_mac (host interfaces, not docker container's veth).

## Why
After PR #250 + agent-v0.19.1 deploy, only n8n (qemu) auto-linked. AdGuard, Birthday-invitation-server, HO-Database, HO-Services, and proxmox-01 (all docker-in-LXC) stayed unlinked.

## Verified live
After local rebuild + restart, `proxmox-01` host now publishes:
\`\`\`json
{"virt_type":"lxc","system_uuid":null,"hostname":"Claude","primary_mac":"bc:24:11:35:26:fa"}
\`\`\`
and links to `kingduck/116 (lxc)` per `hosts` table.

## Test plan
- [x] \`npm test\` (1309 pass, +2 new)
- [x] \`tsc --noEmit\` clean
- [x] Live test on dev VM agent — proxmox-01 → kingduck/116 link established

🤖 Generated with [Claude Code](https://claude.com/claude-code)