### PR TITLE
Seed hosts.proxmox_cluster_id from pve-cluster MQTT

### DIFF
--- a/docs/superpowers/plans/2026-05-10-pve-multicluster-id-seeding.md
+++ b/docs/superpowers/plans/2026-05-10-pve-multicluster-id-seeding.md
@@ -1,0 +1,324 @@
+# PVE Multi-Cluster `cluster_id` Seeding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a PVE node publishes a `pve-cluster` MQTT message, seed `hosts.proxmox_cluster_id` on that PVE node host with the reported cluster name, so the identity matcher resolves a real cluster_id for linked guests instead of always-null.
+
+**Architecture:** Single change in the hub MQTT pipeline. `handlePveCluster` gains a `hostId` parameter (already available on the MQTT topic). `ingestPveCluster` gains a `hostId` parameter and wraps its existing `pve_cluster_status` UPSERT plus a new `UPDATE hosts SET proxmox_cluster_id = ? WHERE host_id = ?` in a single `db.transaction`. Matcher unchanged — it already JOINs to `hosts.proxmox_cluster_id`.
+
+**Tech Stack:** TypeScript, better-sqlite3, node:test, tsx.
+
+**Spec:** [docs/superpowers/specs/2026-05-10-pve-multicluster-id-seeding-design.md](../specs/2026-05-10-pve-multicluster-id-seeding-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `hub/src/ingest.ts` — extend `ingestPveCluster` signature + wrap writes in tx; update `module.exports` annotation.
+- **Modify** `hub/src/mqtt.ts` — extend `handlePveCluster` signature; update import-side type and dispatch call.
+- **Create** `tests/unit/hub-ingest-pve-cluster.test.ts` — unit tests for the new behavior.
+
+No schema migration. No new files in `hub/src/`. No agent changes. No frontend changes.
+
+---
+
+## Task 1: Failing test for the seeding behavior
+
+**Files:**
+- Create: `tests/unit/hub-ingest-pve-cluster.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/unit/hub-ingest-pve-cluster.test.ts` with the following content:
+
+```ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+const { createTestDb } = require('../helpers/db');
+const { ingestPveCluster, upsertHost } = require('../../hub/src/ingest');
+
+interface HostRow { host_id: string; proxmox_cluster_id: string | null }
+interface ClusterRow { cluster_name: string; quorate: number; total_nodes: number; online_nodes: number }
+
+function status(clusterName: string, overrides: Partial<{ quorate: number; totalNodes: number; onlineNodes: number }> = {}) {
+  return {
+    clusterName,
+    quorate: overrides.quorate ?? 1,
+    totalNodes: overrides.totalNodes ?? 3,
+    onlineNodes: overrides.onlineNodes ?? 3,
+  };
+}
+
+describe('ingestPveCluster', () => {
+  let db: any;
+  beforeEach(() => { db = createTestDb(); });
+  afterEach(() => { db.close(); });
+
+  it('seeds hosts.proxmox_cluster_id for the publishing PVE node', () => {
+    upsertHost(db, 'proxmox-01');
+    ingestPveCluster(db, 'proxmox-01', status('homelab'));
+    const cluster = db.prepare('SELECT * FROM pve_cluster_status WHERE cluster_name = ?').get('homelab') as ClusterRow | undefined;
+    assert.ok(cluster, 'pve_cluster_status row exists');
+    assert.equal(cluster!.quorate, 1);
+    const host = db.prepare('SELECT host_id, proxmox_cluster_id FROM hosts WHERE host_id = ?').get('proxmox-01') as HostRow | undefined;
+    assert.equal(host?.proxmox_cluster_id, 'homelab');
+  });
+
+  it('updates host cluster_id when the cluster is renamed', () => {
+    upsertHost(db, 'proxmox-01');
+    ingestPveCluster(db, 'proxmox-01', status('old-name'));
+    ingestPveCluster(db, 'proxmox-01', status('new-name'));
+    const host = db.prepare('SELECT proxmox_cluster_id FROM hosts WHERE host_id = ?').get('proxmox-01') as HostRow | undefined;
+    assert.equal(host?.proxmox_cluster_id, 'new-name');
+  });
+
+  it('is a silent no-op when the host row does not yet exist', () => {
+    ingestPveCluster(db, 'unknown-node', status('homelab'));
+    const cluster = db.prepare('SELECT * FROM pve_cluster_status WHERE cluster_name = ?').get('homelab') as ClusterRow | undefined;
+    assert.ok(cluster, 'pve_cluster_status row written even without host row');
+    const host = db.prepare('SELECT host_id FROM hosts WHERE host_id = ?').get('unknown-node') as HostRow | undefined;
+    assert.equal(host, undefined, 'no host row created by ingestPveCluster');
+  });
+
+  it('does not modify other host rows', () => {
+    upsertHost(db, 'proxmox-01');
+    upsertHost(db, 'other-host');
+    ingestPveCluster(db, 'proxmox-01', status('homelab'));
+    const other = db.prepare('SELECT proxmox_cluster_id FROM hosts WHERE host_id = ?').get('other-host') as HostRow | undefined;
+    assert.equal(other?.proxmox_cluster_id, null);
+  });
+});
+```
+
+> Note: `upsertHost` is the existing helper exported from `hub/src/ingest.ts`. Real signature: `upsertHost(db, hostId, agentVersion?, runtimeType?, hostGroup?, hostLabels?)`. The tests above use the two-arg form (`hostId` only) which inserts a minimal `hosts` row with `runtime_type='docker'` defaults — sufficient for these tests.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx tsx --test tests/unit/hub-ingest-pve-cluster.test.ts`
+
+Expected: FAIL. The two-arg call signature `ingestPveCluster(db, status)` is current, so the three-arg call in the test will either crash on `status.clusterName` being undefined, or pass through to a UPSERT that succeeds — but the `hosts.proxmox_cluster_id` assertion fails because nothing populates that column today.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/unit/hub-ingest-pve-cluster.test.ts
+git commit -m "test: failing tests for PVE cluster_id seeding"
+```
+
+---
+
+## Task 2: Extend `ingestPveCluster` to seed `hosts.proxmox_cluster_id`
+
+**Files:**
+- Modify: `hub/src/ingest.ts:850-860` (the `ingestPveCluster` function body)
+- Modify: `hub/src/ingest.ts:937` (the `module.exports` block — type assertion only, no functional change)
+
+- [ ] **Step 1: Replace the `ingestPveCluster` function body**
+
+In `hub/src/ingest.ts`, replace the entire current implementation (lines ~850–860):
+
+```ts
+function ingestPveCluster(db: Database.Database, status: PveClusterRecord): void {
+  db.prepare(`
+    INSERT INTO pve_cluster_status (cluster_name, quorate, total_nodes, online_nodes, observed_at)
+    VALUES (?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(cluster_name) DO UPDATE SET
+      quorate      = excluded.quorate,
+      total_nodes  = excluded.total_nodes,
+      online_nodes = excluded.online_nodes,
+      observed_at  = excluded.observed_at
+  `).run(status.clusterName, status.quorate, status.totalNodes, status.onlineNodes);
+}
+```
+
+with:
+
+```ts
+function ingestPveCluster(db: Database.Database, hostId: string, status: PveClusterRecord): void {
+  const upsertCluster = db.prepare(`
+    INSERT INTO pve_cluster_status (cluster_name, quorate, total_nodes, online_nodes, observed_at)
+    VALUES (?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(cluster_name) DO UPDATE SET
+      quorate      = excluded.quorate,
+      total_nodes  = excluded.total_nodes,
+      online_nodes = excluded.online_nodes,
+      observed_at  = excluded.observed_at
+  `);
+  const seedHostClusterId = db.prepare(`
+    UPDATE hosts SET proxmox_cluster_id = ? WHERE host_id = ?
+  `);
+  db.transaction(() => {
+    upsertCluster.run(status.clusterName, status.quorate, status.totalNodes, status.onlineNodes);
+    seedHostClusterId.run(status.clusterName, hostId);
+  })();
+}
+```
+
+- [ ] **Step 2: No change needed to `module.exports`**
+
+The `module.exports` block at the bottom of `hub/src/ingest.ts` exports the function reference itself; the runtime signature is whatever the function definition has. No edit needed.
+
+> If a TypeScript type assertion in the consuming `mqtt.ts` (next task) describes the function shape, update it there.
+
+- [ ] **Step 3: Run the new test — should still fail**
+
+Run: `npx tsx --test tests/unit/hub-ingest-pve-cluster.test.ts`
+
+Expected: PASS. The function now writes both rows. (If the test still fails because of the call-site signature in `mqtt.ts`, that is fine — the unit test imports `ingestPveCluster` directly and does not touch `mqtt.ts`.)
+
+- [ ] **Step 4: Run the full test suite to catch any regressions**
+
+Run: `npm test`
+
+Expected: PASS. Any failure is likely a call-site that has not yet been updated. The only known production call site is `hub/src/mqtt.ts:871`, addressed in Task 3.
+
+> If `npm test` fails because TypeScript type-checking flags a call-site arity mismatch in `hub/src/mqtt.ts:871`, do **not** patch it here. Stop and proceed to Task 3 — the change belongs there.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hub/src/ingest.ts
+git commit -m "feat(hub): ingestPveCluster seeds hosts.proxmox_cluster_id"
+```
+
+---
+
+## Task 3: Thread `hostId` through `handlePveCluster`
+
+**Files:**
+- Modify: `hub/src/mqtt.ts:28` (import-side type assertion for `ingestPveCluster`)
+- Modify: `hub/src/mqtt.ts:340` (dispatch call site)
+- Modify: `hub/src/mqtt.ts:870-878` (the `handlePveCluster` function definition)
+
+- [ ] **Step 1: Update the import-side type for `ingestPveCluster`**
+
+In `hub/src/mqtt.ts:28`, change:
+
+```ts
+ingestPveCluster: (db: Database.Database, status: any) => void;
+```
+
+to:
+
+```ts
+ingestPveCluster: (db: Database.Database, hostId: string, status: any) => void;
+```
+
+- [ ] **Step 2: Replace the `handlePveCluster` function**
+
+Replace the current `handlePveCluster` at `hub/src/mqtt.ts:870`:
+
+```ts
+function handlePveCluster(db: Database.Database, payload: PveClusterPayload): void {
+  ingestPveCluster(db, {
+    clusterName: payload.cluster_name,
+    quorate: payload.quorate,
+    totalNodes: payload.total_nodes,
+    onlineNodes: payload.online_nodes,
+  });
+  logger.info('mqtt', `Ingested PVE cluster ${payload.cluster_name} quorate=${payload.quorate}`);
+}
+```
+
+with:
+
+```ts
+function handlePveCluster(db: Database.Database, hostId: string, payload: PveClusterPayload): void {
+  ingestPveCluster(db, hostId, {
+    clusterName: payload.cluster_name,
+    quorate: payload.quorate,
+    totalNodes: payload.total_nodes,
+    onlineNodes: payload.online_nodes,
+  });
+  logger.info('mqtt', `Ingested PVE cluster ${payload.cluster_name} quorate=${payload.quorate}`);
+}
+```
+
+- [ ] **Step 3: Update the dispatch site**
+
+At `hub/src/mqtt.ts:340`, change:
+
+```ts
+} else if (type === 'pve-cluster') {
+  handlePveCluster(db, payload);
+}
+```
+
+to:
+
+```ts
+} else if (type === 'pve-cluster') {
+  handlePveCluster(db, hostId, payload);
+}
+```
+
+`hostId` is already in scope at this dispatch site (extracted from the topic earlier in the handler — see `hub/src/mqtt.ts` around the topic-parse block above line 320).
+
+- [ ] **Step 4: Type-check**
+
+Run: `npm run typecheck`
+
+Expected: PASS with no errors.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `npm test`
+
+Expected: PASS. All existing tests still pass; the new `hub-ingest-pve-cluster.test.ts` passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hub/src/mqtt.ts
+git commit -m "feat(hub): handlePveCluster forwards hostId to ingest"
+```
+
+---
+
+## Task 4: Manual verification on vdev (post-deploy smoke test)
+
+This task is for the human operator after the implementation lands and is deployed to the vdev VM via the standard deploy loop (see memory: "insightd VM ops").
+
+- [ ] **Step 1: Deploy hub to vdev**
+
+Use the standard vdev deploy loop (the operator knows the recipe). Confirm the hub container restarts cleanly.
+
+- [ ] **Step 2: Wait one PVE collection cycle (~30s)**
+
+Wait for the proxmox-01 PVE agent to publish at least one `pve-cluster` MQTT message after the new hub starts.
+
+- [ ] **Step 3: Inspect the `hosts` table for the PVE node**
+
+On the vdev VM, use the standard alpine+sqlite recipe (memory: "insightd VM ops") to run:
+
+```sql
+SELECT host_id, proxmox_cluster_id FROM hosts WHERE host_id = 'proxmox-01';
+```
+
+Expected: one row with `proxmox_cluster_id` populated with the actual PVE cluster name (whatever corosync reports — *not* null).
+
+- [ ] **Step 4: Restart an in-guest agent and verify the linked guest gets the cluster_id**
+
+Restart an in-guest agent (e.g., the n8n VM at 10.0.0.125 — see memory). Wait one cycle. Then:
+
+```sql
+SELECT host_id, proxmox_node, proxmox_vmid, proxmox_cluster_id FROM hosts WHERE proxmox_vmid IS NOT NULL;
+```
+
+Expected: every row that has a non-null `proxmox_vmid` (i.e., is linked) has the same `proxmox_cluster_id` as the PVE node.
+
+- [ ] **Step 5: Confirm UI is unaffected**
+
+Open the hub UI. Confirm the host detail page for the n8n VM still shows the hypervisor-link card (PR #249 work). No regression.
+
+- [ ] **Step 6: Tag and release**
+
+If verification passes, the operator can tag a hub release per the standard `hub-v*` tagging recipe. (No agent changes — no `agent-v*` tag needed.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Both writes (pve_cluster_status UPSERT + hosts UPDATE) covered in Task 2 inside one transaction. Signature change propagated through Task 3. Edge cases from spec (no host row, cluster rename, other-host isolation) all covered in Task 1 tests. Standalone-PVE case is implicit — agent never publishes, code path never runs.
+- **No backfill:** intentionally omitted per spec non-goal. Already-linked guests stay null until next identity-hint message naturally re-resolves them.
+- **No matcher change:** the matcher already reads via `LEFT JOIN hosts`. Once the seed lands, future matches pick up cluster_id with zero matcher edits.

--- a/docs/superpowers/specs/2026-05-10-pve-multicluster-id-seeding-design.md
+++ b/docs/superpowers/specs/2026-05-10-pve-multicluster-id-seeding-design.md
@@ -1,0 +1,170 @@
+# PVE Multi-Cluster `cluster_id` Seeding
+
+**Status:** Design approved (2026-05-10), pending implementation plan.
+
+**Follow-up to:** [2026-05-09 Proxmox Guest ↔ Host Auto-Correlation](./2026-05-09-proxmox-guest-host-correlation-design.md) (PR #249), the only remaining v2 item from that work.
+
+## Problem
+
+The identity matcher in `hub/src/identity/matcher.ts` propagates `cluster_id` from the PVE node host's `hosts.proxmox_cluster_id` column to each linked in-guest agent host. Today nothing populates that column for PVE node hosts, so every linked guest gets `cluster_id = null`.
+
+Consequence: in a single-cluster homelab (the current state), this is cosmetic — the linkage still works because the matcher disambiguates on UUID (qemu) or hostname/MAC (lxc). But a second PVE cluster with overlapping VMIDs would cause the matcher to over-match: a guest in cluster A could resolve to a guest in cluster B, since neither side has a real `cluster_id` to scope against.
+
+## Goal
+
+Seed `hosts.proxmox_cluster_id` on each PVE node host with the cluster name reported by that node's `pve-cluster` MQTT message. After this lands, the existing matcher's `LEFT JOIN hosts h ON h.host_id = cs.host_id` resolves a real cluster_id, and `IdentityMatch.cluster_id` propagates onto linked guests on next match.
+
+## Non-goals
+
+- Backfilling already-linked guest hosts. Single-cluster homelab is the current state; null cluster_id on existing links is harmless. The next identity-hint message naturally re-resolves and writes the correct cluster_id.
+- Cross-cluster matcher scoping logic. The matcher already reads cluster_id; no change needed there.
+- Standalone-PVE handling. Standalone agents never publish `pve-cluster` (per `agent/src/scheduler.ts:188`), so `proxmox_cluster_id` stays null and matches today's behavior.
+- Schema changes. `hosts.proxmox_cluster_id` already exists (added with PR #249).
+- Cluster rename / re-cluster handling beyond "next ingest cycle wins". `pve_cluster_status` is keyed on `cluster_name` and accepts whatever each node reports.
+
+## Architecture
+
+```
+┌──────────────┐    insightd/<host>/pve-cluster    ┌────────────────────┐
+│ PVE agent    │  ────────────────────────────►   │ hub MQTT handler   │
+│ (proxmox-01) │  { cluster_name, quorate, ... }   │ handlePveCluster() │
+└──────────────┘                                   └─────────┬──────────┘
+                                                             │
+                                                             ▼
+                                                  ┌────────────────────┐
+                                                  │ ingestPveCluster() │
+                                                  │  (single tx)       │
+                                                  │                    │
+                                                  │  1. UPSERT into    │
+                                                  │     pve_cluster_   │
+                                                  │     status         │
+                                                  │  2. UPDATE hosts   │
+                                                  │     SET proxmox_   │
+                                                  │     cluster_id = ? │
+                                                  │     WHERE host_id  │
+                                                  │     = ?            │
+                                                  └────────────────────┘
+```
+
+**Principle:** the two writes derive from the same MQTT message and represent one atomic state transition for that PVE node — wrap them in `db.transaction` so a hub crash mid-write cannot leave the cluster table updated but the host row stale (or vice versa).
+
+## Component changes
+
+All edits in two files. No new files.
+
+### 1. `hub/src/ingest.ts` — `ingestPveCluster`
+
+Extend the function signature to take `hostId` and wrap both writes in a single transaction.
+
+**Before** (current `hub/src/ingest.ts:850–860`):
+
+```ts
+function ingestPveCluster(db: Database.Database, status: PveClusterRecord): void {
+  db.prepare(`
+    INSERT INTO pve_cluster_status (cluster_name, quorate, total_nodes, online_nodes, observed_at)
+    VALUES (?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(cluster_name) DO UPDATE SET
+      quorate      = excluded.quorate,
+      total_nodes  = excluded.total_nodes,
+      online_nodes = excluded.online_nodes,
+      observed_at  = excluded.observed_at
+  `).run(status.clusterName, status.quorate, status.totalNodes, status.onlineNodes);
+}
+```
+
+**After:**
+
+```ts
+function ingestPveCluster(db: Database.Database, hostId: string, status: PveClusterRecord): void {
+  const upsertCluster = db.prepare(`
+    INSERT INTO pve_cluster_status (cluster_name, quorate, total_nodes, online_nodes, observed_at)
+    VALUES (?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(cluster_name) DO UPDATE SET
+      quorate      = excluded.quorate,
+      total_nodes  = excluded.total_nodes,
+      online_nodes = excluded.online_nodes,
+      observed_at  = excluded.observed_at
+  `);
+  const seedHostClusterId = db.prepare(`
+    UPDATE hosts SET proxmox_cluster_id = ? WHERE host_id = ?
+  `);
+  db.transaction(() => {
+    upsertCluster.run(status.clusterName, status.quorate, status.totalNodes, status.onlineNodes);
+    seedHostClusterId.run(status.clusterName, hostId);
+  })();
+}
+```
+
+Also update the type assertion in `module.exports` at `hub/src/ingest.ts:937` and the import-side type in `hub/src/mqtt.ts:28`.
+
+### 2. `hub/src/mqtt.ts` — `handlePveCluster`
+
+Take `hostId` and forward it.
+
+**Before** (`hub/src/mqtt.ts:870`):
+
+```ts
+function handlePveCluster(db: Database.Database, payload: PveClusterPayload): void {
+  ingestPveCluster(db, { ... });
+  ...
+}
+```
+
+**After:**
+
+```ts
+function handlePveCluster(db: Database.Database, hostId: string, payload: PveClusterPayload): void {
+  ingestPveCluster(db, hostId, { ... });
+  ...
+}
+```
+
+Dispatch site (`hub/src/mqtt.ts:340`):
+
+```ts
+} else if (type === 'pve-cluster') {
+  handlePveCluster(db, hostId, payload);
+}
+```
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Standalone PVE (no cluster) | Agent's `collectClusterStatus` returns null, `publishPveCluster` is skipped, `handlePveCluster` never runs. `hosts.proxmox_cluster_id` stays null. Matches today. |
+| PVE node host row not yet upserted when first `pve-cluster` arrives | `UPDATE … WHERE host_id = ?` matches zero rows. Silent no-op. Next cycle (after the node's first `collection` upserts the host row) will succeed. |
+| Cluster renamed in PVE | New `cluster_name` from corosync. New row in `pve_cluster_status` (PK is `cluster_name`, old row orphans — pre-existing behavior, out of scope). PVE node host's `proxmox_cluster_id` overwritten with new name on next cycle. Linked guests keep stale name until next identity-hint message re-resolves them. |
+| Multiple PVE nodes in same cluster | Each independently UPDATEs its own `hosts` row to the same `cluster_name`. Idempotent. |
+| PVE node moved to a different cluster | Next `pve-cluster` cycle reports new `cluster_name`. Host's `proxmox_cluster_id` overwritten. Linked guests catch up on next identity-hint. |
+| Already-linked guests with null `cluster_id` | Stay null until next identity-hint MQTT message fires the matcher. Acceptable per non-goal. |
+
+## Testing
+
+One new unit test in `tests/unit/ingest-pve-cluster.test.ts`:
+
+- **Seed → assert host updated.** Insert a row into `hosts` with `host_id='proxmox-01'`. Call `ingestPveCluster(db, 'proxmox-01', { clusterName: 'homelab', quorate: 1, totalNodes: 3, onlineNodes: 3 })`. Assert `pve_cluster_status` row exists AND `hosts.proxmox_cluster_id = 'homelab'` for `proxmox-01`.
+- **Update on cluster rename.** Run twice with different `clusterName`. Assert the second value wins.
+- **No host row → silent no-op.** Call without inserting `hosts` row first. Assert no error, no `hosts` row created.
+- **Other hosts untouched.** Insert two `hosts` rows; call for one. Assert the other's `proxmox_cluster_id` stays null.
+
+Existing matcher tests already cover the `cluster_id` propagation path (since the matcher reads it via JOIN); no changes needed there.
+
+**Manual UX test on vdev VM after deploy:**
+
+1. Deploy to vdev. Confirm `proxmox-01` PVE agent publishes `pve-cluster`.
+2. `sqlite3` query: `SELECT host_id, proxmox_cluster_id FROM hosts WHERE host_id='proxmox-01';` — expect cluster name, not null.
+3. Restart an in-guest agent (e.g. n8n VM). Confirm its identity hint fires the matcher, then query `hosts` for the in-guest agent's host_id — expect `proxmox_cluster_id` populated with same cluster name.
+
+## Migration & rollout
+
+- No schema change. Column exists.
+- Backwards compatible: old PVE agents publish the same `pve-cluster` payload; the new hostId comes from the MQTT topic, not the payload. Mixed-version environments work.
+- No backfill. Existing links naturally re-resolve on next identity-hint cycle.
+
+## Surface summary
+
+- 2 files touched (`hub/src/ingest.ts`, `hub/src/mqtt.ts`)
+- 1 new unit test file (~4 cases)
+- 0 schema migrations
+- 0 new MQTT topics
+- 0 API or UI changes

--- a/hub/src/ingest.ts
+++ b/hub/src/ingest.ts
@@ -847,8 +847,8 @@ function ingestPveZfs(db: Database.Database, hostId: string, items: PveZfsRecord
  * Hub stores nothing on standalone PVE installs (publishPveCluster
  * short-circuits when the agent's collectClusterStatus returns null).
  */
-function ingestPveCluster(db: Database.Database, status: PveClusterRecord): void {
-  db.prepare(`
+function ingestPveCluster(db: Database.Database, hostId: string, status: PveClusterRecord): void {
+  const upsertCluster = db.prepare(`
     INSERT INTO pve_cluster_status (cluster_name, quorate, total_nodes, online_nodes, observed_at)
     VALUES (?, ?, ?, ?, datetime('now'))
     ON CONFLICT(cluster_name) DO UPDATE SET
@@ -856,7 +856,14 @@ function ingestPveCluster(db: Database.Database, status: PveClusterRecord): void
       total_nodes  = excluded.total_nodes,
       online_nodes = excluded.online_nodes,
       observed_at  = excluded.observed_at
-  `).run(status.clusterName, status.quorate, status.totalNodes, status.onlineNodes);
+  `);
+  const seedHostClusterId = db.prepare(`
+    UPDATE hosts SET proxmox_cluster_id = ? WHERE host_id = ?
+  `);
+  db.transaction(() => {
+    upsertCluster.run(status.clusterName, status.quorate, status.totalNodes, status.onlineNodes);
+    seedHostClusterId.run(status.clusterName, hostId);
+  })();
 }
 
 interface PveGuestSnapshotRecord {

--- a/hub/src/ingest.ts
+++ b/hub/src/ingest.ts
@@ -846,6 +846,9 @@ function ingestPveZfs(db: Database.Database, hostId: string, items: PveZfsRecord
  * every PVE node publishes the same row each cycle and last write wins.
  * Hub stores nothing on standalone PVE installs (publishPveCluster
  * short-circuits when the agent's collectClusterStatus returns null).
+ *
+ * Also seeds hosts.proxmox_cluster_id on the publishing PVE node host
+ * so the identity matcher can resolve cluster_id for linked guests.
  */
 function ingestPveCluster(db: Database.Database, hostId: string, status: PveClusterRecord): void {
   const upsertCluster = db.prepare(`

--- a/hub/src/mqtt.ts
+++ b/hub/src/mqtt.ts
@@ -25,7 +25,7 @@ const { ingestContainers, ingestDisk, ingestVolumes, ingestPvs, ingestPvcs, inge
   ingestHost: (db: Database.Database, hostId: string, metrics: any) => void;
   ingestPveStorage: (db: Database.Database, hostId: string, items: any[]) => void;
   ingestPveZfs: (db: Database.Database, hostId: string, items: any[]) => void;
-  ingestPveCluster: (db: Database.Database, status: any) => void;
+  ingestPveCluster: (db: Database.Database, hostId: string, status: any) => void;
   ingestPveGuestSnapshots: (db: Database.Database, hostId: string, items: any[]) => void;
   ingestPveBackups: (db: Database.Database, hostId: string, items: any[]) => void;
 };
@@ -337,7 +337,7 @@ function startSubscriber(db: Database.Database, config: MqttConfig): Promise<Mqt
         } else if (type === 'pve-zfs') {
           handlePveZfs(db, hostId, payload);
         } else if (type === 'pve-cluster') {
-          handlePveCluster(db, payload);
+          handlePveCluster(db, hostId, payload);
         } else if (type === 'pve-guest-snapshots') {
           handlePveGuestSnapshots(db, hostId, payload);
         } else if (type === 'pve-backups') {
@@ -867,8 +867,8 @@ function handlePveZfs(db: Database.Database, hostId: string, payload: PveZfsPayl
   logger.info('mqtt', `Ingested ${items.length} ZFS pools from ${hostId}`);
 }
 
-function handlePveCluster(db: Database.Database, payload: PveClusterPayload): void {
-  ingestPveCluster(db, {
+function handlePveCluster(db: Database.Database, hostId: string, payload: PveClusterPayload): void {
+  ingestPveCluster(db, hostId, {
     clusterName: payload.cluster_name,
     quorate: payload.quorate,
     totalNodes: payload.total_nodes,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import logger = require('../utils/logger');
 
-const SCHEMA_VERSION = 50;
+const SCHEMA_VERSION = 51;
 
 function bootstrap(db: Database.Database): void {
   db.exec(`
@@ -18,7 +18,11 @@ function bootstrap(db: Database.Database): void {
       runtime_type  TEXT NOT NULL DEFAULT 'docker',
       host_group    TEXT,
       host_group_override TEXT,
-      host_labels   TEXT  -- v48: agent-reported labels (Proxmox identity bridge in PR4+)
+      host_labels   TEXT,  -- v48: agent-reported labels (Proxmox identity bridge in PR4+)
+      proxmox_cluster_id TEXT, -- v51: PVE cluster the host belongs to (seeded from pve-cluster MQTT)
+      proxmox_node TEXT,
+      proxmox_vmid INTEGER,
+      proxmox_guest_type TEXT
     );
 
     CREATE TABLE IF NOT EXISTS container_snapshots (
@@ -1222,6 +1226,20 @@ function migrate(db: Database.Database, fromVersion: number): void {
         PRIMARY KEY (host_id, guest_vmid)
       );
     `);
+  }
+  if (fromVersion < 51) {
+    // v51: Proxmox guest <-> host correlation (mirrors hub/src/db/schema.ts v51 migration)
+    try { db.exec('ALTER TABLE hosts ADD COLUMN proxmox_cluster_id TEXT'); } catch { /* already exists */ }
+    try { db.exec('ALTER TABLE hosts ADD COLUMN proxmox_node TEXT'); } catch { /* already exists */ }
+    try { db.exec('ALTER TABLE hosts ADD COLUMN proxmox_vmid INTEGER'); } catch { /* already exists */ }
+    try { db.exec('ALTER TABLE hosts ADD COLUMN proxmox_guest_type TEXT'); } catch { /* already exists */ }
+    try {
+      db.exec(`CREATE INDEX IF NOT EXISTS hosts_proxmox_link
+               ON hosts (proxmox_cluster_id, proxmox_vmid)
+               WHERE proxmox_vmid IS NOT NULL`);
+    } catch { /* already exists */ }
+    try { db.exec('ALTER TABLE container_snapshots ADD COLUMN guest_uuid TEXT'); } catch { /* already exists */ }
+    try { db.exec('ALTER TABLE container_snapshots ADD COLUMN guest_primary_mac TEXT'); } catch { /* already exists */ }
   }
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1238,8 +1238,6 @@ function migrate(db: Database.Database, fromVersion: number): void {
                ON hosts (proxmox_cluster_id, proxmox_vmid)
                WHERE proxmox_vmid IS NOT NULL`);
     } catch { /* already exists */ }
-    try { db.exec('ALTER TABLE container_snapshots ADD COLUMN guest_uuid TEXT'); } catch { /* already exists */ }
-    try { db.exec('ALTER TABLE container_snapshots ADD COLUMN guest_primary_mac TEXT'); } catch { /* already exists */ }
   }
 }
 

--- a/tests/unit/hub-ingest-pve-cluster.test.ts
+++ b/tests/unit/hub-ingest-pve-cluster.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+const { createTestDb } = require('../helpers/db');
+const { ingestPveCluster, upsertHost } = require('../../hub/src/ingest');
+
+interface HostRow { host_id: string; proxmox_cluster_id: string | null }
+interface ClusterRow { cluster_name: string; quorate: number; total_nodes: number; online_nodes: number }
+
+function status(clusterName: string, overrides: Partial<{ quorate: number; totalNodes: number; onlineNodes: number }> = {}) {
+  return {
+    clusterName,
+    quorate: overrides.quorate ?? 1,
+    totalNodes: overrides.totalNodes ?? 3,
+    onlineNodes: overrides.onlineNodes ?? 3,
+  };
+}
+
+describe('ingestPveCluster', () => {
+  let db: any;
+  beforeEach(() => { db = createTestDb(); });
+  afterEach(() => { db.close(); });
+
+  it('seeds hosts.proxmox_cluster_id for the publishing PVE node', () => {
+    upsertHost(db, 'proxmox-01');
+    ingestPveCluster(db, 'proxmox-01', status('homelab'));
+    const cluster = db.prepare('SELECT * FROM pve_cluster_status WHERE cluster_name = ?').get('homelab') as ClusterRow | undefined;
+    assert.ok(cluster, 'pve_cluster_status row exists');
+    assert.equal(cluster!.quorate, 1);
+    const host = db.prepare('SELECT host_id, proxmox_cluster_id FROM hosts WHERE host_id = ?').get('proxmox-01') as HostRow | undefined;
+    assert.equal(host?.proxmox_cluster_id, 'homelab');
+  });
+
+  it('updates host cluster_id when the cluster is renamed', () => {
+    upsertHost(db, 'proxmox-01');
+    ingestPveCluster(db, 'proxmox-01', status('old-name'));
+    ingestPveCluster(db, 'proxmox-01', status('new-name'));
+    const host = db.prepare('SELECT proxmox_cluster_id FROM hosts WHERE host_id = ?').get('proxmox-01') as HostRow | undefined;
+    assert.equal(host?.proxmox_cluster_id, 'new-name');
+  });
+
+  it('is a silent no-op when the host row does not yet exist', () => {
+    ingestPveCluster(db, 'unknown-node', status('homelab'));
+    const cluster = db.prepare('SELECT * FROM pve_cluster_status WHERE cluster_name = ?').get('homelab') as ClusterRow | undefined;
+    assert.ok(cluster, 'pve_cluster_status row written even without host row');
+    const host = db.prepare('SELECT host_id FROM hosts WHERE host_id = ?').get('unknown-node') as HostRow | undefined;
+    assert.equal(host, undefined, 'no host row created by ingestPveCluster');
+  });
+
+  it('does not modify other host rows', () => {
+    upsertHost(db, 'proxmox-01');
+    upsertHost(db, 'other-host');
+    ingestPveCluster(db, 'proxmox-01', status('homelab'));
+    const other = db.prepare('SELECT proxmox_cluster_id FROM hosts WHERE host_id = ?').get('other-host') as HostRow | undefined;
+    assert.equal(other?.proxmox_cluster_id, null);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #249. Seeds `hosts.proxmox_cluster_id` on the publishing PVE node host when the hub ingests a `pve-cluster` MQTT message. The identity matcher already reads `cluster_id` via `LEFT JOIN hosts h ON h.host_id = cs.host_id`, so future matches naturally pick up the cluster name for linked guests instead of always-null. Single-cluster homelabs are unaffected (cosmetic today); multi-cluster setups with overlapping VMIDs no longer over-match.

- `ingestPveCluster(db, hostId, status)` — gains `hostId`, wraps the existing UPSERT plus a new `UPDATE hosts SET proxmox_cluster_id = ? WHERE host_id = ?` in one `db.transaction`.
- `handlePveCluster(db, hostId, payload)` — threads `hostId` through; dispatch site at the `pve-cluster` topic branch updated.
- `src/db/schema.ts` — bumped to v51, mirrors hub's four `proxmox_*` columns into the standalone `hosts` bootstrap (needed because `tests/helpers/db.ts` bootstraps from this file).

No backfill of already-linked guests — they re-resolve naturally on next identity-hint message. No matcher change.

Spec: `docs/superpowers/specs/2026-05-10-pve-multicluster-id-seeding-design.md`
Plan: `docs/superpowers/plans/2026-05-10-pve-multicluster-id-seeding.md`

## Test Plan

- [x] 4 new unit tests in `tests/unit/hub-ingest-pve-cluster.test.ts` (seed, rename, no-host-row no-op, other-host isolation)
- [x] Full suite: 1313 pass, 0 fail
- [x] `npm run typecheck` clean
- [ ] Manual vdev verification (Task 4 of plan): deploy → query `SELECT host_id, proxmox_cluster_id FROM hosts WHERE host_id='proxmox-01'` (expect cluster name, not null) → restart in-guest agent → query linked guest rows for matching `proxmox_cluster_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)