### PR TITLE
docs: add launch release and trust docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ Security issues — please use GitHub's private vulnerability reporting (see `SE
 
 Releases are cut by maintainers via tags: `hub-vX.Y.Z` and `agent-vX.Y.Z` independently trigger the publish workflows in `.github/workflows/`. Hub and agent versions are not coupled; a hub release without an agent change just bumps the hub.
 
+Use [`docs/release-checklist.md`](./docs/release-checklist.md) before tagging a public release so tests, Docker smoke checks, Quick Start validation, release notes, and post-release verification happen consistently.
+
 ## Where things live
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Confidence: high (3 signals agree)
 ## Try it
 
 - [Quick Start guide](https://docs.insightd.org/guides/quick-start/) — full Docker Compose walkthrough
+- [Privacy and security model](./docs/privacy-security.md) — what insightd can see, where data lives, and which permissions matter
 - Or jump straight to [install](#quick-start) below
 
 > **First-time user?** I'm actively collecting early-user feedback. If you try insightd, I'm especially looking for feedback on whether **install worked on the first try**, **what environment you used**, and **what was confusing**. → [Join the discussion](https://github.com/goldenproductions/insightd/discussions/286)

--- a/docs/privacy-security.md
+++ b/docs/privacy-security.md
@@ -1,0 +1,115 @@
+# Privacy and security model
+
+Insightd is designed for self-hosted homelabs. It gives useful visibility into hosts, containers, Kubernetes nodes/pods, Proxmox guests, and HTTP endpoints, but it also needs access to operational data. This page explains the trust model and the permissions you should think about before installing it.
+
+## Short version
+
+- Insightd is self-hosted; there is no hosted insightd cloud service required for normal operation.
+- Data is stored locally by the hub in SQLite.
+- The hub, agent, and Mosquitto broker are intended to run on your own network or VPN.
+- MQTT should not be exposed directly to the public internet.
+- No telemetry is required for insightd to operate.
+- Optional integrations such as email, webhooks, and AI diagnosis only run when you configure them.
+
+## What data is collected
+
+Depending on what you enable, insightd can collect and store:
+
+- host metrics such as CPU, memory, disk, network, uptime, and load
+- container, pod, LXC, QEMU, and endpoint status
+- container or pod logs requested through the UI or used for diagnosis
+- restart history and health-check output
+- insight, alert, and feedback metadata
+- alert delivery settings such as email or webhook configuration
+
+This information can reveal service names, hostnames, internal URLs, error messages, and operational patterns. Treat the hub database and backups as sensitive operational data.
+
+## Local storage
+
+The hub uses SQLite for local persistence. Keep the database and its backups private. If you copy the database for debugging, redact sensitive hostnames, URLs, logs, tokens, and credentials first.
+
+## Network model
+
+The typical multi-host setup is:
+
+```text
+agent(s) -> MQTT broker -> hub -> web UI / email / webhooks
+```
+
+Recommended network posture:
+
+- Keep the hub UI behind your LAN, VPN, reverse proxy auth, or another access control layer appropriate for your setup.
+- Keep Mosquitto/MQTT private to your LAN or VPN.
+- Do not expose MQTT directly to the public internet.
+- Use firewall rules so only expected agents can reach the broker.
+- Use HTTPS at your reverse proxy if you expose the UI outside localhost/LAN.
+
+## Docker permissions
+
+Docker monitoring usually requires access to the Docker socket. The Docker socket is highly privileged: software with write-capable Docker socket access can often control containers and may effectively gain root-equivalent power on the host.
+
+Practical guidance:
+
+- Only deploy the agent on hosts you trust insightd to observe.
+- Keep `INSIGHTD_ALLOW_ACTIONS=false` unless you deliberately want start/stop/restart actions from the UI.
+- Keep `INSIGHTD_ALLOW_UPDATES=false` unless you deliberately want remote agent updates.
+- Prefer least-privilege network exposure even if the tool itself is local.
+
+## Kubernetes permissions
+
+The Kubernetes/k3s agent runs as a DaemonSet and uses Kubernetes APIs plus kubelet metrics to observe nodes and pods.
+
+Practical guidance:
+
+- Review the RBAC manifest before applying it.
+- Keep permissions read-only unless a future feature explicitly requires otherwise.
+- Scope the deployment to the clusters you actually want to monitor.
+- Treat pod names, namespaces, events, and logs as sensitive if they reveal application or customer data.
+
+## Proxmox VE permissions
+
+The Proxmox adapter reports LXC/QEMU guests, storage, backups, ZFS pools, and cluster signals.
+
+Practical guidance:
+
+- Use an API token rather than a personal administrator password.
+- Prefer a dedicated Proxmox user/token for insightd.
+- Grant only the permissions needed for monitoring the nodes and guests you want insightd to see.
+- Rotate the token if it is copied into logs, issues, screenshots, or support requests.
+
+## Email and webhooks
+
+Email digests, alert delivery, and webhooks are optional.
+
+Practical guidance:
+
+- Use dedicated SMTP credentials when possible.
+- Use dedicated webhook URLs for Slack, Discord, Telegram, ntfy, or generic integrations.
+- Treat webhook URLs as secrets; anyone with the URL may be able to post to that destination.
+- Redact webhook URLs, SMTP usernames/passwords, and message payloads before sharing logs.
+
+## Optional AI diagnosis
+
+The optional "Diagnose with AI" feature requires a configured Gemini API key. It is not required for the built-in diagnosis engine.
+
+If you enable it, assume relevant diagnosis context may be sent to the configured AI provider. Do not enable it for logs or environments where sending operational context to that provider would violate your expectations or policies.
+
+## Install script auditability
+
+The quick install command downloads and runs a shell script:
+
+```bash
+curl -sSL https://insightd.org/install.sh | bash
+```
+
+If you prefer to audit before running it, read the script first:
+
+```bash
+curl -fsSL https://insightd.org/install.sh
+```
+
+The install script is also public on GitHub from the README link.
+
+## Reporting vulnerabilities
+
+Please do not open public GitHub issues for security vulnerabilities. Use GitHub private vulnerability reporting as described in `SECURITY.md`.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,152 @@
+# Release checklist
+
+Use this checklist when preparing a public insightd release. The goal is to ship a release that is understandable, installable, and easy to roll back from — not just to push tags.
+
+## 1. Decide what is shipping
+
+- [ ] Pick release scope: hub, agent, or both.
+- [ ] Confirm the target version(s), for example `hub-v0.24.1` and/or `agent-v0.24.1`.
+- [ ] Review merged PRs since the last relevant tag.
+- [ ] Identify any user-facing behavior changes that need release notes.
+- [ ] Confirm no launch-blocking docs placeholders remain in `README.md`, install docs, or the website.
+
+Useful commands:
+
+```bash
+git fetch --tags
+git tag --list 'hub-v*' --sort=-v:refname | head
+git tag --list 'agent-v*' --sort=-v:refname | head
+git log --oneline <previous-tag>..HEAD
+```
+
+## 2. Run local quality gates
+
+- [ ] Install dependencies from a clean checkout or after pulling latest `main`.
+- [ ] Run backend/unit/integration tests.
+- [ ] Run TypeScript typecheck.
+- [ ] Build the frontend.
+
+Commands:
+
+```bash
+npm install
+npm test
+npm run typecheck
+cd hub/src/web/frontend && npm install && npm run build
+```
+
+## 3. Smoke test Docker Compose
+
+- [ ] Build local images.
+- [ ] Start the stack with Docker Compose.
+- [ ] Verify the hub health endpoint responds.
+- [ ] Open the UI and complete or verify the setup wizard path.
+- [ ] Confirm the local agent appears in the UI within the expected interval.
+- [ ] Check hub, agent, and Mosquitto logs for startup errors.
+
+Commands:
+
+```bash
+docker compose build
+docker compose up -d
+curl -fsS http://localhost:3000/api/health
+docker compose logs --tail=100 hub agent mosquitto
+docker compose down
+```
+
+## 4. Validate Quick Start from a clean host
+
+Before a public release, test the user path on a clean Linux VM with Docker and Compose v2 installed.
+
+- [ ] Run the install command exactly as documented.
+- [ ] Confirm `~/insightd/.env` is created with owner-only permissions.
+- [ ] Confirm `docker compose ps` shows hub, agent, and Mosquitto running.
+- [ ] Confirm the hub health endpoint responds.
+- [ ] Open the setup wizard and create the first admin user.
+- [ ] Confirm the local agent appears in the UI.
+- [ ] Record anything confusing or broken and fix docs before tagging.
+
+Command:
+
+```bash
+curl -sSL https://insightd.org/install.sh | bash
+```
+
+## 5. Review trust and security-sensitive docs
+
+- [ ] Confirm the README explains that insightd is self-hosted and SQLite-backed.
+- [ ] Confirm the install script is linked so users can audit before running it.
+- [ ] Confirm MQTT is described as a private network/VPN component, not something to expose publicly.
+- [ ] Confirm Docker socket, Kubernetes RBAC, Proxmox token permissions, email credentials, and webhook credentials are documented if they changed.
+- [ ] Confirm `SECURITY.md` still points users to private vulnerability reporting.
+
+## 6. Prepare release notes
+
+Write notes for humans, not just a changelog dump.
+
+Include:
+
+- [ ] One-sentence summary of the release.
+- [ ] What changed for homelab users.
+- [ ] Any install, upgrade, or configuration changes.
+- [ ] Known rough edges.
+- [ ] Links to Quick Start and early-user feedback discussion.
+
+Suggested structure:
+
+```markdown
+## Summary
+
+## Highlights
+
+## Upgrade notes
+
+## Fixes and polish
+
+## Known rough edges
+
+## Feedback wanted
+```
+
+## 7. Tag and publish
+
+Only tag from the commit that passed the checks above.
+
+- [ ] Ensure the working tree is clean.
+- [ ] Push `main`.
+- [ ] Create the relevant tag(s).
+- [ ] Push the tag(s) to trigger Docker Hub publish workflows.
+- [ ] Watch GitHub Actions until the publish jobs pass.
+- [ ] Verify the Docker Hub image tags exist for the expected architectures.
+
+Commands:
+
+```bash
+git status --short
+git push origin main
+git tag hub-vX.Y.Z
+git push origin hub-vX.Y.Z
+# If the agent changed:
+git tag agent-vX.Y.Z
+git push origin agent-vX.Y.Z
+```
+
+## 8. Post-release verification
+
+- [ ] Pull the published image(s) on a test host.
+- [ ] Run the Quick Start or upgrade path against the published tag(s).
+- [ ] Confirm the UI shows the expected version(s).
+- [ ] Confirm alerts/digests/webhooks still work if they were touched.
+- [ ] Update README/docs version references if needed.
+- [ ] Publish GitHub release notes.
+- [ ] Publish or schedule the launch/update post.
+
+## 9. Rollback notes
+
+Before announcing widely, know the rollback path:
+
+- [ ] Identify the previous known-good hub tag.
+- [ ] Identify the previous known-good agent tag.
+- [ ] Confirm whether the release included database migrations.
+- [ ] If migrations are not reversible, note that rollback may require restoring the SQLite backup.
+- [ ] Keep the announcement honest about any known rough edges.


### PR DESCRIPTION
## Summary
- add a public release checklist covering tests, Docker smoke checks, Quick Start validation, release notes, tagging, and rollback notes
- add a privacy and security model page for self-hosted data, MQTT exposure, Docker/Kubernetes/Proxmox permissions, email/webhook secrets, and optional AI diagnosis
- link the new docs from README and CONTRIBUTING

## Test plan
- [x] git diff --check
- [x] docs-only change; no runtime test suite run