### PR TITLE
Disk-fill ETA insights (Linux disks + Proxmox storage)

### DIFF
--- a/docs/superpowers/plans/2026-05-10-disk-fill-eta-plan.md
+++ b/docs/superpowers/plans/2026-05-10-disk-fill-eta-plan.md
@@ -182,10 +182,10 @@ describe('dailyTrend helper', () => {
   it('returns null when fewer than half of day pairs agree with positive trend', () => {
     const daily = [
       { day: 'd1', avg: 50 },
-      { day: 'd2', avg: 60 },
-      { day: 'd3', avg: 55 },
+      { day: 'd2', avg: 50 },
+      { day: 'd3', avg: 50 },
       { day: 'd4', avg: 50 },
-      { day: 'd5', avg: 60 },  // last - first = 10, but only 2/4 days are increasing
+      { day: 'd5', avg: 60 },  // last - first = 10, but only 1/4 pairs are increasing
     ];
     const out = dailyTrend(daily, 0.05);
     assert.equal(out, null);

--- a/docs/superpowers/plans/2026-05-10-disk-fill-eta-plan.md
+++ b/docs/superpowers/plans/2026-05-10-disk-fill-eta-plan.md
@@ -1,0 +1,990 @@
+# Disk-Fill ETA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Predict when a Linux disk mount or Proxmox storage pool will fill within 14 days, surface as a `prediction`-category insight.
+
+**Architecture:** New module `hub/src/insights/disk-fill.ts` exposes `generateDiskFillInsights(db)`. It is called once per insights cycle from `generateInsights` in `detector.ts`, builds its own 12-column INSERT prepared statement (matching right-sizing), and reads `disk_snapshots`, `pve_storage_snapshots`, and `alert_state`. Trend math mirrors `computeMetricTrend` (daily averages over 7d, ≥4 days required, ≥1% relative growth, ≥half day-pairs consistent in direction).
+
+**Tech Stack:** Node.js 20, TypeScript (strict), better-sqlite3, node:test + tsx.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-disk-fill-eta-design.md`
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `hub/src/insights/disk-fill.ts` | create | Self-contained module: trend helper, disk-snapshots loop, pve-storage loop, alert-dedup query, `generateDiskFillInsights` export. ~150 lines. |
+| `tests/unit/detector-disk-fill.test.ts` | create | TDD harness. Seeds raw snapshots, calls `generateInsights`, asserts on the `insights` table. ~300 lines. |
+| `hub/src/insights/detector.ts` | modify | Add one require + one call inside `generateInsights` to wire `generateDiskFillInsights` into the cycle. |
+
+No schema changes. No frontend changes (existing `InsightsPage.tsx` renders `prediction` insights with the 🔮 icon and severity grouping; the percent metric already routes to the percent formatter).
+
+## Conventions to mirror
+
+- **CommonJS exports** at the bottom: `module.exports = { generateDiskFillInsights };`. Match `proxmox-checks.ts` and `detector.ts` patterns. Caller in `detector.ts` will use `require('./disk-fill')`.
+- **Local 12-column INSERT prepared statement** built inside the module — same as `generateRightSizingInsights` (`detector.ts:771-783`). The 10-column shared `insert` argument is unused; right-sizing accepts it as `_insert` for symmetry. Mirror that.
+- **Test scaffolding:** `node:test` + `assert/strict`, `createTestDb()` from `tests/helpers/db`, `suppressConsole()` from `tests/helpers/mocks`. Schema bootstrap is automatic via `createTestDb`.
+- **Insight inserts** go through the local prepared statement; the cycle-start `DELETE FROM insights` in `generateInsights` already clears prior rows, so the test only needs to call `generateInsights(db)` once and read the table back.
+
+---
+
+## Task 1: Create empty disk-fill module + wire into detector
+
+**Files:**
+- Create: `hub/src/insights/disk-fill.ts`
+- Modify: `hub/src/insights/detector.ts` (one require, one call inside `generateInsights`)
+
+**Why first:** Establishes the import wiring before any logic. After this task the module exists, exports a no-op, and is invoked each cycle. All later tasks add behavior + tests.
+
+- [ ] **Step 1: Create `hub/src/insights/disk-fill.ts` with a no-op export**
+
+```ts
+/**
+ * Disk-fill ETA predictions. One insight per (host, mount) or (host, storage)
+ * that will reach saturation within 14 days at the current 7-day growth
+ * rate. Sibling to right-sizing and proxmox-checks — runs from the
+ * generateInsights cycle and writes into the shared `insights` table under
+ * category 'prediction'.
+ */
+import type Database from 'better-sqlite3';
+
+export function generateDiskFillInsights(db: Database.Database): number {
+  void db;
+  return 0;
+}
+
+module.exports = { generateDiskFillInsights };
+```
+
+- [ ] **Step 2: Wire the call into `generateInsights` in `detector.ts`**
+
+Find the existing call site (around line 386):
+```ts
+  const { generateProxmoxInsights } = require('./proxmox-checks') as typeof import('./proxmox-checks');
+  count += generateProxmoxInsights(db, insert);
+```
+
+Add immediately after it:
+```ts
+  const { generateDiskFillInsights } = require('./disk-fill') as typeof import('./disk-fill');
+  count += generateDiskFillInsights(db);
+```
+
+(`generateDiskFillInsights` only takes `db` — the right-sizing-style local prepared statement is internal to the module, so no `insert` is passed.)
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run typecheck`
+Expected: passes (no errors).
+
+- [ ] **Step 4: Run existing test suite to confirm no regression**
+
+Run: `npm test`
+Expected: all existing tests pass. The new module is invoked but does nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hub/src/insights/disk-fill.ts hub/src/insights/detector.ts
+git commit -m "scaffold disk-fill module + wire into generateInsights"
+```
+
+---
+
+## Task 2: Add a daily-average trend helper + its unit test
+
+**Files:**
+- Create: `tests/unit/detector-disk-fill.test.ts`
+- Modify: `hub/src/insights/disk-fill.ts`
+
+The helper computes the same shape as `computeMetricTrend` but parameterized to read `total_gb`/`used_gb` from `disk_snapshots`. Returns `null` when the trend is too weak or noisy. Direct unit tests up-front make later tasks easier — they can build on a known-good trend primitive.
+
+- [ ] **Step 1: Create the test file with the helper exposed for testing**
+
+Add to `disk-fill.ts` a helper export so the test can call it directly:
+
+```ts
+export interface DailyAvg { day: string; avg: number }
+
+/**
+ * Compute a daily-averaged growth slope from rows already grouped by
+ * day and ordered ascending by day. Returns null when the trend fails any
+ * of the consistency / minimum-growth filters. Mirrors the rejection
+ * conditions of detector.ts::computeMetricTrend.
+ */
+export function dailyTrend(
+  daily: DailyAvg[],
+  minAbsoluteGrowth: number,
+): { current: number; dailyGrowth: number; dayCount: number } | null {
+  if (daily.length < 4) return null;
+  const first = daily[0]!.avg;
+  const last = daily[daily.length - 1]!.avg;
+  const days = daily.length - 1;
+  const dailyGrowth = (last - first) / days;
+  if (last > 0 && Math.abs(dailyGrowth / last) < 0.01) return null;
+  if (Math.abs(dailyGrowth) < minAbsoluteGrowth) return null;
+  let increasing = 0;
+  let decreasing = 0;
+  for (let i = 1; i < daily.length; i++) {
+    const diff = daily[i]!.avg - daily[i - 1]!.avg;
+    if (diff > 0) increasing++;
+    else if (diff < 0) decreasing++;
+  }
+  if (dailyGrowth > 0 && increasing < Math.ceil(days / 2)) return null;
+  if (dailyGrowth < 0 && decreasing < Math.ceil(days / 2)) return null;
+  return { current: last, dailyGrowth, dayCount: daily.length };
+}
+```
+
+Update bottom of file:
+```ts
+module.exports = { generateDiskFillInsights, dailyTrend };
+```
+
+- [ ] **Step 2: Write the unit test for `dailyTrend`**
+
+Create `tests/unit/detector-disk-fill.test.ts`:
+
+```ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+const { dailyTrend } = require('../../hub/src/insights/disk-fill');
+
+describe('dailyTrend helper', () => {
+  it('returns null when fewer than 4 days', () => {
+    const daily = [
+      { day: '2026-05-04', avg: 50 },
+      { day: '2026-05-05', avg: 51 },
+      { day: '2026-05-06', avg: 52 },
+    ];
+    assert.equal(dailyTrend(daily, 0.05), null);
+  });
+
+  it('returns null when relative growth < 1% of current', () => {
+    const daily = Array.from({ length: 7 }, (_, i) => ({
+      day: `2026-05-0${i + 1}`,
+      avg: 1000 + i * 0.5, // 0.5 GB/day on a 1000 GB current = 0.05% — under floor
+    }));
+    assert.equal(dailyTrend(daily, 0.05), null);
+  });
+
+  it('returns null when absolute growth < minimum', () => {
+    const daily = Array.from({ length: 7 }, (_, i) => ({
+      day: `2026-05-0${i + 1}`,
+      avg: 50 + i * 0.01, // 0.01 GB/day, below 0.05 GB/day floor
+    }));
+    assert.equal(dailyTrend(daily, 0.05), null);
+  });
+
+  it('returns null when fewer than half of day pairs agree with positive trend', () => {
+    const daily = [
+      { day: 'd1', avg: 50 },
+      { day: 'd2', avg: 60 },
+      { day: 'd3', avg: 55 },
+      { day: 'd4', avg: 50 },
+      { day: 'd5', avg: 60 },  // last - first = 10, but only 2/4 days are increasing
+    ];
+    const out = dailyTrend(daily, 0.05);
+    assert.equal(out, null);
+  });
+
+  it('returns slope, current, dayCount on a clean rising trend', () => {
+    const daily = Array.from({ length: 7 }, (_, i) => ({
+      day: `2026-05-0${i + 1}`,
+      avg: 50 + i * 1, // 1 GB/day
+    }));
+    const out = dailyTrend(daily, 0.05);
+    assert.ok(out);
+    assert.equal(out!.dayCount, 7);
+    assert.equal(out!.current, 56);
+    assert.equal(Math.round(out!.dailyGrowth * 100) / 100, 1);
+  });
+});
+```
+
+- [ ] **Step 3: Run only this test file, expect green**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hub/src/insights/disk-fill.ts tests/unit/detector-disk-fill.test.ts
+git commit -m "add dailyTrend helper + unit tests"
+```
+
+---
+
+## Task 3: Test scaffolding for end-to-end disk-fill insight assertions
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts`
+
+Add a second `describe` block with seed/query helpers shared by all detector-level cases.
+
+- [ ] **Step 1: Append the integration-test scaffolding**
+
+Add to the test file, after the `describe('dailyTrend helper', …)` block:
+
+```ts
+const { createTestDb } = require('../helpers/db');
+const { suppressConsole } = require('../helpers/mocks');
+const { generateInsights } = require('../../hub/src/insights/detector');
+
+interface InsightRow {
+  entity_type: string; entity_id: string; category: string; severity: string;
+  title: string; message: string; metric: string | null;
+  current_value: number | null; baseline_value: number | null;
+  evidence: string | null; suggested_action: string | null; confidence: string | null;
+}
+
+describe('detector — disk-fill ETA insights', () => {
+  let db: any;
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = suppressConsole();
+    db = createTestDb();
+    db.prepare(`INSERT INTO hosts (host_id, first_seen, last_seen) VALUES ('node-1', datetime('now'), datetime('now'))`).run();
+  });
+
+  afterEach(() => {
+    db.close();
+    restore();
+  });
+
+  /**
+   * Seed N days of disk snapshots, one per day at noon, with linear growth.
+   * day 0 = 7 days ago. day 6 = today. usedAtDayN = startGb + dailyGrowthGb * N.
+   */
+  function seedDisk(opts: {
+    hostId?: string;
+    mount?: string;
+    totalGb: number;
+    startGb: number;
+    dailyGrowthGb: number;
+    days?: number;
+  }): void {
+    const hostId = opts.hostId ?? 'node-1';
+    const mount = opts.mount ?? '/';
+    const totalGb = opts.totalGb;
+    const days = opts.days ?? 7;
+    for (let d = 0; d < days; d++) {
+      const usedGb = opts.startGb + opts.dailyGrowthGb * d;
+      const usedPct = (usedGb / totalGb) * 100;
+      const at = `datetime('now', '-${days - 1 - d} days')`;
+      db.prepare(`
+        INSERT INTO disk_snapshots (host_id, mount_point, total_gb, used_gb, used_percent, collected_at)
+        VALUES (?, ?, ?, ?, ?, ${at})
+      `).run(hostId, mount, totalGb, usedGb, usedPct);
+    }
+  }
+
+  /**
+   * Seed N days of pve_storage snapshots in bytes. Mirrors seedDisk shape.
+   */
+  function seedPveStorage(opts: {
+    hostId?: string;
+    storageName?: string;
+    storageType?: string;
+    totalBytes: number;
+    startBytes: number;
+    dailyGrowthBytes: number;
+    days?: number;
+    active?: number;
+  }): void {
+    const hostId = opts.hostId ?? 'node-1';
+    const storageName = opts.storageName ?? 'local-zfs';
+    const storageType = opts.storageType ?? 'zfspool';
+    const days = opts.days ?? 7;
+    const active = opts.active ?? 1;
+    for (let d = 0; d < days; d++) {
+      const used = opts.startBytes + opts.dailyGrowthBytes * d;
+      const at = `datetime('now', '-${days - 1 - d} days')`;
+      db.prepare(`
+        INSERT INTO pve_storage_snapshots (host_id, storage_name, storage_type, total_bytes, used_bytes, active, shared, collected_at)
+        VALUES (?, ?, ?, ?, ?, ?, 0, ${at})
+      `).run(hostId, storageName, storageType, opts.totalBytes, used, active);
+    }
+  }
+
+  function getDiskFillInsights(): InsightRow[] {
+    return db.prepare(
+      `SELECT entity_type, entity_id, category, severity, title, message, metric,
+              current_value, baseline_value, evidence, suggested_action, confidence
+       FROM insights
+       WHERE category = 'prediction'
+         AND (metric = 'disk_used_percent' OR metric = 'pve_storage_used_percent')`
+    ).all() as InsightRow[];
+  }
+
+  // Tests will be added in subsequent tasks — start with a smoke test that
+  // confirms the no-op module runs cleanly inside generateInsights.
+  it('runs cleanly with no disk data', () => {
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
+  });
+});
+```
+
+Add these imports at the top of the file (next to existing ones):
+```ts
+import { beforeEach, afterEach } from 'node:test';
+```
+
+- [ ] **Step 2: Run the test file**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: PASS — 5 helper tests + 1 smoke test = 6 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/detector-disk-fill.test.ts
+git commit -m "add detector-disk-fill integration test scaffold"
+```
+
+---
+
+## Task 4: Implement disk-snapshots path — warning case (TDD)
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts` (add failing test)
+- Modify: `hub/src/insights/disk-fill.ts` (implement disk loop to make it pass)
+
+- [ ] **Step 1: Add the failing warning-case test**
+
+Inside the `describeIntegration('detector — disk-fill ETA insights', …)` block, append:
+
+```ts
+it('fires a warning insight when disk fills in 8 days at 5 GB/day on a 100 GB disk at 60%', () => {
+  // 60 GB used today, growing 5 GB/day. Remaining = 40 GB → 8 days. Warning band.
+  seedDisk({ totalGb: 100, startGb: 55, dailyGrowthGb: 5 / 6 * 6 / 6 });
+  // The math: with 7 daily samples spanning days 0..6, last-first = 6 * dailyGrowth.
+  // For dailyGrowth=5 we need startGb such that day-6 = 60. startGb = 60 - 5*6 = 30.
+  // Reseed cleanly.
+  db.prepare('DELETE FROM disk_snapshots').run();
+  seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+
+  generateInsights(db);
+
+  const insights = getDiskFillInsights();
+  assert.equal(insights.length, 1, `expected one disk-fill insight, got: ${JSON.stringify(insights)}`);
+  const i = insights[0]!;
+  assert.equal(i.entity_type, 'host');
+  assert.equal(i.entity_id, 'node-1');
+  assert.equal(i.severity, 'warning');
+  assert.equal(i.metric, 'disk_used_percent');
+  assert.match(i.title, /Disk "\/" on node-1 filling up/);
+  assert.match(i.message, /full in ~8 days/);
+  assert.equal(i.confidence, 'medium');
+});
+```
+
+- [ ] **Step 2: Run the test, expect FAIL**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 1 test fails (`expected one disk-fill insight, got: []`). Helper tests + smoke test still pass.
+
+- [ ] **Step 3: Implement the disk path**
+
+Replace the body of `disk-fill.ts` with:
+
+```ts
+/**
+ * Disk-fill ETA predictions. One insight per (host, mount) or (host, storage)
+ * that will reach saturation within 14 days at the current 7-day growth
+ * rate. Sibling to right-sizing and proxmox-checks — runs from the
+ * generateInsights cycle and writes into the shared `insights` table under
+ * category 'prediction'.
+ */
+import type Database from 'better-sqlite3';
+
+const FLOOR_USED_PERCENT = 50;
+const HORIZON_DAYS = 14;
+const CRITICAL_DAYS = 3;
+const MIN_DISK_GROWTH_GB = 0.05;       // 50 MB/day
+const MIN_PVE_GROWTH_BYTES = 50 * 1024 * 1024; // 50 MB/day
+
+export interface DailyAvg { day: string; avg: number }
+
+export function dailyTrend(
+  daily: DailyAvg[],
+  minAbsoluteGrowth: number,
+): { current: number; dailyGrowth: number; dayCount: number } | null {
+  if (daily.length < 4) return null;
+  const first = daily[0]!.avg;
+  const last = daily[daily.length - 1]!.avg;
+  const days = daily.length - 1;
+  const dailyGrowth = (last - first) / days;
+  if (last > 0 && Math.abs(dailyGrowth / last) < 0.01) return null;
+  if (Math.abs(dailyGrowth) < minAbsoluteGrowth) return null;
+  let increasing = 0;
+  let decreasing = 0;
+  for (let i = 1; i < daily.length; i++) {
+    const diff = daily[i]!.avg - daily[i - 1]!.avg;
+    if (diff > 0) increasing++;
+    else if (diff < 0) decreasing++;
+  }
+  if (dailyGrowth > 0 && increasing < Math.ceil(days / 2)) return null;
+  if (dailyGrowth < 0 && decreasing < Math.ceil(days / 2)) return null;
+  return { current: last, dailyGrowth, dayCount: daily.length };
+}
+
+interface DiskRow { host_id: string; mount_point: string; total_gb: number; used_gb: number; used_percent: number }
+interface DailyDiskRow { day: string; avg: number | null }
+
+function generateDiskInsights(db: Database.Database, insert: ReturnType<Database.Database['prepare']>): number {
+  let count = 0;
+  // Latest snapshot per (host, mount).
+  const latest = db.prepare(`
+    SELECT host_id, mount_point, total_gb, used_gb, used_percent
+    FROM disk_snapshots ds
+    WHERE collected_at = (
+      SELECT MAX(collected_at) FROM disk_snapshots
+      WHERE host_id = ds.host_id AND mount_point = ds.mount_point
+    )
+  `).all() as DiskRow[];
+
+  for (const row of latest) {
+    if (!row.total_gb || row.total_gb <= 0) continue;
+    if (row.used_percent < FLOOR_USED_PERCENT) continue;
+    if (row.used_gb >= row.total_gb) continue;
+    if (alertOpen(db, row.host_id, row.mount_point, 'disk_full')) continue;
+
+    const daily = db.prepare(`
+      SELECT DATE(collected_at) AS day, AVG(used_gb) AS avg
+      FROM disk_snapshots
+      WHERE host_id = ? AND mount_point = ?
+        AND collected_at >= datetime('now', '-7 days')
+      GROUP BY DATE(collected_at)
+      ORDER BY day
+    `).all(row.host_id, row.mount_point) as DailyDiskRow[];
+    const cleaned = daily.filter((r): r is { day: string; avg: number } => r.avg != null);
+
+    const trend = dailyTrend(cleaned, MIN_DISK_GROWTH_GB);
+    if (!trend || trend.dailyGrowth <= 0) continue;
+
+    const remainingGb = row.total_gb - trend.current;
+    const daysUntil = Math.round(remainingGb / trend.dailyGrowth);
+    if (daysUntil <= 0 || daysUntil > HORIZON_DAYS) continue;
+
+    const severity: 'critical' | 'warning' = daysUntil <= CRITICAL_DAYS ? 'critical' : 'warning';
+    const dayWord = daysUntil === 1 ? 'day' : 'days';
+    const usedPct = round1((trend.current / row.total_gb) * 100);
+    const evidence = JSON.stringify({
+      mount_point: row.mount_point,
+      used_gb: round1(trend.current),
+      total_gb: round1(row.total_gb),
+      daily_growth_gb: round2(trend.dailyGrowth),
+      day_count: trend.dayCount,
+    });
+
+    insert.run(
+      'host', row.host_id, 'prediction', severity,
+      `Disk "${row.mount_point}" on ${row.host_id} filling up`,
+      `${row.mount_point} at ${usedPct}% (${round1(trend.current)}/${round1(row.total_gb)} GB), growing ${round2(trend.dailyGrowth)} GB/day — full in ~${daysUntil} ${dayWord}`,
+      'disk_used_percent', usedPct, 100, evidence,
+      `Check largest consumers: \`du -h ${row.mount_point} | sort -h | tail -20\`. Common causes: log rotation broken, container volumes, package cache.`,
+      'medium',
+    );
+    count++;
+  }
+  return count;
+}
+
+function alertOpen(db: Database.Database, hostId: string, target: string, alertType: string): boolean {
+  const row = db.prepare(`
+    SELECT 1 FROM alert_state
+    WHERE alert_type = ? AND host_id = ? AND target = ? AND resolved_at IS NULL
+    LIMIT 1
+  `).get(alertType, hostId, target);
+  return !!row;
+}
+
+function round1(n: number): number { return Math.round(n * 10) / 10; }
+function round2(n: number): number { return Math.round(n * 100) / 100; }
+
+export function generateDiskFillInsights(db: Database.Database): number {
+  const insert = db.prepare(`
+    INSERT INTO insights
+      (entity_type, entity_id, category, severity, title, message,
+       metric, current_value, baseline_value, evidence,
+       suggested_action, confidence)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  let count = 0;
+  count += generateDiskInsights(db, insert);
+  return count;
+}
+
+module.exports = { generateDiskFillInsights, dailyTrend };
+```
+
+- [ ] **Step 4: Run the test, expect PASS**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: all tests PASS (5 helper + smoke + warning case = 7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hub/src/insights/disk-fill.ts tests/unit/detector-disk-fill.test.ts
+git commit -m "implement disk-snapshots fill prediction (warning case)"
+```
+
+---
+
+## Task 5: Severity branching + horizon + shrinking + flat (no-impl-change tests)
+
+These tests exercise existing code paths. No implementation change expected; if any of them require code, the missing branch is in `generateDiskInsights`.
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts`
+
+- [ ] **Step 1: Append the four cases**
+
+Inside the integration `describe`, append:
+
+```ts
+it('fires critical when ETA <= 3 days', () => {
+  // 60 GB used today (last day) with 20 GB/day growth ⇒ remaining 40 GB ⇒ 2 days.
+  // Day 6 = 60 ⇒ startGb = 60 - 20*6 = -60. Use a smaller current to keep startGb non-negative.
+  // Use total=100, startGb=0, dailyGrowth=10 → day 6 = 60 GB used (60%), remaining 40 → 4 days. That's still warning.
+  // Bigger growth: total=100, startGb=10, dailyGrowth=10 → day 6 = 70 GB used, remaining 30 → 3 days. Critical at boundary.
+  seedDisk({ totalGb: 100, startGb: 10, dailyGrowthGb: 10 });
+  generateInsights(db);
+  const insights = getDiskFillInsights();
+  assert.equal(insights.length, 1);
+  assert.equal(insights[0]!.severity, 'critical');
+  assert.match(insights[0]!.message, /full in ~3 days/);
+});
+
+it('does not fire when ETA > 14 days', () => {
+  // 60% used, growing 1 GB/day on 100 GB → 40 days. Above horizon.
+  seedDisk({ totalGb: 100, startGb: 54, dailyGrowthGb: 1 });
+  generateInsights(db);
+  assert.equal(getDiskFillInsights().length, 0);
+});
+
+it('does not fire when disk is shrinking', () => {
+  // Used decreasing 5 GB/day from 95 GB ⇒ ends at 65 GB, still over floor, but slope is negative.
+  seedDisk({ totalGb: 100, startGb: 95, dailyGrowthGb: -5 });
+  generateInsights(db);
+  assert.equal(getDiskFillInsights().length, 0);
+});
+
+it('does not fire when disk is flat', () => {
+  // 70 GB used, no daily change.
+  seedDisk({ totalGb: 100, startGb: 70, dailyGrowthGb: 0 });
+  generateInsights(db);
+  assert.equal(getDiskFillInsights().length, 0);
+});
+```
+
+- [ ] **Step 2: Run the file, expect all pass**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 11 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/detector-disk-fill.test.ts
+git commit -m "add severity / horizon / shrinking / flat tests for disk-fill"
+```
+
+---
+
+## Task 6: Floor + insufficient-data cases
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts`
+
+- [ ] **Step 1: Append**
+
+```ts
+it('does not fire when used_percent < 50% (floor)', () => {
+  // 30 GB used, growing 5 GB/day, 100 GB total → ETA 14 days, but below floor.
+  seedDisk({ totalGb: 100, startGb: 0, dailyGrowthGb: 5 });
+  generateInsights(db);
+  assert.equal(getDiskFillInsights().length, 0);
+});
+
+it('does not fire with fewer than 4 days of data', () => {
+  // Only 3 days seeded, all above floor.
+  seedDisk({ totalGb: 100, startGb: 60, dailyGrowthGb: 5, days: 3 });
+  generateInsights(db);
+  assert.equal(getDiskFillInsights().length, 0);
+});
+```
+
+- [ ] **Step 2: Run, expect pass**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 13 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/detector-disk-fill.test.ts
+git commit -m "add floor + insufficient-data tests for disk-fill"
+```
+
+---
+
+## Task 7: Alert dedup test
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts`
+
+- [ ] **Step 1: Append**
+
+```ts
+it('does not fire when an open disk_full alert exists for the same (host, mount)', () => {
+  seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+  db.prepare(`
+    INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, message, trigger_value)
+    VALUES ('node-1', 'disk_full', '/', datetime('now'), datetime('now'), 'disk full', '90')
+  `).run();
+  generateInsights(db);
+  assert.equal(getDiskFillInsights().length, 0);
+});
+
+it('still fires when a disk_full alert exists but is resolved', () => {
+  seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+  db.prepare(`
+    INSERT INTO alert_state (host_id, alert_type, target, triggered_at, resolved_at, last_notified, message, trigger_value)
+    VALUES ('node-1', 'disk_full', '/', datetime('now', '-2 days'), datetime('now', '-1 day'), datetime('now', '-2 days'), 'disk full', '90')
+  `).run();
+  generateInsights(db);
+  assert.equal(getDiskFillInsights().length, 1);
+});
+```
+
+- [ ] **Step 2: Run, expect pass**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 15 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/detector-disk-fill.test.ts
+git commit -m "add alert dedup tests for disk-fill"
+```
+
+---
+
+## Task 8: Multi-mount + evidence JSON shape
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts`
+
+- [ ] **Step 1: Append**
+
+```ts
+it('fires only for mounts above the floor when multiple mounts on one host', () => {
+  seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5, mount: '/' });
+  seedDisk({ totalGb: 100, startGb: 5, dailyGrowthGb: 5, mount: '/var/log' }); // ends at 35% — below floor
+  generateInsights(db);
+  const insights = getDiskFillInsights();
+  assert.equal(insights.length, 1);
+  assert.match(insights[0]!.title, /Disk "\/" on node-1/);
+});
+
+it('embeds expected fields in evidence JSON', () => {
+  seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+  generateInsights(db);
+  const i = getDiskFillInsights()[0]!;
+  const evidence = JSON.parse(i.evidence!);
+  assert.equal(evidence.mount_point, '/');
+  assert.equal(typeof evidence.used_gb, 'number');
+  assert.equal(typeof evidence.total_gb, 'number');
+  assert.equal(typeof evidence.daily_growth_gb, 'number');
+  assert.equal(evidence.day_count, 7);
+});
+```
+
+- [ ] **Step 2: Run, expect pass**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 17 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/detector-disk-fill.test.ts
+git commit -m "add multi-mount + evidence-shape tests for disk-fill"
+```
+
+---
+
+## Task 9: pve_storage path — TDD
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts` (add failing test)
+- Modify: `hub/src/insights/disk-fill.ts` (add pve loop)
+
+- [ ] **Step 1: Add failing pve warning case**
+
+Inside the integration `describe`, append:
+
+```ts
+it('fires a warning insight on a pve_storage pool filling within horizon', () => {
+  // 60 GB used today on 100 GB pool, growing 5 GB/day → 8 days.
+  const GB = 1024 ** 3;
+  seedPveStorage({
+    storageName: 'local-zfs',
+    totalBytes: 100 * GB,
+    startBytes: 30 * GB,
+    dailyGrowthBytes: 5 * GB,
+  });
+  generateInsights(db);
+  const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+  assert.equal(insights.length, 1);
+  const i = insights[0]!;
+  assert.equal(i.severity, 'warning');
+  assert.match(i.title, /Storage pool "local-zfs" on node-1 filling up/);
+  assert.match(i.suggested_action!, /pvesm status/);
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 1 fail (no pve_storage insight produced).
+
+- [ ] **Step 3: Implement the pve loop**
+
+In `disk-fill.ts`, add (just above `generateDiskFillInsights`):
+
+```ts
+interface PveStorageRow { host_id: string; storage_name: string; storage_type: string; total_bytes: number; used_bytes: number; active: number }
+interface DailyPveRow { day: string; avg: number | null }
+
+function generatePveStorageInsights(db: Database.Database, insert: ReturnType<Database.Database['prepare']>): number {
+  let count = 0;
+  const latest = db.prepare(`
+    SELECT host_id, storage_name, storage_type, total_bytes, used_bytes, active
+    FROM pve_storage_snapshots ps
+    WHERE collected_at = (
+      SELECT MAX(collected_at) FROM pve_storage_snapshots
+      WHERE host_id = ps.host_id AND storage_name = ps.storage_name
+    )
+  `).all() as PveStorageRow[];
+
+  for (const row of latest) {
+    if (!row.total_bytes || row.total_bytes <= 0) continue;
+    if (!row.active) continue;
+    const usedPct = (row.used_bytes / row.total_bytes) * 100;
+    if (usedPct < FLOOR_USED_PERCENT) continue;
+    if (row.used_bytes >= row.total_bytes) continue;
+    if (alertOpen(db, row.host_id, row.storage_name, 'pve_storage_saturation')) continue;
+
+    const daily = db.prepare(`
+      SELECT DATE(collected_at) AS day, AVG(used_bytes) AS avg
+      FROM pve_storage_snapshots
+      WHERE host_id = ? AND storage_name = ?
+        AND collected_at >= datetime('now', '-7 days')
+      GROUP BY DATE(collected_at)
+      ORDER BY day
+    `).all(row.host_id, row.storage_name) as DailyPveRow[];
+    const cleaned = daily.filter((r): r is { day: string; avg: number } => r.avg != null);
+
+    const trend = dailyTrend(cleaned, MIN_PVE_GROWTH_BYTES);
+    if (!trend || trend.dailyGrowth <= 0) continue;
+
+    const remaining = row.total_bytes - trend.current;
+    const daysUntil = Math.round(remaining / trend.dailyGrowth);
+    if (daysUntil <= 0 || daysUntil > HORIZON_DAYS) continue;
+
+    const severity: 'critical' | 'warning' = daysUntil <= CRITICAL_DAYS ? 'critical' : 'warning';
+    const dayWord = daysUntil === 1 ? 'day' : 'days';
+    const liveUsedPct = round1((trend.current / row.total_bytes) * 100);
+    const evidence = JSON.stringify({
+      storage_name: row.storage_name,
+      storage_type: row.storage_type,
+      used_bytes: Math.round(trend.current),
+      total_bytes: row.total_bytes,
+      daily_growth_bytes: Math.round(trend.dailyGrowth),
+      day_count: trend.dayCount,
+    });
+
+    insert.run(
+      'host', row.host_id, 'prediction', severity,
+      `Storage pool "${row.storage_name}" on ${row.host_id} filling up`,
+      `${row.storage_name} at ${liveUsedPct}% (${formatGb(trend.current)}/${formatGb(row.total_bytes)} GB), growing ${formatGb(trend.dailyGrowth)} GB/day — full in ~${daysUntil} ${dayWord}`,
+      'pve_storage_used_percent', liveUsedPct, 100, evidence,
+      `Inspect with \`pvesm status\` and review per-storage usage in Datacenter → Storage. Common causes: backups accumulating, disk images, ISO uploads.`,
+      'medium',
+    );
+    count++;
+  }
+  return count;
+}
+
+function formatGb(bytes: number): string {
+  return (bytes / (1024 ** 3)).toFixed(1);
+}
+```
+
+Update `generateDiskFillInsights` to call both:
+```ts
+export function generateDiskFillInsights(db: Database.Database): number {
+  const insert = db.prepare(`
+    INSERT INTO insights
+      (entity_type, entity_id, category, severity, title, message,
+       metric, current_value, baseline_value, evidence,
+       suggested_action, confidence)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  let count = 0;
+  count += generateDiskInsights(db, insert);
+  count += generatePveStorageInsights(db, insert);
+  return count;
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 18 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hub/src/insights/disk-fill.ts tests/unit/detector-disk-fill.test.ts
+git commit -m "implement pve_storage fill prediction (warning case)"
+```
+
+---
+
+## Task 10: pve_storage edge cases
+
+**Files:**
+- Modify: `tests/unit/detector-disk-fill.test.ts`
+
+- [ ] **Step 1: Append**
+
+```ts
+it('skips pve_storage with active=0', () => {
+  const GB = 1024 ** 3;
+  seedPveStorage({
+    storageName: 'mounted-offline',
+    totalBytes: 100 * GB,
+    startBytes: 30 * GB,
+    dailyGrowthBytes: 5 * GB,
+    active: 0,
+  });
+  generateInsights(db);
+  const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+  assert.equal(insights.length, 0);
+});
+
+it('dedups against open pve_storage_saturation alert', () => {
+  const GB = 1024 ** 3;
+  seedPveStorage({
+    storageName: 'local-zfs',
+    totalBytes: 100 * GB,
+    startBytes: 30 * GB,
+    dailyGrowthBytes: 5 * GB,
+  });
+  db.prepare(`
+    INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, message, trigger_value)
+    VALUES ('node-1', 'pve_storage_saturation', 'local-zfs', datetime('now'), datetime('now'), 'storage saturated', '90')
+  `).run();
+  generateInsights(db);
+  const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+  assert.equal(insights.length, 0);
+});
+
+it('skips pve_storage with null total_bytes', () => {
+  // active=1, but total_bytes is NULL — possible in real data when PVE hides
+  // the storage size for inactive shared storage.
+  db.prepare(`
+    INSERT INTO pve_storage_snapshots (host_id, storage_name, storage_type, total_bytes, used_bytes, active, shared, collected_at)
+    VALUES ('node-1', 'broken', 'dir', NULL, 60, 1, 0, datetime('now'))
+  `).run();
+  generateInsights(db);
+  const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+  assert.equal(insights.length, 0);
+});
+```
+
+- [ ] **Step 2: Run, expect pass**
+
+Run: `npx tsx --test tests/unit/detector-disk-fill.test.ts`
+Expected: 21 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/detector-disk-fill.test.ts
+git commit -m "add pve_storage edge case tests (active=0, dedup, null total)"
+```
+
+---
+
+## Task 11: Final integration — full suite + typecheck + manual verification
+
+**Files:**
+- None (validation only)
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run: `npm test`
+Expected: all tests pass, including the 21 new disk-fill cases.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: passes.
+
+- [ ] **Step 3: Manual verification on the live VM (vdev)**
+
+Skip this step in CI / non-interactive environments. For the human running the implementation:
+
+```bash
+# from a machine that can SSH to the dev VM
+ssh dev-vm
+cd ~/insightd
+git fetch origin && git checkout insights/disk-fill-eta
+# Build + redeploy hub locally — see reference_insightd_ops.md memory for the
+# exact "deploy" loop used in this repo (NOT a release).
+docker compose build hub && docker compose up -d hub
+# Wait for the hourly insights cycle (or trigger generateInsights manually
+# via tsx — see the same memory).
+sqlite3 /path/to/insightd.db \
+  "SELECT entity_id, severity, title, message FROM insights
+   WHERE category='prediction' AND metric LIKE '%disk%';"
+```
+
+Expected: zero or more rows on hosts where a real disk is filling. Inspect titles and messages for plausibility.
+
+- [ ] **Step 4: No final commit needed**
+
+All work was committed task-by-task. Branch `insights/disk-fill-eta` is ready for PR.
+
+---
+
+## Self-review
+
+- **Spec coverage:** every spec requirement maps to a task.
+  - 50% floor → Task 6 + impl in Task 4.
+  - Alert dedup → Task 7 (disk) + Task 10 (pve).
+  - Daily-average trend, 4-day minimum, consistency, growth thresholds → Task 2 (helper) + Task 5 (cases).
+  - 14-day horizon, 3-day critical → Task 5.
+  - disk_snapshots source → Task 4.
+  - pve_storage_snapshots source → Task 9 + Task 10.
+  - Insight payload shape (title, message, metric, evidence JSON, suggested_action, confidence) → Task 4 (disk), Task 9 (pve), Task 8 (evidence shape assertion).
+  - Wipe-and-rewrite via existing detector cycle → Task 1 (wiring) + verified by all integration tests calling `generateInsights`.
+  - Defensive null/zero total handling → Task 4 (impl) + Task 10 (pve null total test).
+
+- **No placeholders:** all steps have exact paths, exact code, exact commands and expected outputs.
+
+- **Type consistency:** `generateDiskFillInsights(db)` signature matches across Tasks 1, 4, 9, 11; helper exports (`dailyTrend`, `DailyAvg`) consistent between module and test imports; insert column count and ordering match across tasks.

--- a/docs/superpowers/specs/2026-05-10-disk-fill-eta-design.md
+++ b/docs/superpowers/specs/2026-05-10-disk-fill-eta-design.md
@@ -47,7 +47,7 @@ For each source (disk_snapshots → mount, pve_storage_snapshots → storage poo
 1. Read latest snapshot. Skip if `total_bytes` is null/0 or `active = 0` (pve_storage only).
 2. **Floor:** skip if `used_percent < 50`.
 3. **Alert dedup:** skip if an open `alert_state` row exists with `alert_type IN ('disk_full', 'pve_storage_saturation')` and matching host/target.
-4. **Trend:** OLS linear regression of usage vs time, over the last 7 days of raw snapshots. For Linux disks, regress on `used_gb`; for pve_storage, on `used_bytes`. Reject if `n < 24` samples (less than ~hourly coverage over the window).
+4. **Trend:** mirror the existing `computeMetricTrend` shape used by host/container predictions. Group raw snapshots into daily averages over the last 7 days, then compute slope as `(last_day_avg − first_day_avg) / (days − 1)`. Reject if fewer than 4 days of data. Reject if relative growth is below 1 % of current value per day (noise floor). Reject if fewer than half of day-over-day changes agree with the trend direction (consistency check). Reject if absolute growth is below a per-source minimum: 0.05 GB/day for `disk_snapshots`, 50 MB/day for `pve_storage_snapshots`. For Linux disks, average `used_gb`; for pve_storage, average `used_bytes`.
 5. **Direction:** skip if `dailyGrowth <= 0`.
 6. **ETA:** `daysUntil = round((total - current) / dailyGrowth)`. Skip if `> 14` or `<= 0`.
 7. **Severity:** critical if `daysUntil <= 3`, otherwise warning.
@@ -62,11 +62,11 @@ For each source (disk_snapshots → mount, pve_storage_snapshots → storage poo
 | `message` | `{mount} at {used_pct}% ({used}/{total} GB), growing {dailyGrowth} GB/day — full in ~{daysUntil} {day(s)}` | analogous, "{storage}" + bytes-formatted |
 | `current_value` | `used_percent` | `used_percent` |
 | `baseline_value` | 100 (saturation %) | 100 |
-| `evidence` (JSON) | `{ mount_point, used_gb, total_gb, daily_growth_gb, sample_count, slope_r2 }` | `{ storage_name, storage_type, used_bytes, total_bytes, daily_growth_bytes, sample_count, slope_r2 }` |
+| `evidence` (JSON) | `{ mount_point, used_gb, total_gb, daily_growth_gb, day_count }` | `{ storage_name, storage_type, used_bytes, total_bytes, daily_growth_bytes, day_count }` |
 | `suggested_action` | `Check largest consumers: \`du -h {mount} \| sort -h \| tail -20\`. Common causes: log rotation broken, container volumes, package cache.` | `Inspect with \`pvesm status\` and review per-storage usage in Datacenter → Storage. Common causes: backups accumulating, disk images, ISO uploads.` |
 | `confidence` | `medium` | `medium` |
 
-`slope_r2` is included so a future "explanation depth" pass can mark low-r² (noisy) predictions as lower confidence; v1 always uses `medium`.
+v1 always emits `medium` confidence. Future iterations could derate based on noisier signals (e.g., spike + decay patterns).
 
 ## Data flow
 
@@ -80,8 +80,8 @@ For each source (disk_snapshots → mount, pve_storage_snapshots → storage poo
 | Case | Handling |
 |---|---|
 | Disk shrinking (cleanup happened) | `dailyGrowth <= 0` → skip |
-| Brand-new host (<7 days of data) | `n < 24` → skip; reconsider next cycle |
-| Disk yo-yos (logs grow then rotate) | OLS averages over 7d; if net-flat → skip |
+| Brand-new host (<4 days of data) | skip; reconsider next cycle |
+| Disk yo-yos (logs grow then rotate) | Daily averages smooth intra-day noise; consistency check rejects if fewer than half of day pairs increase |
 | Disk replaced / mount remounted (total changes mid-window) | Regression on `used_bytes` still computes a slope; ETA may be off for one cycle, self-corrects next hour |
 | pve_storage with `active = 0` | Skip (mirrors `pve_storage_saturation` alert) |
 | Mount disappeared from latest snapshot | Loop never visits it; stale insight cleared by cycle wipe |
@@ -106,7 +106,7 @@ Cases:
 | 4 | 30% used (below floor), growing fast | no insight |
 | 5 | Disk shrinking | no insight |
 | 6 | Flat disk (slope ≈ 0) | no insight |
-| 7 | Only 12 samples in 7d window | no insight |
+| 7 | Only 3 days of data in window | no insight (n < 4 days) |
 | 8 | Open `disk_full` alert for same (host, mount) | no insight |
 | 9 | pve_storage equivalent of #2 | warning, message uses `storage_name` + `pvesm status` |
 | 10 | pve_storage with `active = 0` | no insight |
@@ -125,7 +125,7 @@ Coverage target: every branch in `runDiskFillPredictions`.
 ## Open questions
 
 - `alert_state` column name for the dedup query: `evaluator.ts:1113` references `target` for `disk_full`. Confirm during implementation that the same column name applies for `pve_storage_saturation`.
-- Whether to export `computeMetricTrend` from `detector.ts` for reuse, or inline a small OLS helper in `disk-fill.ts`. Prefer inline to keep the new module standalone unless the existing function maps cleanly.
+- Whether to export `computeMetricTrend` from `detector.ts` for reuse, or inline an analogous helper in `disk-fill.ts`. The existing function is private; its signature accepts a metric column name and a single host/container scope, which doesn't quite fit a (host, mount) two-key scope. Lean toward inline.
 
 ## Out of scope (followups)
 
@@ -133,4 +133,4 @@ Coverage target: every branch in `runDiskFillPredictions`.
 - HTTP endpoint insights, log-pattern standalone insights, cluster-wide patterns — separate specs.
 - Per-disk silence UI.
 - Configurable horizon.
-- Lowering `confidence` based on `slope_r2` (placeholder evidence field).
+- Confidence-derating heuristics for noisy series.

--- a/docs/superpowers/specs/2026-05-10-disk-fill-eta-design.md
+++ b/docs/superpowers/specs/2026-05-10-disk-fill-eta-design.md
@@ -1,0 +1,136 @@
+# Disk-fill ETA insights
+
+**Status:** design
+**Date:** 2026-05-10
+**Author:** Andreas (with Claude)
+**Sub-project of:** Insights coverage expansion (parent roadmap: HTTP endpoint insights, disk-fill ETA, log-pattern standalone insights, cluster-wide patterns — this spec covers disk-fill ETA only).
+
+## Summary
+
+Predict when a disk or Proxmox storage pool will run out of space, and surface it as a `prediction`-category insight before the existing `disk_full` / `pve_storage_saturation` alerts fire. Mirrors the existing host-CPU and host-memory prediction insights in shape, severity, and 14-day horizon.
+
+Sources: `disk_snapshots` (Linux mounts) and `pve_storage_snapshots` (Proxmox storage pools). Volumes, k8s PVs, and PVCs are deferred — their snapshot tables only carry declared capacity, not actual usage, so ETA is not computable without new collection.
+
+## Goals
+
+- Surface disks/pools that will fill within 14 days at current growth rate.
+- Reuse existing `prediction` category, severity bar (critical ≤3 days, warning ≤14 days), and detector cycle.
+- Stay quiet on idle disks (floor at 50% used) and avoid duplicating the `disk_full` / `pve_storage_saturation` alerts when those are already open.
+- Self-clear when the trend reverses (handled by detector's existing wipe-and-rewrite cycle).
+
+## Non-goals
+
+- New alert type or webhook delivery — insights only. The existing `disk_full` and `pve_storage_saturation` alerts continue to handle hard saturation.
+- Volume / PV / PVC fill ETA. Their schemas (`volume_snapshots.size_bytes`, `pv_snapshots.capacity_bytes`, `pvc_snapshots.request_bytes`/`capacity_bytes`) carry only declared/total capacity. Adding usage collection is a separate sub-project.
+- Per-disk silencing UI. Insights are not silenceable today; if needed it would generalize across all insights, not just disk-fill.
+- A configurable horizon. 14 days mirrors host predictions; can be revisited if real usage shows it wrong.
+
+## Architecture
+
+New module `hub/src/insights/disk-fill.ts`. Peer to `proxmox-checks.ts`. Single export:
+
+```ts
+export function runDiskFillPredictions(
+  db: Database.Database,
+  insert: InsightInsert,
+): number;
+```
+
+`detector.ts` calls it once per cycle from `runDetector()`, accumulating its return value into the existing insight count. One added line of wiring; no other detector changes.
+
+No schema change. Insights are written through the existing 12-column `INSERT` (the same path right-sizing and diagnosis use), so `category`, `metric`, `current_value`, `baseline_value`, `evidence`, `suggested_action`, and `confidence` columns are already in place.
+
+## Detector logic
+
+For each source (disk_snapshots → mount, pve_storage_snapshots → storage pool), iterate (host_id, target):
+
+1. Read latest snapshot. Skip if `total_bytes` is null/0 or `active = 0` (pve_storage only).
+2. **Floor:** skip if `used_percent < 50`.
+3. **Alert dedup:** skip if an open `alert_state` row exists with `alert_type IN ('disk_full', 'pve_storage_saturation')` and matching host/target.
+4. **Trend:** OLS linear regression of usage vs time, over the last 7 days of raw snapshots. For Linux disks, regress on `used_gb`; for pve_storage, on `used_bytes`. Reject if `n < 24` samples (less than ~hourly coverage over the window).
+5. **Direction:** skip if `dailyGrowth <= 0`.
+6. **ETA:** `daysUntil = round((total - current) / dailyGrowth)`. Skip if `> 14` or `<= 0`.
+7. **Severity:** critical if `daysUntil <= 3`, otherwise warning.
+8. Insert insight (`prediction` category, `entity_type='host'`, `entity_id=host_id`).
+
+### Insight payload
+
+| Field | Disk variant | pve_storage variant |
+|---|---|---|
+| `metric` | `disk_used_percent` | `pve_storage_used_percent` |
+| `title` | `Disk "{mount}" on {host} filling up` | `Storage pool "{storage}" on {host} filling up` |
+| `message` | `{mount} at {used_pct}% ({used}/{total} GB), growing {dailyGrowth} GB/day — full in ~{daysUntil} {day(s)}` | analogous, "{storage}" + bytes-formatted |
+| `current_value` | `used_percent` | `used_percent` |
+| `baseline_value` | 100 (saturation %) | 100 |
+| `evidence` (JSON) | `{ mount_point, used_gb, total_gb, daily_growth_gb, sample_count, slope_r2 }` | `{ storage_name, storage_type, used_bytes, total_bytes, daily_growth_bytes, sample_count, slope_r2 }` |
+| `suggested_action` | `Check largest consumers: \`du -h {mount} \| sort -h \| tail -20\`. Common causes: log rotation broken, container volumes, package cache.` | `Inspect with \`pvesm status\` and review per-storage usage in Datacenter → Storage. Common causes: backups accumulating, disk images, ISO uploads.` |
+| `confidence` | `medium` | `medium` |
+
+`slope_r2` is included so a future "explanation depth" pass can mark low-r² (noisy) predictions as lower confidence; v1 always uses `medium`.
+
+## Data flow
+
+- **Trigger:** existing hourly `runDetector()` cron in `scheduler.ts`. No new schedule.
+- **Wipe-and-rewrite:** detector clears stale insights at cycle start, so disk-fill rows disappear automatically when conditions clear (disk shrinks, alert opens, trend goes flat).
+- **Read path:** existing `GET /api/insights` and `InsightsPage.tsx` surface the rows with no frontend change. The 🔮 prediction icon, severity grouping, and current/baseline/deviation card already render correctly for `metric ∈ {disk_used_percent, pve_storage_used_percent}` because the formatter falls through to "percent" rendering.
+- **Concurrency:** detector runs serial; no locking concern.
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Disk shrinking (cleanup happened) | `dailyGrowth <= 0` → skip |
+| Brand-new host (<7 days of data) | `n < 24` → skip; reconsider next cycle |
+| Disk yo-yos (logs grow then rotate) | OLS averages over 7d; if net-flat → skip |
+| Disk replaced / mount remounted (total changes mid-window) | Regression on `used_bytes` still computes a slope; ETA may be off for one cycle, self-corrects next hour |
+| pve_storage with `active = 0` | Skip (mirrors `pve_storage_saturation` alert) |
+| Mount disappeared from latest snapshot | Loop never visits it; stale insight cleared by cycle wipe |
+| `total_bytes` null or 0 | Skip (defensive; `pve_storage_snapshots.total_bytes` is nullable) |
+| `current >= total` (impossible but defensive) | Skip — alerts handle it |
+
+Each `(host, target)` iteration is wrapped in try/catch; one failing row logs and continues. Mirrors `runProxmoxChecks`.
+
+Logging: `logger.debug` per insert, one `logger.info` summary line per cycle: `disk-fill predictions: N inserted across M sources`.
+
+## Testing
+
+New file `tests/unit/detector-disk-fill.test.ts`, peer to `detector-proxmox.test.ts` and `detector-right-sizing.test.ts`. Uses `node:test` + tsx (project convention). In-memory SQLite, `applySchema()`, seed rows.
+
+Cases:
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | 1 GB/day growth, 60% used, 100 GB total → ETA 40d | no insight |
+| 2 | 5 GB/day growth, 60% used, 100 GB total → ETA 8d | warning insight |
+| 3 | 20 GB/day, 60% used, 100 GB total → ETA 2d | critical insight |
+| 4 | 30% used (below floor), growing fast | no insight |
+| 5 | Disk shrinking | no insight |
+| 6 | Flat disk (slope ≈ 0) | no insight |
+| 7 | Only 12 samples in 7d window | no insight |
+| 8 | Open `disk_full` alert for same (host, mount) | no insight |
+| 9 | pve_storage equivalent of #2 | warning, message uses `storage_name` + `pvesm status` |
+| 10 | pve_storage with `active = 0` | no insight |
+| 11 | Multiple mounts, only one above floor | one insight |
+| 12 | Insight evidence JSON shape | parses, contains `daily_growth_gb` + `sample_count` |
+
+Coverage target: every branch in `runDiskFillPredictions`.
+
+**Manual verification post-merge:** vdev deploy, query `SELECT * FROM insights WHERE category='prediction' AND metric LIKE '%disk%'` after one detector cycle on the live VMs (proxmox-01 has a slowly-filling disk — good live signal).
+
+## Risk + rollback
+
+- **Risk:** Wrong slope on noisy disks (logs rotating, snapshots churning) producing flapping insights between cycles. Mitigation: 50% floor, 7d window smooths short-term noise, alert-dedup hides the case where the disk is already flagged.
+- **Rollback:** Remove the `runDiskFillPredictions` call from `runDetector()`. New file becomes dead code; safe to leave in place or revert in the same PR. No schema change, no data migration.
+
+## Open questions
+
+- `alert_state` column name for the dedup query: `evaluator.ts:1113` references `target` for `disk_full`. Confirm during implementation that the same column name applies for `pve_storage_saturation`.
+- Whether to export `computeMetricTrend` from `detector.ts` for reuse, or inline a small OLS helper in `disk-fill.ts`. Prefer inline to keep the new module standalone unless the existing function maps cleanly.
+
+## Out of scope (followups)
+
+- Volume / PV / PVC fill ETA — needs usage collection.
+- HTTP endpoint insights, log-pattern standalone insights, cluster-wide patterns — separate specs.
+- Per-disk silence UI.
+- Configurable horizon.
+- Lowering `confidence` based on `slope_r2` (placeholder evidence field).

--- a/hub/src/insights/detector.ts
+++ b/hub/src/insights/detector.ts
@@ -386,6 +386,9 @@ function generateInsights(db: Database.Database, baselineCache?: BaselineCache |
   const { generateProxmoxInsights } = require('./proxmox-checks') as typeof import('./proxmox-checks');
   count += generateProxmoxInsights(db, insert);
 
+  const { generateDiskFillInsights } = require('./disk-fill') as typeof import('./disk-fill');
+  count += generateDiskFillInsights(db);
+
   // --- Correlation enrichment ---
   enrichInsightsWithCorrelations(db);
 

--- a/hub/src/insights/disk-fill.ts
+++ b/hub/src/insights/disk-fill.ts
@@ -63,11 +63,12 @@ function generateDiskInsights(db: Database.Database, insert: DiskInsightInsert):
   // Hoist all prepared statements outside the loop — compile once, run many.
   const latestStmt = db.prepare(`
     SELECT host_id, mount_point, total_gb, used_gb, used_percent
-    FROM disk_snapshots ds
-    WHERE collected_at = (
-      SELECT MAX(collected_at) FROM disk_snapshots
-      WHERE host_id = ds.host_id AND mount_point = ds.mount_point
+    FROM (
+      SELECT host_id, mount_point, total_gb, used_gb, used_percent,
+             ROW_NUMBER() OVER (PARTITION BY host_id, mount_point ORDER BY collected_at DESC, id DESC) AS rn
+      FROM disk_snapshots
     )
+    WHERE rn = 1
   `);
   const dailyStmt = db.prepare(`
     SELECT DATE(collected_at) AS day, AVG(used_gb) AS avg
@@ -99,7 +100,7 @@ function generateDiskInsights(db: Database.Database, insert: DiskInsightInsert):
     if (!trend || trend.dailyGrowth <= 0) continue;
 
     const remainingGb = row.total_gb - trend.current;
-    const daysUntil = Math.round(remainingGb / trend.dailyGrowth);
+    const daysUntil = Math.ceil(remainingGb / trend.dailyGrowth);
     if (daysUntil <= 0 || daysUntil > HORIZON_DAYS) continue;
 
     const severity: 'critical' | 'warning' = daysUntil <= CRITICAL_DAYS ? 'critical' : 'warning';
@@ -135,11 +136,12 @@ interface DailyPveRow { day: string; avg: number | null }
 function generatePveStorageInsights(db: Database.Database, insert: DiskInsightInsert): number {
   const latestStmt = db.prepare(`
     SELECT host_id, storage_name, storage_type, total_bytes, used_bytes, active
-    FROM pve_storage_snapshots ps
-    WHERE collected_at = (
-      SELECT MAX(collected_at) FROM pve_storage_snapshots
-      WHERE host_id = ps.host_id AND storage_name = ps.storage_name
+    FROM (
+      SELECT host_id, storage_name, storage_type, total_bytes, used_bytes, active,
+             ROW_NUMBER() OVER (PARTITION BY host_id, storage_name ORDER BY collected_at DESC, id DESC) AS rn
+      FROM pve_storage_snapshots
     )
+    WHERE rn = 1
   `);
   const dailyStmt = db.prepare(`
     SELECT DATE(collected_at) AS day, AVG(used_bytes) AS avg
@@ -173,7 +175,7 @@ function generatePveStorageInsights(db: Database.Database, insert: DiskInsightIn
     if (!trend || trend.dailyGrowth <= 0) continue;
 
     const remaining = row.total_bytes - trend.current;
-    const daysUntil = Math.round(remaining / trend.dailyGrowth);
+    const daysUntil = Math.ceil(remaining / trend.dailyGrowth);
     if (daysUntil <= 0 || daysUntil > HORIZON_DAYS) continue;
 
     const severity: 'critical' | 'warning' = daysUntil <= CRITICAL_DAYS ? 'critical' : 'warning';

--- a/hub/src/insights/disk-fill.ts
+++ b/hub/src/insights/disk-fill.ts
@@ -129,8 +129,84 @@ function generateDiskInsights(db: Database.Database, insert: DiskInsightInsert):
 function round1(n: number): number { return Math.round(n * 10) / 10; }
 function round2(n: number): number { return Math.round(n * 100) / 100; }
 
+interface PveStorageRow { host_id: string; storage_name: string; storage_type: string; total_bytes: number; used_bytes: number; active: number }
+interface DailyPveRow { day: string; avg: number | null }
+
+function generatePveStorageInsights(db: Database.Database, insert: DiskInsightInsert): number {
+  const latestStmt = db.prepare(`
+    SELECT host_id, storage_name, storage_type, total_bytes, used_bytes, active
+    FROM pve_storage_snapshots ps
+    WHERE collected_at = (
+      SELECT MAX(collected_at) FROM pve_storage_snapshots
+      WHERE host_id = ps.host_id AND storage_name = ps.storage_name
+    )
+  `);
+  const dailyStmt = db.prepare(`
+    SELECT DATE(collected_at) AS day, AVG(used_bytes) AS avg
+    FROM pve_storage_snapshots
+    WHERE host_id = ? AND storage_name = ?
+      AND collected_at >= datetime('now', '-7 days')
+    GROUP BY DATE(collected_at)
+    ORDER BY day
+  `);
+  const alertStmt = db.prepare(`
+    SELECT 1 FROM alert_state
+    WHERE alert_type = ? AND host_id = ? AND target = ? AND resolved_at IS NULL
+    LIMIT 1
+  `);
+
+  let count = 0;
+  const latest = latestStmt.all() as PveStorageRow[];
+
+  for (const row of latest) {
+    if (!row.total_bytes || row.total_bytes <= 0) continue;
+    if (!row.active) continue;
+    const usedPct = (row.used_bytes / row.total_bytes) * 100;
+    if (usedPct < FLOOR_USED_PERCENT) continue;
+    if (row.used_bytes >= row.total_bytes) continue;
+    if (alertStmt.get('pve_storage_saturation', row.host_id, row.storage_name)) continue;
+
+    const daily = dailyStmt.all(row.host_id, row.storage_name) as DailyPveRow[];
+    const cleaned = daily.filter((r): r is { day: string; avg: number } => r.avg != null);
+
+    const trend = dailyTrend(cleaned, MIN_PVE_GROWTH_BYTES);
+    if (!trend || trend.dailyGrowth <= 0) continue;
+
+    const remaining = row.total_bytes - trend.current;
+    const daysUntil = Math.round(remaining / trend.dailyGrowth);
+    if (daysUntil <= 0 || daysUntil > HORIZON_DAYS) continue;
+
+    const severity: 'critical' | 'warning' = daysUntil <= CRITICAL_DAYS ? 'critical' : 'warning';
+    const dayWord = daysUntil === 1 ? 'day' : 'days';
+    const liveUsedPct = round1((trend.current / row.total_bytes) * 100);
+    const evidence = JSON.stringify({
+      storage_name: row.storage_name,
+      storage_type: row.storage_type,
+      used_bytes: Math.round(trend.current),
+      total_bytes: row.total_bytes,
+      daily_growth_bytes: Math.round(trend.dailyGrowth),
+      day_count: trend.dayCount,
+    });
+
+    insert.run(
+      'host', row.host_id, 'prediction', severity,
+      `Storage pool "${row.storage_name}" on ${row.host_id} filling up`,
+      `${row.storage_name} at ${liveUsedPct}% (${formatGb(trend.current)}/${formatGb(row.total_bytes)} GB), growing ${formatGb(trend.dailyGrowth)} GB/day — full in ~${daysUntil} ${dayWord}`,
+      'pve_storage_used_percent', liveUsedPct, 100, evidence,
+      `Inspect with \`pvesm status\` and review per-storage usage in Datacenter → Storage. Common causes: backups accumulating, disk images, ISO uploads.`,
+      'medium',
+    );
+    count++;
+  }
+  return count;
+}
+
+function formatGb(bytes: number): string {
+  return (bytes / (1024 ** 3)).toFixed(1);
+}
+
 export function generateDiskFillInsights(db: Database.Database): number {
-  const insert: DiskInsightInsert = db.prepare(`
+  const insert = db.prepare(`
     INSERT INTO insights
       (entity_type, entity_id, category, severity, title, message,
        metric, current_value, baseline_value, evidence,
@@ -139,6 +215,7 @@ export function generateDiskFillInsights(db: Database.Database): number {
   `) as unknown as DiskInsightInsert;
   let count = 0;
   count += generateDiskInsights(db, insert);
+  count += generatePveStorageInsights(db, insert);
   return count;
 }
 

--- a/hub/src/insights/disk-fill.ts
+++ b/hub/src/insights/disk-fill.ts
@@ -1,0 +1,16 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * Disk-fill ETA predictions. One insight per (host, mount) or (host, storage)
+ * that will reach saturation within 14 days at the current 7-day growth
+ * rate. Sibling to right-sizing and proxmox-checks — runs from the
+ * generateInsights cycle and writes into the shared `insights` table under
+ * category 'prediction'.
+ */
+
+export function generateDiskFillInsights(db: Database.Database): number {
+  void db;
+  return 0;
+}
+
+module.exports = { generateDiskFillInsights };

--- a/hub/src/insights/disk-fill.ts
+++ b/hub/src/insights/disk-fill.ts
@@ -8,9 +8,40 @@ import type Database from 'better-sqlite3';
  * category 'prediction'.
  */
 
+export interface DailyAvg { day: string; avg: number }
+
+/**
+ * Compute a daily-averaged growth slope from rows already grouped by
+ * day and ordered ascending by day. Returns null when the trend fails any
+ * of the consistency / minimum-growth filters. Mirrors the rejection
+ * conditions of detector.ts::computeMetricTrend.
+ */
+export function dailyTrend(
+  daily: DailyAvg[],
+  minAbsoluteGrowth: number,
+): { current: number; dailyGrowth: number; dayCount: number } | null {
+  if (daily.length < 4) return null;
+  const first = daily[0]!.avg;
+  const last = daily[daily.length - 1]!.avg;
+  const days = daily.length - 1;
+  const dailyGrowth = (last - first) / days;
+  if (last > 0 && Math.abs(dailyGrowth / last) < 0.01) return null;
+  if (Math.abs(dailyGrowth) < minAbsoluteGrowth) return null;
+  let increasing = 0;
+  let decreasing = 0;
+  for (let i = 1; i < daily.length; i++) {
+    const diff = daily[i]!.avg - daily[i - 1]!.avg;
+    if (diff > 0) increasing++;
+    else if (diff < 0) decreasing++;
+  }
+  if (dailyGrowth > 0 && increasing < Math.ceil(days / 2)) return null;
+  if (dailyGrowth < 0 && decreasing < Math.ceil(days / 2)) return null;
+  return { current: last, dailyGrowth, dayCount: daily.length };
+}
+
 export function generateDiskFillInsights(db: Database.Database): number {
   void db;
   return 0;
 }
 
-module.exports = { generateDiskFillInsights };
+module.exports = { generateDiskFillInsights, dailyTrend };

--- a/hub/src/insights/disk-fill.ts
+++ b/hub/src/insights/disk-fill.ts
@@ -8,14 +8,14 @@ import type Database from 'better-sqlite3';
  * category 'prediction'.
  */
 
+const FLOOR_USED_PERCENT = 50;
+const HORIZON_DAYS = 14;
+const CRITICAL_DAYS = 3;
+const MIN_DISK_GROWTH_GB = 0.05;       // 50 MB/day
+const MIN_PVE_GROWTH_BYTES = 50 * 1024 * 1024; // 50 MB/day
+
 export interface DailyAvg { day: string; avg: number }
 
-/**
- * Compute a daily-averaged growth slope from rows already grouped by
- * day and ordered ascending by day. Returns null when the trend fails any
- * of the consistency / minimum-growth filters. Mirrors the rejection
- * conditions of detector.ts::computeMetricTrend.
- */
 export function dailyTrend(
   daily: DailyAvg[],
   minAbsoluteGrowth: number,
@@ -39,9 +39,107 @@ export function dailyTrend(
   return { current: last, dailyGrowth, dayCount: daily.length };
 }
 
+interface DiskInsightInsert {
+  run(
+    entityType: string,
+    entityId: string,
+    category: string,
+    severity: 'critical' | 'warning' | 'info',
+    title: string,
+    message: string,
+    metric: string | null,
+    currentValue: number | null,
+    baselineValue: number | null,
+    evidence: string | null,
+    suggestedAction: string | null,
+    confidence: string | null,
+  ): { changes: number };
+}
+
+interface DiskRow { host_id: string; mount_point: string; total_gb: number; used_gb: number; used_percent: number }
+interface DailyDiskRow { day: string; avg: number | null }
+
+function generateDiskInsights(db: Database.Database, insert: DiskInsightInsert): number {
+  // Hoist all prepared statements outside the loop — compile once, run many.
+  const latestStmt = db.prepare(`
+    SELECT host_id, mount_point, total_gb, used_gb, used_percent
+    FROM disk_snapshots ds
+    WHERE collected_at = (
+      SELECT MAX(collected_at) FROM disk_snapshots
+      WHERE host_id = ds.host_id AND mount_point = ds.mount_point
+    )
+  `);
+  const dailyStmt = db.prepare(`
+    SELECT DATE(collected_at) AS day, AVG(used_gb) AS avg
+    FROM disk_snapshots
+    WHERE host_id = ? AND mount_point = ?
+      AND collected_at >= datetime('now', '-7 days')
+    GROUP BY DATE(collected_at)
+    ORDER BY day
+  `);
+  const alertStmt = db.prepare(`
+    SELECT 1 FROM alert_state
+    WHERE alert_type = ? AND host_id = ? AND target = ? AND resolved_at IS NULL
+    LIMIT 1
+  `);
+
+  let count = 0;
+  const latest = latestStmt.all() as DiskRow[];
+
+  for (const row of latest) {
+    if (!row.total_gb || row.total_gb <= 0) continue;
+    if (row.used_percent < FLOOR_USED_PERCENT) continue;
+    if (row.used_gb >= row.total_gb) continue;
+    if (alertStmt.get('disk_full', row.host_id, row.mount_point)) continue;
+
+    const daily = dailyStmt.all(row.host_id, row.mount_point) as DailyDiskRow[];
+    const cleaned = daily.filter((r): r is { day: string; avg: number } => r.avg != null);
+
+    const trend = dailyTrend(cleaned, MIN_DISK_GROWTH_GB);
+    if (!trend || trend.dailyGrowth <= 0) continue;
+
+    const remainingGb = row.total_gb - trend.current;
+    const daysUntil = Math.round(remainingGb / trend.dailyGrowth);
+    if (daysUntil <= 0 || daysUntil > HORIZON_DAYS) continue;
+
+    const severity: 'critical' | 'warning' = daysUntil <= CRITICAL_DAYS ? 'critical' : 'warning';
+    const dayWord = daysUntil === 1 ? 'day' : 'days';
+    const usedPct = round1((trend.current / row.total_gb) * 100);
+    const evidence = JSON.stringify({
+      mount_point: row.mount_point,
+      used_gb: round1(trend.current),
+      total_gb: round1(row.total_gb),
+      daily_growth_gb: round2(trend.dailyGrowth),
+      day_count: trend.dayCount,
+    });
+
+    insert.run(
+      'host', row.host_id, 'prediction', severity,
+      `Disk "${row.mount_point}" on ${row.host_id} filling up`,
+      `${row.mount_point} at ${usedPct}% (${round1(trend.current)}/${round1(row.total_gb)} GB), growing ${round2(trend.dailyGrowth)} GB/day — full in ~${daysUntil} ${dayWord}`,
+      'disk_used_percent', usedPct, 100, evidence,
+      `Check largest consumers: \`du -h ${row.mount_point} | sort -h | tail -20\`. Common causes: log rotation broken, container volumes, package cache.`,
+      'medium',
+    );
+    count++;
+  }
+  return count;
+}
+
+function round1(n: number): number { return Math.round(n * 10) / 10; }
+function round2(n: number): number { return Math.round(n * 100) / 100; }
+
 export function generateDiskFillInsights(db: Database.Database): number {
-  void db;
-  return 0;
+  const insert: DiskInsightInsert = db.prepare(`
+    INSERT INTO insights
+      (entity_type, entity_id, category, severity, title, message,
+       metric, current_value, baseline_value, evidence,
+       suggested_action, confidence)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `) as unknown as DiskInsightInsert;
+  let count = 0;
+  count += generateDiskInsights(db, insert);
+  return count;
 }
 
 module.exports = { generateDiskFillInsights, dailyTrend };

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -170,4 +170,36 @@ describe('detector — disk-fill ETA insights', () => {
     assert.match(i.message, /full in ~8 days/);
     assert.equal(i.confidence, 'medium');
   });
+
+  it('fires critical when ETA <= 3 days', () => {
+    // 7 daily samples, day 0 = 10 GB used, day 6 = 70 GB used. Last avg = 70.
+    // Slope = (70-10)/6 = 10. Remaining = 30. daysUntil = round(30/10) = 3 → critical at boundary.
+    seedDisk({ totalGb: 100, startGb: 10, dailyGrowthGb: 10 });
+    generateInsights(db);
+    const insights = getDiskFillInsights();
+    assert.equal(insights.length, 1);
+    assert.equal(insights[0]!.severity, 'critical');
+    assert.match(insights[0]!.message, /full in ~3 days/);
+  });
+
+  it('does not fire when ETA > 14 days', () => {
+    // 60% used, growing 1 GB/day on 100 GB → 40 days. Above horizon.
+    seedDisk({ totalGb: 100, startGb: 54, dailyGrowthGb: 1 });
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
+  });
+
+  it('does not fire when disk is shrinking', () => {
+    // Used decreasing 5 GB/day from 95 GB ⇒ ends at 65 GB, still over floor, but slope is negative.
+    seedDisk({ totalGb: 100, startGb: 95, dailyGrowthGb: -5 });
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
+  });
+
+  it('does not fire when disk is flat', () => {
+    // 70 GB used, no daily change.
+    seedDisk({ totalGb: 100, startGb: 70, dailyGrowthGb: 0 });
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
+  });
 });

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+const { dailyTrend } = require('../../hub/src/insights/disk-fill');
+
+describe('dailyTrend helper', () => {
+  it('returns null when fewer than 4 days', () => {
+    const daily = [
+      { day: '2026-05-04', avg: 50 },
+      { day: '2026-05-05', avg: 51 },
+      { day: '2026-05-06', avg: 52 },
+    ];
+    assert.equal(dailyTrend(daily, 0.05), null);
+  });
+
+  it('returns null when relative growth < 1% of current', () => {
+    const daily = Array.from({ length: 7 }, (_, i) => ({
+      day: `2026-05-0${i + 1}`,
+      avg: 1000 + i * 0.5, // 0.5 GB/day on a 1000 GB current = 0.05% — under floor
+    }));
+    assert.equal(dailyTrend(daily, 0.05), null);
+  });
+
+  it('returns null when absolute growth < minimum', () => {
+    const daily = Array.from({ length: 7 }, (_, i) => ({
+      day: `2026-05-0${i + 1}`,
+      avg: 50 + i * 0.01, // 0.01 GB/day, below 0.05 GB/day floor
+    }));
+    assert.equal(dailyTrend(daily, 0.05), null);
+  });
+
+  it('returns null when fewer than half of day pairs agree with positive trend', () => {
+    const daily = [
+      { day: 'd1', avg: 50 },
+      { day: 'd2', avg: 50 },
+      { day: 'd3', avg: 50 },
+      { day: 'd4', avg: 50 },
+      { day: 'd5', avg: 60 },  // last - first = 10, but only 1/4 days are increasing
+    ];
+    const out = dailyTrend(daily, 0.05);
+    assert.equal(out, null);
+  });
+
+  it('returns slope, current, dayCount on a clean rising trend', () => {
+    const daily = Array.from({ length: 7 }, (_, i) => ({
+      day: `2026-05-0${i + 1}`,
+      avg: 50 + i * 1, // 1 GB/day
+    }));
+    const out = dailyTrend(daily, 0.05);
+    assert.ok(out);
+    assert.equal(out!.dayCount, 7);
+    assert.equal(out!.current, 56);
+    assert.equal(Math.round(out!.dailyGrowth * 100) / 100, 1);
+  });
+});

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -150,4 +150,24 @@ describe('detector — disk-fill ETA insights', () => {
     generateInsights(db);
     assert.equal(getDiskFillInsights().length, 0);
   });
+
+  it('fires a warning insight when disk fills in 8 days at 5 GB/day on a 100 GB disk at 60%', () => {
+    // 60 GB used today, growing 5 GB/day. Remaining = 40 GB → 8 days. Warning band.
+    // 7 daily samples spanning days 0..6, last - first = 6 * dailyGrowth.
+    // For dailyGrowth=5 we need startGb such that day-6 = 60. startGb = 60 - 5*6 = 30.
+    seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+
+    generateInsights(db);
+
+    const insights = getDiskFillInsights();
+    assert.equal(insights.length, 1, `expected one disk-fill insight, got: ${JSON.stringify(insights)}`);
+    const i = insights[0]!;
+    assert.equal(i.entity_type, 'host');
+    assert.equal(i.entity_id, 'node-1');
+    assert.equal(i.severity, 'warning');
+    assert.equal(i.metric, 'disk_used_percent');
+    assert.match(i.title, /Disk "\/" on node-1 filling up/);
+    assert.match(i.message, /full in ~8 days/);
+    assert.equal(i.confidence, 'medium');
+  });
 });

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -216,4 +216,24 @@ describe('detector — disk-fill ETA insights', () => {
     generateInsights(db);
     assert.equal(getDiskFillInsights().length, 0);
   });
+
+  it('does not fire when an open disk_full alert exists for the same (host, mount)', () => {
+    seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, message, trigger_value)
+      VALUES ('node-1', 'disk_full', '/', datetime('now'), datetime('now'), 'disk full', '90')
+    `).run();
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
+  });
+
+  it('still fires when a disk_full alert exists but is resolved', () => {
+    seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, resolved_at, last_notified, message, trigger_value)
+      VALUES ('node-1', 'disk_full', '/', datetime('now', '-2 days'), datetime('now', '-1 day'), datetime('now', '-2 days'), 'disk full', '90')
+    `).run();
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 1);
+  });
 });

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -257,4 +257,22 @@ describe('detector — disk-fill ETA insights', () => {
     assert.equal(typeof evidence.daily_growth_gb, 'number');
     assert.equal(evidence.day_count, 7);
   });
+
+  it('fires a warning insight on a pve_storage pool filling within horizon', () => {
+    // 60 GB used today on 100 GB pool, growing 5 GB/day → 8 days.
+    const GB = 1024 ** 3;
+    seedPveStorage({
+      storageName: 'local-zfs',
+      totalBytes: 100 * GB,
+      startBytes: 30 * GB,
+      dailyGrowthBytes: 5 * GB,
+    });
+    generateInsights(db);
+    const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+    assert.equal(insights.length, 1);
+    const i = insights[0]!;
+    assert.equal(i.severity, 'warning');
+    assert.match(i.title, /Storage pool "local-zfs" on node-1 filling up/);
+    assert.match(i.suggested_action!, /pvesm status/);
+  });
 });

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -275,4 +275,47 @@ describe('detector — disk-fill ETA insights', () => {
     assert.match(i.title, /Storage pool "local-zfs" on node-1 filling up/);
     assert.match(i.suggested_action!, /pvesm status/);
   });
+
+  it('skips pve_storage with active=0', () => {
+    const GB = 1024 ** 3;
+    seedPveStorage({
+      storageName: 'mounted-offline',
+      totalBytes: 100 * GB,
+      startBytes: 30 * GB,
+      dailyGrowthBytes: 5 * GB,
+      active: 0,
+    });
+    generateInsights(db);
+    const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+    assert.equal(insights.length, 0);
+  });
+
+  it('dedups against open pve_storage_saturation alert', () => {
+    const GB = 1024 ** 3;
+    seedPveStorage({
+      storageName: 'local-zfs',
+      totalBytes: 100 * GB,
+      startBytes: 30 * GB,
+      dailyGrowthBytes: 5 * GB,
+    });
+    db.prepare(`
+      INSERT INTO alert_state (host_id, alert_type, target, triggered_at, last_notified, message, trigger_value)
+      VALUES ('node-1', 'pve_storage_saturation', 'local-zfs', datetime('now'), datetime('now'), 'storage saturated', '90')
+    `).run();
+    generateInsights(db);
+    const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+    assert.equal(insights.length, 0);
+  });
+
+  it('skips pve_storage with null total_bytes', () => {
+    // active=1, but total_bytes is NULL — possible in real data when PVE hides
+    // the storage size for inactive shared storage.
+    db.prepare(`
+      INSERT INTO pve_storage_snapshots (host_id, storage_name, storage_type, total_bytes, used_bytes, active, shared, collected_at)
+      VALUES ('node-1', 'broken', 'dir', NULL, 60, 1, 0, datetime('now'))
+    `).run();
+    generateInsights(db);
+    const insights = getDiskFillInsights().filter(i => i.metric === 'pve_storage_used_percent');
+    assert.equal(insights.length, 0);
+  });
 });

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 const { dailyTrend } = require('../../hub/src/insights/disk-fill');
 
@@ -50,5 +50,104 @@ describe('dailyTrend helper', () => {
     assert.equal(out!.dayCount, 7);
     assert.equal(out!.current, 56);
     assert.equal(Math.round(out!.dailyGrowth * 100) / 100, 1);
+  });
+});
+
+const { createTestDb } = require('../helpers/db');
+const { suppressConsole } = require('../helpers/mocks');
+const { generateInsights } = require('../../hub/src/insights/detector');
+
+interface InsightRow {
+  entity_type: string; entity_id: string; category: string; severity: string;
+  title: string; message: string; metric: string | null;
+  current_value: number | null; baseline_value: number | null;
+  evidence: string | null; suggested_action: string | null; confidence: string | null;
+}
+
+describe('detector — disk-fill ETA insights', () => {
+  let db: any;
+  let restore: () => void;
+
+  beforeEach(() => {
+    restore = suppressConsole();
+    db = createTestDb();
+    db.prepare(`INSERT INTO hosts (host_id, first_seen, last_seen) VALUES ('node-1', datetime('now'), datetime('now'))`).run();
+  });
+
+  afterEach(() => {
+    db.close();
+    restore();
+  });
+
+  /**
+   * Seed N days of disk snapshots, one per day at noon, with linear growth.
+   * day 0 = 7 days ago. day 6 = today. usedAtDayN = startGb + dailyGrowthGb * N.
+   */
+  function seedDisk(opts: {
+    hostId?: string;
+    mount?: string;
+    totalGb: number;
+    startGb: number;
+    dailyGrowthGb: number;
+    days?: number;
+  }): void {
+    const hostId = opts.hostId ?? 'node-1';
+    const mount = opts.mount ?? '/';
+    const totalGb = opts.totalGb;
+    const days = opts.days ?? 7;
+    for (let d = 0; d < days; d++) {
+      const usedGb = opts.startGb + opts.dailyGrowthGb * d;
+      const usedPct = (usedGb / totalGb) * 100;
+      const at = `datetime('now', '-${days - 1 - d} days')`;
+      db.prepare(`
+        INSERT INTO disk_snapshots (host_id, mount_point, total_gb, used_gb, used_percent, collected_at)
+        VALUES (?, ?, ?, ?, ?, ${at})
+      `).run(hostId, mount, totalGb, usedGb, usedPct);
+    }
+  }
+
+  /**
+   * Seed N days of pve_storage snapshots in bytes. Mirrors seedDisk shape.
+   */
+  function seedPveStorage(opts: {
+    hostId?: string;
+    storageName?: string;
+    storageType?: string;
+    totalBytes: number;
+    startBytes: number;
+    dailyGrowthBytes: number;
+    days?: number;
+    active?: number;
+  }): void {
+    const hostId = opts.hostId ?? 'node-1';
+    const storageName = opts.storageName ?? 'local-zfs';
+    const storageType = opts.storageType ?? 'zfspool';
+    const days = opts.days ?? 7;
+    const active = opts.active ?? 1;
+    for (let d = 0; d < days; d++) {
+      const used = opts.startBytes + opts.dailyGrowthBytes * d;
+      const at = `datetime('now', '-${days - 1 - d} days')`;
+      db.prepare(`
+        INSERT INTO pve_storage_snapshots (host_id, storage_name, storage_type, total_bytes, used_bytes, active, shared, collected_at)
+        VALUES (?, ?, ?, ?, ?, ?, 0, ${at})
+      `).run(hostId, storageName, storageType, opts.totalBytes, used, active);
+    }
+  }
+
+  function getDiskFillInsights(): InsightRow[] {
+    return db.prepare(
+      `SELECT entity_type, entity_id, category, severity, title, message, metric,
+              current_value, baseline_value, evidence, suggested_action, confidence
+       FROM insights
+       WHERE category = 'prediction'
+         AND (metric = 'disk_used_percent' OR metric = 'pve_storage_used_percent')`
+    ).all() as InsightRow[];
+  }
+
+  // Tests will be added in subsequent tasks — start with a smoke test that
+  // confirms the no-op module runs cleanly inside generateInsights.
+  it('runs cleanly with no disk data', () => {
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
   });
 });

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -236,4 +236,25 @@ describe('detector — disk-fill ETA insights', () => {
     generateInsights(db);
     assert.equal(getDiskFillInsights().length, 1);
   });
+
+  it('fires only for mounts above the floor when multiple mounts on one host', () => {
+    seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5, mount: '/' });
+    seedDisk({ totalGb: 100, startGb: 5, dailyGrowthGb: 5, mount: '/var/log' }); // ends at 35% — below floor
+    generateInsights(db);
+    const insights = getDiskFillInsights();
+    assert.equal(insights.length, 1);
+    assert.match(insights[0]!.title, /Disk "\/" on node-1/);
+  });
+
+  it('embeds expected fields in evidence JSON', () => {
+    seedDisk({ totalGb: 100, startGb: 30, dailyGrowthGb: 5 });
+    generateInsights(db);
+    const i = getDiskFillInsights()[0]!;
+    const evidence = JSON.parse(i.evidence!);
+    assert.equal(evidence.mount_point, '/');
+    assert.equal(typeof evidence.used_gb, 'number');
+    assert.equal(typeof evidence.total_gb, 'number');
+    assert.equal(typeof evidence.daily_growth_gb, 'number');
+    assert.equal(evidence.day_count, 7);
+  });
 });

--- a/tests/unit/detector-disk-fill.test.ts
+++ b/tests/unit/detector-disk-fill.test.ts
@@ -202,4 +202,18 @@ describe('detector — disk-fill ETA insights', () => {
     generateInsights(db);
     assert.equal(getDiskFillInsights().length, 0);
   });
+
+  it('does not fire when used_percent < 50% (floor)', () => {
+    // 30 GB used today, growing 5 GB/day, 100 GB total → ETA 14 days, but below floor.
+    seedDisk({ totalGb: 100, startGb: 0, dailyGrowthGb: 5 });
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
+  });
+
+  it('does not fire with fewer than 4 days of data', () => {
+    // Only 3 days seeded, all above floor.
+    seedDisk({ totalGb: 100, startGb: 60, dailyGrowthGb: 5, days: 3 });
+    generateInsights(db);
+    assert.equal(getDiskFillInsights().length, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- Predict when Linux disks (`disk_snapshots`) and Proxmox storage pools (`pve_storage_snapshots`) will saturate within 14 days, surface as `prediction`-category insights.
- Severity: critical ≤3 days, warning ≤14 days. Floor at 50% used. Dedups against open `disk_full` / `pve_storage_saturation` alerts.
- Defers volume / PV / PVC ETA — those snapshot tables only carry declared capacity, not actual usage.

## Design

Detector logic mirrors the existing host/container `prediction` insights in `detector.ts`: 7-day daily-average slope, ≥4 days required, ≥1% relative growth, ≥half day-pairs consistent in direction, per-source minimum-growth threshold (50 MB/day).

Implementation lives in a new module `hub/src/insights/disk-fill.ts` (sibling to `proxmox-checks.ts`) and is wired into `generateInsights` with a single call. No schema change. No frontend change — the existing `InsightsPage` renders `prediction` rows correctly for both new metrics.

Spec: \`docs/superpowers/specs/2026-05-10-disk-fill-eta-design.md\`
Plan: \`docs/superpowers/plans/2026-05-10-disk-fill-eta-plan.md\`

## Hardening (post-review)

- `Math.ceil` instead of `Math.round` for `daysUntil` so sub-day urgent fills surface as 1-day critical instead of silently rounding to 0.
- ROW_NUMBER window-function "latest row per entity" pick instead of correlated MAX(collected_at) subquery (per memory note on snapshot-table query patterns; also handles tied-timestamp duplicates).

## Test plan
- [x] 21 unit tests in \`tests/unit/detector-disk-fill.test.ts\`: dailyTrend helper (5), disk path (warning/critical/horizon/shrinking/flat/floor/insufficient-data/dedup/multi-mount/evidence-shape), pve_storage path (warning/active=0/dedup/null-total).
- [x] Full suite: 1372/1372 pass.
- [x] \`npm run typecheck\`: clean.
- [x] vdev deploy on dev host — \`generateDiskFillInsights\` invoked; 0 inserts on real data (verified by direct call). Behavior is conservative: kingduck deduped via open alerts, AdGuard/Birthday have stale snapshots (>7d gap → daily window empty → skip), FILECLOUD growth 0.26%/day < 1% relative floor → skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)